### PR TITLE
`Dashboard`: Enable Caching for Course icons

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -46,17 +46,13 @@ struct CourseGridCell: View {
 private extension CourseGridCell {
     var header: some View {
         HStack(alignment: .center) {
-            AsyncImage(url: courseForDashboard.course.courseIconURL) { phase in
-                switch phase {
-                case let .success(image):
-                    image
-                        .resizable()
-                        .clipShape(.circle)
-                        .frame(width: .extraLargeImage)
-                case .failure, .empty:
-                    EmptyView()
-                @unknown default:
-                    EmptyView()
+            VStack {
+                if let imageURL = courseForDashboard.course.courseIconURL {
+                    ArtemisAsyncImage(imageURL: imageURL) {
+                        EmptyView()
+                    }
+                    .clipShape(.circle)
+                    .frame(width: .extraLargeImage)
                 }
             }
             .frame(height: .extraLargeImage)


### PR DESCRIPTION
### Problem
Currently, the icon images for courses on the dashboard are loaded asynchronously without caching as described in #116. This leads to undesirable behavior, for example: when scrolling, the images appear delayed, making the content next to them jump to the side as soon as the image has finished loading.

### Solution
By using ArtemisAsyncImage which has caching built in, we can make sure that the images are always displayed instantly whenever possible.

### Before vs After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/5119b2d9-729b-4f60-912e-e656ed022195" alt="Before" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/051b0305-7982-4b6b-848f-1ec9e74647ad" alt="After" width="300">
