### PR TITLE
Adapt size of problem statement view to new component

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -220,7 +220,7 @@ public struct ExerciseDetailView: View {
                     ArtemisWebView(urlRequest: $urlRequest,
                                    contentHeight: $webViewHeight,
                                    isLoading: $isWebViewLoading,
-                                   customJSHeightQuery: webViewContentJS)
+                                   customJSHeightQuery: webViewHeightJS)
                     .frame(height: webViewHeight)
                     .allowsHitTesting(false)
                     .loadingIndicator(isLoading: $isWebViewLoading)
@@ -281,15 +281,15 @@ public struct ExerciseDetailView: View {
         urlRequest = URLRequest(url: URL(string: "/courses/\(courseId)/exercises/\(exercise.id)/problem-statement/\(participationId?.description ?? "")", relativeTo: UserSession.shared.institution?.baseURL)!)
     }
 
-    /// JavaScript to reduce visible content in WebView to just problem statement
-    private let webViewContentJS = """
-        if (document.querySelector("jhi-course-overview") != null
-            && document.querySelector("jhi-programming-exercise-instructions") != null
-            && document.querySelector("jhi-problem-statement").innerText.length > 10) {
-        document.querySelector("jhi-course-overview").innerHTML = document.querySelector("jhi-programming-exercise-instructions").innerHTML;
-        document.querySelector("#programming-exercise-instructions-content").setAttribute("style", "overflow: unset");
+    /// We need a custom height calculation, otherwise the web view is often too small
+    private let webViewHeightJS = """
+        if (document.querySelector("#problem-statement") != null {
+            document.querySelector("#problem-statement").scrollHeight;
+        } else if (document.querySelector(".instructions__content") != null) {
+            document.querySelector(".instructions__content").scrollHeight;
+        } else {
+            document.body.scrollHeight;
         }
-        document.querySelector(".instructions__content").scrollHeight
         """
 }
 

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -283,7 +283,7 @@ public struct ExerciseDetailView: View {
 
     /// We need a custom height calculation, otherwise the web view is often too small
     private let webViewHeightJS = """
-        if (document.querySelector("#problem-statement") != null {
+        if (document.querySelector("#problem-statement") != null) {
             document.querySelector("#problem-statement").scrollHeight;
         } else if (document.querySelector(".instructions__content") != null) {
             document.querySelector(".instructions__content").scrollHeight;


### PR DESCRIPTION
Due to [routing related server side changes](https://github.com/ls1intum/Artemis/pull/8719), the web view for showing the problem statement is sometimes too small for some exercises.
By making sure the WebView measures the correct component to get its size, the full problem statement can be shown.