### PR TITLE
`Communication`: Cache invalidation

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/Schema/SchemaV1.swift
+++ b/ArtemisKit/Sources/Messages/Models/Schema/SchemaV1.swift
@@ -27,11 +27,14 @@ enum SchemaV1: VersionedSchema {
         @Attribute(.unique)
         var host: String
 
+        var lastAccessDate: Date
+
         @Relationship(deleteRule: .cascade, inverse: \Course.server)
         var courses: [Course]
 
-        init(host: String, courses: [Course] = []) {
+        init(host: String, lastAccessDate: Date, courses: [Course] = []) {
             self.host = host
+            self.lastAccessDate = lastAccessDate
             self.courses = courses
         }
     }

--- a/ArtemisKit/Sources/Messages/Repositories/MessagesRepository.swift
+++ b/ArtemisKit/Sources/Messages/Repositories/MessagesRepository.swift
@@ -45,7 +45,7 @@ extension MessagesRepository {
     @discardableResult
     func insertServer(host: String) -> ServerModel {
         log.verbose("begin")
-        let server = ServerModel(host: host)
+        let server = ServerModel(host: host, lastAccessDate: .now)
         context.insert(server)
         return server
     }

--- a/ArtemisKit/Sources/Messages/Repositories/MessagesRepository.swift
+++ b/ArtemisKit/Sources/Messages/Repositories/MessagesRepository.swift
@@ -21,12 +21,14 @@ final class MessagesRepository {
     }()
 
     private let context: ModelContext
+    private let seconds: Int
 
-    init() throws {
+    init(timeoutInSeconds: Int = 24 * 60 * 60) throws {
         let schema = Schema(versionedSchema: SchemaV1.self)
         let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: configuration)
         self.context = container.mainContext
+        self.seconds = timeoutInSeconds
     }
 
     deinit {
@@ -52,6 +54,7 @@ extension MessagesRepository {
 
     func fetchServer(host: String) throws -> ServerModel? {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<ServerModel> { server in
             server.host == host
         }
@@ -64,6 +67,7 @@ extension MessagesRepository {
     func insertCourse(host: String, courseId: Int) throws -> CourseModel {
         log.verbose("begin")
         let server = try fetchServer(host: host) ?? insertServer(host: host)
+        try touch(server: server)
         let course = CourseModel(server: server, courseId: courseId)
         context.insert(course)
         return course
@@ -71,6 +75,7 @@ extension MessagesRepository {
 
     func fetchCourse(host: String, courseId: Int) throws -> CourseModel? {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<CourseModel> { course in
             course.server.host == host
             && course.courseId == courseId
@@ -84,6 +89,7 @@ extension MessagesRepository {
     func insertConversation(host: String, courseId: Int, conversationId: Int, messageDraft: String) throws -> ConversationModel {
         log.verbose("begin")
         let course = try fetchCourse(host: host, courseId: courseId) ?? insertCourse(host: host, courseId: courseId)
+        try touch(server: course.server)
         let conversation = ConversationModel(course: course, conversationId: conversationId, messageDraft: messageDraft)
         context.insert(conversation)
         return conversation
@@ -91,6 +97,7 @@ extension MessagesRepository {
 
     func fetchConversation(host: String, courseId: Int, conversationId: Int) throws -> ConversationModel? {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<ConversationModel> { conversation in
             conversation.course.server.host == host
             && conversation.course.courseId == courseId
@@ -108,6 +115,7 @@ extension MessagesRepository {
         log.verbose("begin")
         let conversation = try fetchConversation(host: host, courseId: courseId, conversationId: conversationId)
             ?? insertConversation(host: host, courseId: courseId, conversationId: conversationId, messageDraft: "")
+        try touch(server: conversation.course.server)
         let message = ConversationOfflineMessageModel(conversation: conversation, date: date, text: text)
         context.insert(message)
         return message
@@ -117,6 +125,7 @@ extension MessagesRepository {
         host: String, courseId: Int, conversationId: Int
     ) throws -> [ConversationOfflineMessageModel] {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<ConversationOfflineMessageModel> { message in
             message.conversation.course.server.host == host
             && message.conversation.course.courseId == courseId
@@ -136,6 +145,7 @@ extension MessagesRepository {
         log.verbose("begin")
         let conversation = try fetchConversation(host: host, courseId: courseId, conversationId: conversationId)
             ?? insertConversation(host: host, courseId: courseId, conversationId: conversationId, messageDraft: "")
+        try touch(server: conversation.course.server)
         let message = MessageModel(conversation: conversation, messageId: messageId, answerMessageDraft: answerMessageDraft)
         context.insert(message)
         return message
@@ -143,6 +153,7 @@ extension MessagesRepository {
 
     func fetchMessage(host: String, courseId: Int, conversationId: Int, messageId: Int) throws -> MessageModel? {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<MessageModel> { message in
             message.conversation.course.server.host == host
             && message.conversation.course.courseId == courseId
@@ -162,6 +173,7 @@ extension MessagesRepository {
         log.verbose("begin")
         let message = try fetchMessage(host: host, courseId: courseId, conversationId: conversationId, messageId: messageId)
             ?? insertMessage(host: host, courseId: courseId, conversationId: conversationId, messageId: messageId, answerMessageDraft: "")
+        try touch(server: message.conversation.course.server)
         let answer = MessageOfflineAnswerModel(message: message, date: date, text: text)
         context.insert(answer)
         return answer
@@ -171,6 +183,7 @@ extension MessagesRepository {
         host: String, courseId: Int, conversationId: Int, messageId: Int
     ) throws -> [MessageOfflineAnswerModel] {
         log.verbose("begin")
+        try purge(host: host)
         let predicate = #Predicate<MessageOfflineAnswerModel> { answer in
             answer.message.conversation.course.server.host == host
             && answer.message.conversation.course.courseId == courseId
@@ -182,5 +195,27 @@ extension MessagesRepository {
 
     func delete(messageOfflineAnswer: MessageOfflineAnswerModel) {
         context.delete(messageOfflineAnswer)
+    }
+
+    // - Cache Invalidation
+
+    func touch(server: ServerModel) throws {
+        log.verbose("begin")
+        server.lastAccessDate = .now
+    }
+
+    func purge(host: String) throws {
+        log.verbose("begin")
+        try context.enumerate(FetchDescriptor<ServerModel>()) { server in
+            if server.host == host {
+                let date = Calendar.current.date(byAdding: .second, value: seconds, to: server.lastAccessDate) ?? .now
+
+                if date < .now {
+                    context.delete(server)
+                }
+            } else {
+                context.delete(server)
+            }
+        }
     }
 }

--- a/ArtemisKit/Tests/ArtemisKitTests/Messages/MessagesRepositoryTests.swift
+++ b/ArtemisKit/Tests/ArtemisKitTests/Messages/MessagesRepositoryTests.swift
@@ -28,4 +28,19 @@ final class MessagesRepositoryTests: XCTestCase {
         let first = try XCTUnwrap(conversation)
         XCTAssertEqual(first.messageDraft, messageDraftUpdate)
     }
+
+    func testCacheInvalidation() async throws {
+        // given
+        let url = try XCTUnwrap(URL(string: "https://example.org"))
+        let host = try XCTUnwrap(url.host())
+        let repository = try await MessagesRepository(timeoutInSeconds: 1)
+
+        // when
+        try await repository.insertServer(host: host)
+        try await Task.sleep(for: .seconds(2))
+        let server = try await repository.fetchServer(host: host)
+
+        // then
+        XCTAssertNil(server)
+    }
 }

--- a/ArtemisKit/Tests/ArtemisKitTests/Messages/SendMessageViewModelTests.swift
+++ b/ArtemisKit/Tests/ArtemisKitTests/Messages/SendMessageViewModelTests.swift
@@ -10,7 +10,6 @@ final class SendMessageViewModelTests: XCTestCase {
             conversation: Conversation(conversation: Channel(id: 1))!,
             configuration: .message,
             delegate: SendMessageViewModelDelegate(
-                loadMessages: {},
                 presentError: { _ in },
                 sendMessage: { _ in }))
     }


### PR DESCRIPTION
1. Touch, i.e., update `lastAccessDate`, on insert
2. Purge on fetch, such that, a client does not receive a value that exceeds the timeout

Still, the database is in-memory.