### PR TITLE
`Communication`: Adapt WebSocket messages

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
-        "version" : "1.8.0"
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "add0a87ec4e31e2ca2a0b2085f0559201e4f5918",
-        "version" : "7.10.1"
+        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
+        "version" : "7.10.2"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mac-cain13/R.swift.git",
       "state" : {
-        "revision" : "a76220f2c4b73bdda670f4a318c6ec983399ac6d",
-        "version" : "7.4.0"
+        "revision" : "384eab88d1a0b98ac96f4819e50a4308ecd5359f",
+        "version" : "7.5.0"
       }
     },
     {

--- a/ArtemisKit/Sources/Messages/Models/ConversationWebsocketDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/ConversationWebsocketDTO.swift
@@ -5,10 +5,9 @@
 //  Created by Sven Andabaka on 11.05.23.
 //
 
-import Foundation
 import SharedModels
 
-enum MetisPostAction: String, RawRepresentable, Codable {
+enum MetisCrudAction: String, RawRepresentable, Codable {
     case create = "CREATE"
     case update = "UPDATE"
     case delete = "DELETE"
@@ -17,5 +16,5 @@ enum MetisPostAction: String, RawRepresentable, Codable {
 
 struct ConversationWebsocketDTO: Codable {
     let conversation: Conversation
-    let action: MetisPostAction
+    let action: MetisCrudAction
 }

--- a/ArtemisKit/Sources/Messages/Models/ConversationWebsocketDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/ConversationWebsocketDTO.swift
@@ -17,5 +17,5 @@ enum MetisPostAction: String, RawRepresentable, Codable {
 
 struct ConversationWebsocketDTO: Codable {
     let conversation: Conversation
-    let metisCrudAction: MetisPostAction
+    let action: MetisPostAction
 }

--- a/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
@@ -5,10 +5,9 @@
 //  Created by Sven Andabaka on 11.05.23.
 //
 
-import Foundation
 import SharedModels
 
 struct MessageWebsocketDTO: Codable {
     let post: Message
-    let action: MetisPostAction
+    let action: MetisCrudAction
 }

--- a/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
@@ -10,4 +10,9 @@ import SharedModels
 struct MessageWebsocketDTO: Codable {
     let post: Message
     let action: MetisCrudAction
+    let notification: Notification?
+}
+
+struct Notification: Codable {
+    let id: Int
 }

--- a/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageWebsocketDTO.swift
@@ -13,6 +13,5 @@ struct MessageWebsocketDTO: Codable {
     let notification: Notification?
 }
 
-struct Notification: Codable {
-    let id: Int
-}
+// Used in the web client's notification service.
+struct Notification: Codable {}

--- a/ArtemisKit/Sources/Messages/Models/WebSocketTopic.swift
+++ b/ArtemisKit/Sources/Messages/Models/WebSocketTopic.swift
@@ -1,0 +1,31 @@
+//
+//  WebSocketTopic.swift
+//
+//
+//  Created by Nityananda Zbil on 09.02.24.
+//
+
+enum WebSocketTopic {
+    /// `makeChannelNotifications` makes a topic for notifications through course-wide channels.
+    ///
+    /// E.g., notifications for writing in a channel.
+    static func makeChannelNotifications(courseId: Int) -> String {
+        "/topic/metis/courses/\(courseId)"
+    }
+
+    /// `makeConversationNotifications` makes a topic for conversation notifications of a user.
+    ///
+    /// E.g., notifications for writing in a group chat.
+    static func makeConversationNotifications(userId: Int64) -> String {
+        "/topic/user/\(userId)/notifications/conversations"
+    }
+
+    // MARK: - User space
+
+    /// `makeConversationMembershipNotifications` makes a topic for membership notifications of a user in a course.
+    ///
+    /// E.g., notifications for starting a group chat.
+    static func makeConversationMembershipNotifications(courseId: Int, userId: Int64) -> String {
+        "/user/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
+    }
+}

--- a/ArtemisKit/Sources/Messages/Networking/WebSocketTopic.swift
+++ b/ArtemisKit/Sources/Messages/Networking/WebSocketTopic.swift
@@ -6,14 +6,14 @@
 //
 
 enum WebSocketTopic {
-    /// `makeChannelNotifications` makes a topic for notifications through course-wide channels.
+    /// Makes a topic for notifications through course-wide channels.
     ///
     /// E.g., notifications for writing in a channel.
     static func makeChannelNotifications(courseId: Int) -> String {
         "/topic/metis/courses/\(courseId)"
     }
 
-    /// `makeConversationNotifications` makes a topic for conversation notifications of a user.
+    /// Makes a topic for conversation notifications of a user.
     ///
     /// E.g., notifications for writing in a group chat.
     static func makeConversationNotifications(userId: Int64) -> String {
@@ -22,7 +22,7 @@ enum WebSocketTopic {
 
     // MARK: - User space
 
-    /// `makeConversationMembershipNotifications` makes a topic for membership notifications of a user in a course.
+    /// Makes a topic for membership notifications of a user in a course.
     ///
     /// E.g., notifications for starting a group chat.
     static func makeConversationMembershipNotifications(courseId: Int, userId: Int64) -> String {

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -348,9 +348,11 @@ private extension ConversationViewModel {
     func subscribeToConversationTopic() {
         let topic: String
         if conversation.value?.baseConversation.type == .channel {
-            topic = "/topic/metis/courses/\(courseId)"
+            // Writing in #random
+            topic = "/topic/metis/courses/\(courseId)" // not /user
         } else if let id = UserSession.shared.user?.id {
-            topic = "/topic/user/\(id)/notifications/conversations"
+            // Writing in group chat
+            topic = "/topic/user/\(id)/notifications/conversations" // not /user, but .notification?
         } else {
             return
         }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -348,11 +348,9 @@ private extension ConversationViewModel {
     func subscribeToConversationTopic() {
         let topic: String
         if conversation.value?.baseConversation.type == .channel {
-            // Writing in #random
-            topic = "/topic/metis/courses/\(courseId)" // not /user
+            topic = WebSocketTopic.makeChannelNotifications(courseId: courseId)
         } else if let id = UserSession.shared.user?.id {
-            // Writing in group chat
-            topic = "/topic/user/\(id)/notifications/conversations" // not /user, but .notification?
+            topic = WebSocketTopic.makeConversationNotifications(userId: id)
         } else {
             return
         }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -51,7 +51,9 @@ class MessagesAvailableViewModel: BaseViewModel {
         let stream = ArtemisStompClient.shared.subscribe(to: topic)
 
         for await message in stream {
-            guard let conversationWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: ConversationWebsocketDTO.self, message: message) else { continue }
+            guard let conversationWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: ConversationWebsocketDTO.self, message: message) else {
+                continue
+            }
             onConversationMembershipMessageReceived(conversationWebsocketDTO: conversationWebsocketDTO)
         }
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -47,7 +47,7 @@ class MessagesAvailableViewModel: BaseViewModel {
             return
         }
 
-        let topic = "/user/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
+        let topic = "/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
         let stream = ArtemisStompClient.shared.subscribe(to: topic)
 
         for await message in stream {
@@ -145,7 +145,7 @@ class MessagesAvailableViewModel: BaseViewModel {
 // MARK: Functions to handle new conversation received socket
 extension MessagesAvailableViewModel {
     private func onConversationMembershipMessageReceived(conversationWebsocketDTO: ConversationWebsocketDTO) {
-        switch conversationWebsocketDTO.metisCrudAction {
+        switch conversationWebsocketDTO.action {
         case .create, .update:
             handleUpdateOrCreate(updatedOrNewConversation: conversationWebsocketDTO.conversation)
         case .delete:

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -47,7 +47,7 @@ class MessagesAvailableViewModel: BaseViewModel {
             return
         }
 
-        let topic = "/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
+        let topic = "/user/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
         let stream = ArtemisStompClient.shared.subscribe(to: topic)
 
         for await message in stream {

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -47,7 +47,7 @@ class MessagesAvailableViewModel: BaseViewModel {
             return
         }
 
-        let topic = "/user/topic/metis/courses/\(courseId)/conversations/user/\(userId)"
+        let topic = WebSocketTopic.makeConversationMembershipNotifications(courseId: courseId, userId: userId)
         let stream = ArtemisStompClient.shared.subscribe(to: topic)
 
         for await message in stream {


### PR DESCRIPTION
https://github.com/ls1intum/Artemis/pull/7789

- renamed metisCrudAction of ConversationWebsocketDTO: action,
- and added a notification field to MessageWebsocketDTO (MetisPostDTO).

---

```
13:43:53.282 ❤️ ERROR ArtemisStompClient.getTypeFromSocketMessage():157 - keyNotFound(CodingKeys(stringValue: "metisCrudAction", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"metisCrudAction\", intValue: nil) (\"metisCrudAction\").", underlyingError: nil))
```

Ref.: https://github.com/ls1intum/Artemis/pull/7789#discussion_r1465411735