### PR TITLE
Add automatic screenshots via fastlane

### DIFF
--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -10,13 +10,28 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* ArtemisApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* ArtemisApp.swift */; };
+		51F1B2252C0CC26800F14D01 /* ArtemisUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F1B2242C0CC26800F14D01 /* ArtemisUITests.swift */; };
+		51F1B22C2C0CC2D700F14D01 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F1B22B2C0CC2D700F14D01 /* SnapshotHelper.swift */; };
 		A166A2592B0381F000AB6119 /* ArtemisKit in Frameworks */ = {isa = PBXBuildFile; productRef = A166A2582B0381F000AB6119 /* ArtemisKit */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		51F1B2262C0CC26800F14D01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7555FF7A242A565900829871;
+			remoteInfo = Artemis;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* ArtemisApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtemisApp.swift; sourceTree = "<group>"; };
+		51F1B2202C0CC26800F14D01 /* ArtemisUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArtemisUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		51F1B2242C0CC26800F14D01 /* ArtemisUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtemisUITests.swift; sourceTree = "<group>"; };
+		51F1B22B2C0CC2D700F14D01 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* Artemis.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Artemis.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A166A2622B03893900AB6119 /* Gemfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Gemfile; sourceTree = SOURCE_ROOT; };
 		A166A2632B03893900AB6119 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
@@ -39,6 +54,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		51F1B21D2C0CC26800F14D01 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -57,12 +79,22 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		51F1B2212C0CC26800F14D01 /* ArtemisUITests */ = {
+			isa = PBXGroup;
+			children = (
+				51F1B2242C0CC26800F14D01 /* ArtemisUITests.swift */,
+				51F1B22B2C0CC2D700F14D01 /* SnapshotHelper.swift */,
+			);
+			path = ArtemisUITests;
+			sourceTree = "<group>";
+		};
 		7555FF72242A565900829871 = {
 			isa = PBXGroup;
 			children = (
 				D51AD00C299E390700FA5B94 /* Artemis.entitlements */,
 				A1C7E0A92B03754200804542 /* ArtemisKit */,
 				7555FF7D242A565900829871 /* Artemis */,
+				51F1B2212C0CC26800F14D01 /* ArtemisUITests */,
 				7555FF7C242A565900829871 /* Products */,
 				22B6A91C292D785600F08C7E /* Frameworks */,
 			);
@@ -72,6 +104,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* Artemis.app */,
+				51F1B2202C0CC26800F14D01 /* ArtemisUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -105,6 +138,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		51F1B21F2C0CC26800F14D01 /* ArtemisUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 51F1B22A2C0CC26800F14D01 /* Build configuration list for PBXNativeTarget "ArtemisUITests" */;
+			buildPhases = (
+				51F1B21C2C0CC26800F14D01 /* Sources */,
+				51F1B21D2C0CC26800F14D01 /* Frameworks */,
+				51F1B21E2C0CC26800F14D01 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				51F1B2272C0CC26800F14D01 /* PBXTargetDependency */,
+			);
+			name = ArtemisUITests;
+			packageProductDependencies = (
+			);
+			productName = ArtemisUITests;
+			productReference = 51F1B2202C0CC26800F14D01 /* ArtemisUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		7555FF7A242A565900829871 /* Artemis */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "Artemis" */;
@@ -133,10 +186,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 1520;
 				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = orgName;
 				TargetAttributes = {
+					51F1B21F2C0CC26800F14D01 = {
+						CreatedOnToolsVersion = 15.2;
+						TestTargetID = 7555FF7A242A565900829871;
+					};
 					7555FF7A242A565900829871 = {
 						CreatedOnToolsVersion = 11.3.1;
 					};
@@ -158,11 +215,19 @@
 			projectRoot = "";
 			targets = (
 				7555FF7A242A565900829871 /* Artemis */,
+				51F1B21F2C0CC26800F14D01 /* ArtemisUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		51F1B21E2C0CC26800F14D01 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7555FF79242A565900829871 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -195,6 +260,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		51F1B21C2C0CC26800F14D01 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51F1B2252C0CC26800F14D01 /* ArtemisUITests.swift in Sources */,
+				51F1B22C2C0CC2D700F14D01 /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7555FF77242A565900829871 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -205,7 +279,59 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		51F1B2272C0CC26800F14D01 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7555FF7A242A565900829871 /* Artemis */;
+			targetProxy = 51F1B2262C0CC26800F14D01 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		51F1B2282C0CC26800F14D01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.artemis.ArtemisUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Artemis;
+			};
+			name = Debug;
+		};
+		51F1B2292C0CC26800F14D01 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.artemis.ArtemisUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Artemis;
+			};
+			name = Release;
+		};
 		7555FFA3242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -385,6 +511,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		51F1B22A2C0CC26800F14D01 /* Build configuration list for PBXNativeTarget "ArtemisUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51F1B2282C0CC26800F14D01 /* Debug */,
