### PR TITLE
`Development`: Replace legacy test servers

### DIFF
--- a/Artemis.entitlements
+++ b/Artemis.entitlements
@@ -7,7 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:artemis.cit.tum.de</string>
-		<string>applinks:artemis-staging.artemis.cit.tum.de/</string>
+		<string>applinks:artemis-staging.artemis.cit.tum.de</string>
 		<string>applinks:artemis-test1.artemis.cit.tum.de</string>
 		<string>applinks:artemis-test2.artemis.cit.tum.de</string>
 		<string>applinks:artemis-test3.artemis.cit.tum.de</string>
@@ -16,7 +16,7 @@
 		<string>applinks:artemis-test6.artemis.cit.tum.de</string>
 		<string>applinks:artemis-test9.artemis.cit.tum.de</string>
 		<string>webcredentials:artemis.cit.tum.de</string>
-		<string>webcredentials:artemis-staging.artemis.cit.tum.de/</string>
+		<string>webcredentials:artemis-staging.artemis.cit.tum.de</string>
 		<string>webcredentials:artemis-test1.artemis.cit.tum.de</string>
 		<string>webcredentials:artemis-test2.artemis.cit.tum.de</string>
 		<string>webcredentials:artemis-test3.artemis.cit.tum.de</string>

--- a/Artemis.entitlements
+++ b/Artemis.entitlements
@@ -6,24 +6,24 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:artemis.in.tum.de</string>
-		<string>applinks:artemis.ase.in.tum.de</string>
-		<string>applinks:artemis-test1.artemis.in.tum.de</string>
-		<string>applinks:artemis-test2.artemis.in.tum.de</string>
-		<string>applinks:artemis-staging.artemis.in.tum.de/</string>
-		<string>applinks:artemis-test3.artemis.in.tum.de</string>
-		<string>applinks:artemis-test5.artemis.in.tum.de</string>
-		<string>applinks:artemis-test6.artemis.in.tum.de</string>
-		<string>applinks:artemis-test10.artemis.in.tum.de</string>
-		<string>webcredentials:artemis.in.tum.de</string>
-		<string>webcredentials:artemis.ase.in.tum.de</string>
-		<string>webcredentials:artemis-test1.artemis.in.tum.de</string>
-		<string>webcredentials:artemis-test2.artemis.in.tum.de</string>
-		<string>webcredentials:artemis-staging.artemis.in.tum.de/</string>
-		<string>webcredentials:artemis-test3.artemis.in.tum.de</string>
-		<string>webcredentials:artemis-test5.artemis.in.tum.de</string>
-		<string>webcredentials:artemis-test6.artemis.in.tum.de</string>
-		<string>webcredentials:artemis-test10.artemis.in.tum.de</string>
+		<string>applinks:artemis.cit.tum.de</string>
+		<string>applinks:artemis-staging.artemis.cit.tum.de/</string>
+		<string>applinks:artemis-test1.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test2.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test3.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test4.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test5.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test6.artemis.cit.tum.de</string>
+		<string>applinks:artemis-test9.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-staging.artemis.cit.tum.de/</string>
+		<string>webcredentials:artemis-test1.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test2.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test3.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test4.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test5.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test6.artemis.cit.tum.de</string>
+		<string>webcredentials:artemis-test9.artemis.cit.tum.de</string>
 	</array>
 </dict>
 </plist>

--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -508,8 +508,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ls1intum/artemis-ios-core-modules";
 			requirement = {
-				branch = "bugfix/development/decoding-error-profileinfo";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -508,8 +508,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ls1intum/artemis-ios-core-modules";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				branch = "bugfix/development/decoding-error-profileinfo";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "0ee18cf4fd8b9a716026f32b266a1ca95720774e",
-        "version" : "6.0.0"
+        "branch" : "bugfix/development/decoding-error-profileinfo",
+        "revision" : "3cd90e6e8e6c39df059b8ba955ccae32d97379dd"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "bugfix/development/decoding-error-profileinfo",
-        "revision" : "3cd90e6e8e6c39df059b8ba955ccae32d97379dd"
+        "revision" : "2e50da01c0818bb2889a25f1ffde6375be7cbdf1",
+        "version" : "7.0.0"
       }
     },
     {

--- a/core/Navigation/Package.swift
+++ b/core/Navigation/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0"))
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/feature/CourseRegistration/Package.swift
+++ b/feature/CourseRegistration/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/feature/CourseView/Package.swift
+++ b/feature/CourseView/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
         .package(path: "../../core/Navigation"),
         .package(path: "../Messages"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")

--- a/feature/Dashboard/Package.swift
+++ b/feature/Dashboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
         .package(path: "../../core/Navigation"),
         .package(path: "../CourseRegistration"),
         .package(path: "../Notifications"),

--- a/feature/Messages/Package.swift
+++ b/feature/Messages/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
         .package(path: "../../core/Navigation"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0")

--- a/feature/Notifications/Package.swift
+++ b/feature/Notifications/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
         .package(path: "../../core/Navigation"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],


### PR DESCRIPTION
- [x] https://github.com/ls1intum/artemis-ios-core-modules/pull/27

Test servers have been replaced by new deployments: https://github.com/ls1intum/Artemis/pull/7358