### PR TITLE
`Lectures`: Display number of lectures

### DIFF
--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -94,5 +94,5 @@
 "date" = "Date";
 "noDateAssociated" = "No date associated";
 "lectureUnits" = "Lecture Units";
-"lecturesGroupTitle" = "%s (Exercises: %i)";
+"lecturesGroupTitle" = "%s (Lectures: %i)";
 "attachments" = "Attachments";


### PR DESCRIPTION
## Vision

| (a) | (b) |
|-|-|
| ![Simulator Screenshot - iPhone 15 - 2024-05-30 at 16 21 39](https://github.com/ls1intum/artemis-ios/assets/23535000/68d1069d-6ffa-4398-8476-d820b3aadafa) | ![Simulator Screenshot - iPhone 15 - 2024-05-30 at 16 21 41](https://github.com/ls1intum/artemis-ios/assets/23535000/6b483045-7dc9-42b3-b96e-c1c276a8a505) |

## As-is

> The app states that a Lecture contains Exercises although the course does not

| (a) | (b) |
|-|-|
| ![Image from iOS (1)](https://github.com/ls1intum/artemis-ios/assets/23535000/877523bd-cab9-4761-b4da-40fc010b2b5c) | ![Image from iOS](https://github.com/ls1intum/artemis-ios/assets/23535000/653cee3b-f02c-4e20-b918-b6ba3ee31c8b) |
