### PR TITLE
`Exercises`: Add new design for exercise list

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -137,58 +137,73 @@ struct ExerciseListCell: View {
     let course: Course
     let exercise: Exercise
 
-    let rows = [
-        GridItem()
-    ]
+    var showAdditionalBadges: Bool {
+        if let releaseDate = exercise.baseExercise.releaseDate,
+           releaseDate > .now {
+            return true
+        }
+        if let categories = exercise.baseExercise.categories, !categories.isEmpty {
+            return true
+        }
+        return exercise.baseExercise.includedInOverallScore != .includedCompletely
+    }
 
     var body: some View {
         Button {
             navigationController.path.append(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
         } label: {
-            VStack(alignment: .leading, spacing: .m) {
-                HStack(spacing: .l) {
-                    exercise.image
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .foregroundColor(Color.Artemis.primaryLabel)
-                        .frame(width: .smallImage)
-                    Text(exercise.baseExercise.title ?? "")
-                        .font(.title3)
-                    Spacer()
+            HStack(alignment: .top) {
+                if let difficulty = exercise.baseExercise.difficulty {
+                    Rectangle()
+                        .frame(width: .m)
+                        .foregroundStyle(difficulty.color)
+                        .accessibilityLabel(difficulty.description)
                 }
-                if let dueDate = exercise.baseExercise.dueDate {
-                    Text(R.string.localizable.dueDate(dueDate.relative ?? "?"))
-                } else {
-                    Text(R.string.localizable.noDueDate())
-                }
-                SubmissionResultStatusView(exercise: exercise)
-                ScrollView(.horizontal) {
-                    LazyHGrid(rows: rows, spacing: .s) {
-                        if let releaseDate = exercise.baseExercise.releaseDate,
-                           releaseDate > .now {
-                            Chip(
-                                text: R.string.localizable.notReleased(),
-                                backgroundColor: Color.Artemis.badgeWarningColor)
-                        }
-                        ForEach(exercise.baseExercise.categories ?? [], id: \.category) { category in
-                            Chip(text: category.category, backgroundColor: UIColor(hexString: category.colorCode).suColor)
-                        }
-                        // TODO: maybe add isActiveQuiz in presentationMode badge
-                        if let difficulty = exercise.baseExercise.difficulty {
-                            Chip(text: difficulty.description, backgroundColor: difficulty.color)
-                        }
-                        if exercise.baseExercise.includedInOverallScore != .includedCompletely {
-                            Chip(
-                                text: exercise.baseExercise.includedInOverallScore.description,
-                                backgroundColor: exercise.baseExercise.includedInOverallScore.color)
+                VStack(alignment: .leading, spacing: .m) {
+                    HStack(spacing: .m) {
+                        exercise.image
+                            .renderingMode(.template)
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(Color.Artemis.primaryLabel)
+                            .frame(width: .smallImage)
+                        Text(exercise.baseExercise.title ?? "")
+                            .font(.title3)
+                            .lineLimit(1)
+                    }
+                    if let dueDate = exercise.baseExercise.dueDate {
+                        Text(dueDate, style: .date)
+                    } else {
+                        Text(R.string.localizable.noDueDate())
+                    }
+                    SubmissionResultStatusView(exercise: exercise)
+                    if showAdditionalBadges {
+                        ScrollView(.horizontal) {
+                            HStack(spacing: .s) {
+                                if let releaseDate = exercise.baseExercise.releaseDate,
+                                   releaseDate > .now {
+                                    Chip(
+                                        text: R.string.localizable.notReleased(),
+                                        backgroundColor: Color.Artemis.badgeWarningColor)
+                                }
+                                ForEach(exercise.baseExercise.categories ?? [], id: \.category) { category in
+                                    Chip(text: category.category, backgroundColor: UIColor(hexString: category.colorCode).suColor)
+                                }
+                                // TODO: maybe add isActiveQuiz in presentationMode badge
+                                if exercise.baseExercise.includedInOverallScore != .includedCompletely {
+                                    Chip(
+                                        text: exercise.baseExercise.includedInOverallScore.description,
+                                        backgroundColor: exercise.baseExercise.includedInOverallScore.color)
+                                }
+                            }
                         }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, .m)
+                .padding(.vertical, .l)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.l)
-            .artemisStyleCard()
+            .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
         }
         // Make button style explicit, otherwise, multiple cells may activate a navigation link.
         .buttonStyle(.plain)

--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 
 // MARK: - ExerciseDetailView
 "exerciseDetails" = "Exercise details";
-"dueDate" = "Due Date: %s";
 "noDueDate" = "No due date";
 "points" = "Points: %s of %s";
 "assessment" = "Assessment: %s";


### PR DESCRIPTION
### Problem
The exercise list on Artemis-iOS currently uses an old design that doesn't match the one currently in use on the Web App. It also feels somewhat out of place on iOS due to a lack of rounded corners.

### Solution
By making the design more similar to the web app, we unify the design across both, leading to a more consistent experience. It also looks more "at home" on iOS by making use of rounded corners and background coloring instead of borders.

### Before vs After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/8552dcb4-101c-4d3a-98fd-36e62b283911" alt="Before" width="250">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/e8c5a1e4-82e6-47ed-a6f4-605fe25c7c57" alt="After" width="250">