### PR TITLE
`Dashboard`: Fix font of Course Title

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -59,7 +59,7 @@ private extension CourseGridCell {
             .padding([.leading, .vertical], .m)
             VStack(alignment: .leading, spacing: 0) {
                 Text(courseForDashboard.course.title ?? "")
-                    .font(.custom("SF Pro", size: 21, relativeTo: .title))
+                    .font(.system(size: UIFontMetrics.default.scaledValue(for: 21)))
                     .multilineTextAlignment(.leading)
                     .lineLimit(2)
                 Text(R.string.localizable.dashboardExercisesLabel(courseForDashboard.course.exercises?.count ?? 0))

--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -46,17 +46,13 @@ struct CourseGridCell: View {
 private extension CourseGridCell {
     var header: some View {
         HStack(alignment: .center) {
-            AsyncImage(url: courseForDashboard.course.courseIconURL) { phase in
-                switch phase {
-                case let .success(image):
-                    image
-                        .resizable()
-                        .clipShape(.circle)
-                        .frame(width: .extraLargeImage)
-                case .failure, .empty:
-                    EmptyView()
-                @unknown default:
-                    EmptyView()
+            VStack {
+                if let imageURL = courseForDashboard.course.courseIconURL {
+                    ArtemisAsyncImage(imageURL: imageURL) {
+                        EmptyView()
+                    }
+                    .clipShape(.circle)
+                    .frame(width: .extraLargeImage)
                 }
             }
             .frame(height: .extraLargeImage)


### PR DESCRIPTION
### Problem
On the Dashboard, the names of the courses are shown with the Helvetica font instead of the system font. The reason for this is a "custom" font (which judging by the name should also be the system font SF Pro) being imported which does not exist.

### Solution
By using the system font directly we can make sure that the used font actually exists and the UI looks consistent.

### Before vs After
You can see the difference especially on `,` and `!`.

<img width="250" alt="Before" src="https://github.com/ls1intum/artemis-ios/assets/98647423/c783292b-832e-4f57-8927-bff9ddddf087">
<img width="250" alt="After" src="https://github.com/ls1intum/artemis-ios/assets/98647423/9aacd84c-5046-4a2c-a638-b9a8954dcfdc">