+				51F1B2292C0CC26800F14D01 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		7555FF76242A565900829871 /* Build configuration list for PBXProject "Artemis" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "5ceb0023189edb62d2411826fe43a8504df1adb7",
-        "version" : "11.1.0"
+        "revision" : "91b63e8e82a3a4ac100fac0a2a58ddd27a8f6f30",
+        "version" : "12.0.0"
       }
     },
     {

--- a/Artemis.xcodeproj/xcshareddata/xcschemes/ArtemisUITests.xcscheme
+++ b/Artemis.xcodeproj/xcshareddata/xcschemes/ArtemisUITests.xcscheme
@@ -1,32 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
-   version = "1.3">
+   LastUpgradeVersion = "1520"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "Artemis.app"
-               BlueprintName = "Artemis"
-               ReferencedContainer = "container:Artemis.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -51,16 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "Artemis.app"
-            BlueprintName = "Artemis"
-            ReferencedContainer = "container:Artemis.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -68,16 +43,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "Artemis.app"
-            BlueprintName = "Artemis"
-            ReferencedContainer = "container:Artemis.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "11.1.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "12.0.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/ArtemisKit/AppDelegate.swift
+++ b/ArtemisKit/Sources/ArtemisKit/AppDelegate.swift
@@ -46,7 +46,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        UserSession.shared.saveNotificationDeviceConfiguration(token: nil, encryptionKey: nil, skippedNotifications: true)
+        UserSessionFactory.shared.saveNotificationDeviceConfiguration(token: nil, encryptionKey: nil, skippedNotifications: true)
         log.error("Did Fail To Register For Remote Notifications With Error: \(error)")
     }
 

--- a/ArtemisKit/Sources/ArtemisKit/RootViewModel.swift
+++ b/ArtemisKit/Sources/ArtemisKit/RootViewModel.swift
@@ -27,7 +27,7 @@ class RootViewModel: ObservableObject {
     private var cancellable: Set<AnyCancellable> = Set()
 
     init(
-        userSession: UserSession = .shared,
+        userSession: UserSession = UserSessionFactory.shared,
         accountService: AccountService = AccountServiceFactory.shared
     ) {
         self.userSession = userSession

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -34,7 +34,9 @@ public struct ExerciseDetailView: View {
 
     public init(course: Course, exercise: Exercise) {
         self._exercise = State(wrappedValue: .done(response: exercise))
-        self._urlRequest = State(wrappedValue: URLRequest(url: URL(string: "/courses/\(course.id)/exercises/\(exercise.id)/problem-statement", relativeTo: UserSession.shared.institution?.baseURL)!))
+        self._urlRequest = State(wrappedValue: URLRequest(url: URL(
+            string: "/courses/\(course.id)/exercises/\(exercise.id)/problem-statement",
+            relativeTo: UserSessionFactory.shared.institution?.baseURL)!))
 
         self.exerciseId = exercise.id
         self.courseId = course.id
@@ -42,7 +44,9 @@ public struct ExerciseDetailView: View {
 
     public init(courseId: Int, exerciseId: Int) {
         self._exercise = State(wrappedValue: .loading)
-        self._urlRequest = State(wrappedValue: URLRequest(url: URL(string: "/courses/\(courseId)/exercises/\(exerciseId)", relativeTo: UserSession.shared.institution?.baseURL)!))
+        self._urlRequest = State(wrappedValue: URLRequest(url: URL(
+            string: "/courses/\(courseId)/exercises/\(exerciseId)",
+            relativeTo: UserSessionFactory.shared.institution?.baseURL)!))
 
         self.exerciseId = exerciseId
         self.courseId = courseId
@@ -278,7 +282,9 @@ public struct ExerciseDetailView: View {
             self.latestResultId = latestResultId
         }
 
-        urlRequest = URLRequest(url: URL(string: "/courses/\(courseId)/exercises/\(exercise.id)/problem-statement/\(participationId?.description ?? "")", relativeTo: UserSession.shared.institution?.baseURL)!)
+        urlRequest = URLRequest(url: URL(
+            string: "/courses/\(courseId)/exercises/\(exercise.id)/problem-statement/\(participationId?.description ?? "")",
+            relativeTo: UserSessionFactory.shared.institution?.baseURL)!)
     }
 
     /// JavaScript to reduce visible content in WebView to just problem statement
@@ -390,7 +396,9 @@ private struct FeedbackView: View {
     @State private var isWebViewLoading = true
 
     init(courseId: Int, exerciseId: Int, participationId: Int, resultId: Int) {
-        self._urlRequest = State(wrappedValue: URLRequest(url: URL(string: "/courses/\(courseId)/exercises/\(exerciseId)/participations/\(participationId)/results/\(resultId)/feedback/", relativeTo: UserSession.shared.institution?.baseURL)!))
+        self._urlRequest = State(wrappedValue: URLRequest(url: URL(
+            string: "/courses/\(courseId)/exercises/\(exerciseId)/participations/\(participationId)/results/\(resultId)/feedback/",
+            relativeTo: UserSessionFactory.shared.institution?.baseURL)!))
     }
 
     var body: some View {

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
@@ -70,7 +70,9 @@ class LectureServiceImpl: LectureService {
     }
 
     func getAttachmentFile(link: String) async -> DataState<URL> {
-        guard let url = URL(string: link, relativeTo: UserSession.shared.institution?.baseURL) else { return .failure(error: UserFacingError(title: "Wrong URL")) }
+        guard let url = URL(string: link, relativeTo: UserSessionFactory.shared.institution?.baseURL) else {
+            return .failure(error: UserFacingError(title: "Wrong URL"))
+        }
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
 

--- a/ArtemisKit/Sources/Dashboard/CourseServiceStub.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseServiceStub.swift
@@ -21,11 +21,7 @@ struct CourseServiceStub: CourseService {
     }()
 
     static let courses: CoursesForDashboardDTO = {
-        var courses = CoursesForDashboardDTO()
-        courses.courses = [
-            course
-        ]
-        return courses
+        return .mock
     }()
 
     func getCourses() async -> DataState<CoursesForDashboardDTO> {

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
@@ -30,7 +30,8 @@ protocol CodeOfConductService {
     func getTemplate() async -> DataState<String>
 }
 
-enum CodeOfConductServiceFactory {
-    @StubOrImpl(stub: CodeOfConductServiceStub(), impl: CodeOfConductServiceImpl())
-    static var shared: CodeOfConductService
+enum CodeOfConductServiceFactory: DependencyFactory {
+    static let liveValue: CodeOfConductService = CodeOfConductServiceImpl()
+
+    static let testValue: CodeOfConductService = CodeOfConductServiceStub()
 }

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
@@ -31,5 +31,6 @@ protocol CodeOfConductService {
 }
 
 enum CodeOfConductServiceFactory {
-    static let shared: CodeOfConductService = CodeOfConductServiceImpl()
+    // TODO: Invert order
+    static let shared: CodeOfConductService = !CommandLine.arguments.contains("-Screenshots") ? CodeOfConductServiceStub() : CodeOfConductServiceImpl()
 }

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
@@ -31,5 +31,6 @@ protocol CodeOfConductService {
 }
 
 enum CodeOfConductServiceFactory {
-    static let shared: CodeOfConductService = CommandLine.arguments.contains("-Screenshots") ? CodeOfConductServiceStub() : CodeOfConductServiceImpl()
+    @StubOrImpl(stub: CodeOfConductServiceStub(), impl: CodeOfConductServiceImpl())
+    static var shared: CodeOfConductService
 }

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductService.swift
@@ -31,6 +31,5 @@ protocol CodeOfConductService {
 }
 
 enum CodeOfConductServiceFactory {
-    // TODO: Invert order
-    static let shared: CodeOfConductService = !CommandLine.arguments.contains("-Screenshots") ? CodeOfConductServiceStub() : CodeOfConductServiceImpl()
+    static let shared: CodeOfConductService = CommandLine.arguments.contains("-Screenshots") ? CodeOfConductServiceStub() : CodeOfConductServiceImpl()
 }

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceImpl.swift
@@ -8,7 +8,7 @@
 import APIClient
 import Common
 
-class CodeOfConductServiceImpl: CodeOfConductService {
+struct CodeOfConductServiceImpl: CodeOfConductService {
 
     private let client = APIClient()
 

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
@@ -8,12 +8,12 @@
 import Foundation
 import Common
 
-public class CodeOfConductServiceStub: CodeOfConductService {
-    public func acceptCodeOfConduct(for courseId: Int) async -> NetworkResponse {
+struct CodeOfConductServiceStub: CodeOfConductService {
+    func acceptCodeOfConduct(for courseId: Int) async -> NetworkResponse {
         return .success
     }
 
-    public func getAgreement(for courseId: Int) async -> DataState<Bool> {
+    func getAgreement(for courseId: Int) async -> DataState<Bool> {
         return .done(response: true)
     }
 

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  CodeOfConductServiceStub.swift
+//
 //
 //  Created by Anian Schleyer on 03.06.24.
 //

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductService/CodeOfConductServiceStub.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  
+//
+//  Created by Anian Schleyer on 03.06.24.
+//
+
+import Foundation
+import Common
+
+public class CodeOfConductServiceStub: CodeOfConductService {
+    public func acceptCodeOfConduct(for courseId: Int) async -> NetworkResponse {
+        return .success
+    }
+
+    public func getAgreement(for courseId: Int) async -> DataState<Bool> {
+        return .done(response: true)
+    }
+
+    func getResponsibleUsers(for courseId: Int) async -> DataState<[ResponsibleUserDTO]> {
+        return .done(response: [])
+    }
+
+    func getTemplate() async -> DataState<String> {
+        return .done(response: "")
+    }
+}

--- a/ArtemisKit/Sources/Messages/Services/CodeOfConductStorageService/CodeOfConductStorageServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/CodeOfConductStorageService/CodeOfConductStorageServiceImpl.swift
@@ -12,7 +12,7 @@ import UserStore
 struct CodeOfConductStorageServiceImpl: CodeOfConductStorageService {
 
     func acceptCodeOfConduct(for courseId: Int, codeOfConduct: String) {
-        guard let serverHost = UserSession.shared.institution?.baseURL?.absoluteString,
+        guard let serverHost = UserSessionFactory.shared.institution?.baseURL?.absoluteString,
               let data = codeOfConduct.data(using: .utf8) else {
             return
         }
@@ -21,7 +21,7 @@ struct CodeOfConductStorageServiceImpl: CodeOfConductStorageService {
     }
 
     func getAgreement(for courseId: Int, codeOfConduct: String) -> Bool {
-        guard let serverHost = UserSession.shared.institution?.baseURL?.absoluteString,
+        guard let serverHost = UserSessionFactory.shared.institution?.baseURL?.absoluteString,
               let data = codeOfConduct.data(using: .utf8) else {
             return false
         }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -179,5 +179,6 @@ extension MessagesService {
 }
 
 enum MessagesServiceFactory {
-    static let shared: MessagesService = MessagesServiceImpl()
+    // TODO: Invert Order
+    static let shared: MessagesService = !CommandLine.arguments.contains("-Screenshots") ? MessagesServiceStub() : MessagesServiceImpl()
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -179,6 +179,5 @@ extension MessagesService {
 }
 
 enum MessagesServiceFactory {
-    // TODO: Invert Order
-    static let shared: MessagesService = !CommandLine.arguments.contains("-Screenshots") ? MessagesServiceStub() : MessagesServiceImpl()
+    static let shared: MessagesService = CommandLine.arguments.contains("-Screenshots") ? MessagesServiceStub() : MessagesServiceImpl()
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -156,19 +156,19 @@ protocol MessagesService {
 
 extension MessagesService {
     func joinChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
-        guard let username = UserSession.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
+        guard let username = UserSessionFactory.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
 
         return await addMembersToChannel(for: courseId, channelId: channelId, usernames: [username])
     }
 
     func leaveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
-        guard let username = UserSession.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
+        guard let username = UserSessionFactory.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
 
         return await removeMembersFromChannel(for: courseId, channelId: channelId, usernames: [username])
     }
 
     func leaveConversation(for courseId: Int, groupChatId: Int64) async -> NetworkResponse {
-        guard let username = UserSession.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
+        guard let username = UserSessionFactory.shared.user?.login else { return .failure(error: UserFacingError(error: APIClientError.wrongParameters)) }
 
         return await removeMembersFromGroupChat(for: courseId, groupChatId: groupChatId, usernames: [username])
     }
@@ -178,7 +178,8 @@ extension MessagesService {
     }
 }
 
-enum MessagesServiceFactory {
-    @StubOrImpl(stub: MessagesServiceStub(), impl: MessagesServiceImpl())
-    static var shared: MessagesService
+enum MessagesServiceFactory: DependencyFactory {
+    static let liveValue: MessagesService = MessagesServiceImpl()
+
+    static let testValue: MessagesService = MessagesServiceStub()
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -179,5 +179,6 @@ extension MessagesService {
 }
 
 enum MessagesServiceFactory {
-    static let shared: MessagesService = CommandLine.arguments.contains("-Screenshots") ? MessagesServiceStub() : MessagesServiceImpl()
+    @StubOrImpl(stub: MessagesServiceStub(), impl: MessagesServiceImpl())
+    static var shared: MessagesService
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -12,7 +12,7 @@ import SharedModels
 import UserStore
 
 // swiftlint:disable file_length type_body_length
-class MessagesServiceImpl: MessagesService {
+struct MessagesServiceImpl: MessagesService {
 
     private let client = APIClient()
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -94,7 +94,7 @@ struct MessagesServiceStub {
 
 extension MessagesServiceStub: MessagesService {
     func getConversations(for courseId: Int) async -> DataState<[Conversation]> {
-        .loading
+        .done(response: [.channel(conversation: .mock)])
     }
 
     func updateIsConversationFavorite(for courseId: Int, and conversationId: Int64, isFavorite: Bool) async -> NetworkResponse {

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -58,7 +58,7 @@ class ConversationViewModel: BaseViewModel {
         messagesRepository: MessagesRepository = .shared,
         messagesService: MessagesService = MessagesServiceFactory.shared,
         stompClient: ArtemisStompClient = .shared,
-        userSession: UserSession = .shared
+        userSession: UserSession = UserSessionFactory.shared
     ) {
         self.course = course
         self.conversation = conversation

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
@@ -31,7 +31,7 @@ final class MessageCellModel {
         isHeaderVisible: Bool,
         retryButtonAction: (() -> Void)?,
         messagesService: MessagesService = MessagesServiceFactory.shared,
-        userSession: UserSession = .shared
+        userSession: UserSession = UserSessionFactory.shared
     ) {
         self.course = course
         self.conversationPath = conversationPath

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -42,7 +42,7 @@ class MessagesAvailableViewModel: BaseViewModel {
         course: Course,
         messagesService: MessagesService = MessagesServiceFactory.shared,
         stompClient: ArtemisStompClient = ArtemisStompClient.shared,
-        userSession: UserSession = UserSession.shared
+        userSession: UserSession = UserSessionFactory.shared
     ) {
         self.course = course
         self.courseId = course.id

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -80,7 +80,7 @@ final class SendMessageViewModel {
         delegate: SendMessageViewModelDelegate,
         messagesRepository: MessagesRepository = .shared,
         messagesService: MessagesService = MessagesServiceFactory.shared,
-        userSession: UserSession = .shared
+        userSession: UserSession = UserSessionFactory.shared
     ) {
         self.course = course
         self.conversation = conversation

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -121,12 +121,12 @@ private extension ConversationInfoSheetView {
                             HStack {
                                 Text(name)
                                 Spacer()
-                                if UserSession.shared.user?.login == member.login {
+                                if UserSessionFactory.shared.user?.login == member.login {
                                     Chip(text: R.string.localizable.youLabel(), backgroundColor: .Artemis.artemisBlue)
                                 }
                             }
                             .contextMenu {
-                                if UserSession.shared.user?.login != member.login,
+                                if UserSessionFactory.shared.user?.login != member.login,
                                    viewModel.canRemoveUsers {
                                     Button(R.string.localizable.removeUserButtonLabel()) {
                                         viewModel.isLoading = true

--- a/ArtemisKit/Sources/Navigation/Deeplinks/DeeplinkHandler.swift
+++ b/ArtemisKit/Sources/Navigation/Deeplinks/DeeplinkHandler.swift
@@ -23,7 +23,7 @@ public class DeeplinkHandler {
     private let userSession: UserSession
 
     private init(
-        userSession: UserSession = .shared
+        userSession: UserSession = UserSessionFactory.shared
     ) {
         self.userSession = userSession
     }

--- a/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -73,7 +73,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
     }
 
     private func subscribeToSingleUserNotificationUpdates() async {
-        guard let userId = UserSession.shared.user?.id else {
+        guard let userId = UserSessionFactory.shared.user?.id else {
             log.debug("User could not be found. Subscribe to UserNotifications not possible")
             return
         }
@@ -199,7 +199,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
     }
 
     private func subscribeToTutorialGroupNotificationUpdates() async {
-        guard let userId = UserSession.shared.user?.id else {
+        guard let userId = UserSessionFactory.shared.user?.id else {
             log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
@@ -217,7 +217,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
     }
 
     private func subscribeToConversationNotificationUpdates() async {
-        guard let userId = UserSession.shared.user?.id else {
+        guard let userId = UserSessionFactory.shared.user?.id else {
             log.debug("User could not be found. Subscription to UserNotifications is not possible")
             return
         }
@@ -228,7 +228,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
         let task = Task {
             for await message in stream {
                 guard let notification = JSONDecoder.getTypeFromSocketMessage(type: Notification.self, message: message),
-                      let userId = UserSession.shared.user?.id else { continue }
+                      let userId = UserSessionFactory.shared.user?.id else { continue }
 
                 // Only add notification if it is not from the current user
                 if notification.author?.id != userId {

--- a/ArtemisKit/Sources/Notifications/ViewModels/NotificationViewModel.swift
+++ b/ArtemisKit/Sources/Notifications/ViewModels/NotificationViewModel.swift
@@ -42,7 +42,7 @@ class NotificationViewModel: ObservableObject {
     }
 
     private func updateLastNotificationSeenDate() {
-        let userLastNotificationSeen = UserSession.shared.user?.lastNotificationRead
+        let userLastNotificationSeen = UserSessionFactory.shared.user?.lastNotificationRead
         let storedLastNotificationSeenDate = UserDefaults.standard.object(forKey: "lastNotificationSeenDate") as? Date
 
         if let userLastNotificationSeen,

--- a/ArtemisUITests/ArtemisUITests.swift
+++ b/ArtemisUITests/ArtemisUITests.swift
@@ -16,7 +16,7 @@ final class ArtemisUITests: XCTestCase {
         super.setUp()
         app = XCUIApplication()
         setupSnapshot(app)
-        app.launchArguments += ["-Screenshots"]
+        app.launchArguments += ["-dependency-factory-test-value"]
     }
     
     @MainActor

--- a/ArtemisUITests/ArtemisUITests.swift
+++ b/ArtemisUITests/ArtemisUITests.swift
@@ -16,7 +16,6 @@ final class ArtemisUITests: XCTestCase {
         super.setUp()
         app = XCUIApplication()
         setupSnapshot(app)
-        app.launchArguments += ["-dependency-factory-test-value"]
     }
     
     @MainActor

--- a/ArtemisUITests/ArtemisUITests.swift
+++ b/ArtemisUITests/ArtemisUITests.swift
@@ -1,0 +1,44 @@
+//
+//  ArtemisUITests.swift
+//  ArtemisUITests
+//
+//  Created by Anian Schleyer on 02.06.24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import XCTest
+
+final class ArtemisUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        app = XCUIApplication()
+        setupSnapshot(app)
+        app.launchArguments += ["-Screenshots"]
+    }
+    
+    @MainActor
+    func testTakeScreenshots() {
+        app.launch()
+
+        snapshot("01Dashboard")
+        
+        // Navigate to course details
+        app.staticTexts["Interactive Learning"].tap()
+        
+        snapshot("02CourseView")
+        
+        // Navigate to messages tab
+        app.tabBars.firstMatch.buttons["Messages"].tap()
+        
+        // Accept code of conduct
+        let accept = app.buttons["Accept"]
+        if accept.exists {
+            accept.tap()
+        }
+        
+        snapshot("03MessagesView")
+    }
+}

--- a/ArtemisUITests/SnapshotHelper.swift
+++ b/ArtemisUITests/SnapshotHelper.swift
@@ -1,0 +1,313 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch let error {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
+
+        #if os(OSX)
+            guard let app = self.app else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+            guard self.app != nil else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            let screenshot = XCUIScreen.main.screenshot()
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+            #else
+            let image = screenshot.image
+            #endif
+
+            guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+            do {
+                // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
+                simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+                let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png", isDirectory: false)
+                #if swift(<5.0)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #else
+                    try image.pngData()?.write(to: path, options: .atomic)
+                #endif
+            } catch let error {
+                NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+                NSLog(error.localizedDescription)
+            }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+            return image
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+            return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
+        #else
+            throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    @MainActor
+    var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,17 @@ default_platform(:ios)
 
 platform :ios do
 
+  desc "Generate new screenshots"
+  lane :screenshots do
+    capture_screenshots
+    upload_to_app_store(
+      api_key: api_key,
+      force: true,
+      overwrite_screenshots: true,
+      precheck_include_in_app_purchases: false
+    )
+  end
+
   desc "[CI] Check static code quality"
   lane :swift_lint do
     swiftlint(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
+### ios screenshots
+
+```sh
+[bundle exec] fastlane ios screenshots
+```
+
+Generate new screenshots
+
 ### ios swift_lint
 
 ```sh

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,26 @@
+# For more information about all available options run fastlane action snapshot
+
+devices([
+   "iPhone 15 Pro Max",
+   "iPhone 14 Plus",
+   "iPad Pro (12.9-inch) (6th generation)",
+   "iPad Pro (12.9-inch) (2nd generation)"
+])
+
+languages([
+  "en-US"
+])
+
+scheme("ArtemisUITests")
+
+output_directory("./screenshots")
+
+ios_version '17.2'
+
+clear_previous_screenshots(true)
+
+override_status_bar(true)
+
+number_of_retries(2)
+
+skip_open_summary(true)


### PR DESCRIPTION
By adding and using mock data (stub services), we can automate screenshots for Artemis-iOS. I've added a fastlane config for it and implemented a UI Test target which takes screenshots of the same features currently shown on the App Store.
This does require the [PR for the mock models](https://github.com/ls1intum/artemis-ios-core-modules/pull/56) to be merged first.

### Screenshots
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/cf8e915c-457f-42dc-8db4-770f32b2a192" width="200" alt="01Dashboard">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/cfcb98ae-f63e-4a70-bb8b-7351df740e58" width="200" alt="02CourseView">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/09006463-7043-49c7-9856-a2db6b121b78" width="200" alt="02MessagesView">