### PR TITLE
`Modeling Exercises`: Add error message for unsupported diagram types

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/apollon-ios-module",
       "state" : {
-        "revision" : "424631162a5f05bcb0278d59ffb8f9b6f9d9c6ca",
-        "version" : "1.0.8"
+        "revision" : "5e4b1223bf33b542bcef2b844f7c451ac0ed7a9e",
+        "version" : "1.0.9"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "969303b0a2ab90a4a7150accc3d18764b9bde37f",
-        "version" : "10.0.0"
+        "revision" : "ba8b4036b3b441d408de7cd0672dddf7b9b824a0",
+        "version" : "10.0.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
-        "version" : "1.8.1"
+        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
+        "version" : "1.8.2"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "8a835d918245ca22f36663dd3862138805d7f707",
-        "version" : "5.1.0"
+        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
+        "version" : "5.1.2"
       }
     }
   ],

--- a/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/ModelingExerciseViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/ModelingExerciseViewModel.swift
@@ -99,6 +99,7 @@ class ModelingExerciseViewModel: BaseViewModel {
             }
         } catch {
             log.error("Could not parse UML string: \(error)")
+            diagramTypeUnsupported = true
         }
     }
 


### PR DESCRIPTION
This PR adds an error message for unsupported modeling exercise diagram types and bumps the dependency versions.