### PR TITLE
`Notifications`: Change notification subscription to new topics

### DIFF
--- a/feature/Messages/Sources/Messages/ViewModels/ConversationViewModel.swift
+++ b/feature/Messages/Sources/Messages/ViewModels/ConversationViewModel.swift
@@ -61,13 +61,13 @@ public class ConversationViewModel: BaseViewModel {
         if ArtemisStompClient.shared.didSubscribeTopic(topic) {
             return
         }
-        websocketSubscriptionTask = Task {
+        websocketSubscriptionTask = Task { [weak self] in
             let stream = ArtemisStompClient.shared.subscribe(to: topic)
 
             for await message in stream {
                 guard let messageWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: MessageWebsocketDTO.self, message: message) else { continue }
 
-                onMessageReceived(messageWebsocketDTO: messageWebsocketDTO)
+                self?.onMessageReceived(messageWebsocketDTO: messageWebsocketDTO)
             }
         }
     }

--- a/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -218,7 +218,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
 
     private func subscribeToConversationNotificationUpdates() async {
         guard let userId = UserSession.shared.user?.id else {
-        log.debug("User could not be found. Subscription to UserNotifications is not possible")
+                log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
 

--- a/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -218,7 +218,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
 
     private func subscribeToConversationNotificationUpdates() async {
         guard let userId = UserSession.shared.user?.id else {
-                log.debug("User could not be found. Subscription to UserNotifications is not possible")
+            log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
 

--- a/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -218,7 +218,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
 
     private func subscribeToConversationNotificationUpdates() async {
         guard let userId = UserSession.shared.user?.id else {
-log.debug("User could not be found. Subscription to UserNotifications is not possible")
+        log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
 

--- a/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/feature/Notifications/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -200,7 +200,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
 
     private func subscribeToTutorialGroupNotificationUpdates() async {
         guard let userId = UserSession.shared.user?.id else {
-            log.debug("User could not be found. Subscribe to UserNotifications not possible")
+            log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
 
@@ -218,7 +218,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
 
     private func subscribeToConversationNotificationUpdates() async {
         guard let userId = UserSession.shared.user?.id else {
-            log.debug("User could not be found. Subscribe to UserNotifications not possible")
+log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
 


### PR DESCRIPTION
Adapt to server changes.

## Context
Related: https://github.com/ls1intum/Artemis/pull/6697/files

The REST APIs

- /conversations-for-notifications, returning `List<Conversation>`
- /tutorial-groups/for-notifications, returning `List<TutorialGroup>`

were deleted.

Similarly, the topics

- /topic/user/${user.id}/notifications
- /topic/conversation/' + conversation.id + '/notifications

were replaced in the web client by

- /topic/user/${user.id}/notifications
- /topic/user/${user.id}/notifications/tutorial-groups
- /topic/user/${user.id}/notifications/conversations