### PR TITLE
`Notifications`: Improve notification sheet presentation

### DIFF
--- a/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,6 @@
 "artemisLabel" = "Artemis";
 "ok" = "OK";
+"close" = "Close";
 
 "notificationsTitle" = "Notifications";
 "notificationAuthorLabel" = "%@ by %@";

--- a/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
@@ -57,6 +57,13 @@ struct NotificationView: View {
             .alert(R.string.localizable.notificationTargetNotFound(), isPresented: $isTargetNotFoundAlertPresented) {
                 Button(R.string.localizable.ok(), role: .cancel) { }
             }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(R.string.localizable.close()) {
+                        dismiss()
+                    }
+                }
+            }
         }
     }
 }

--- a/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
+++ b/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
@@ -29,10 +29,12 @@ private struct NotificationBell: ViewModifier {
                         Image(systemName: "bell.fill")
                             .overlay(Badge(count: viewModel.newNotificationCount))
                     }
+                    .popover(isPresented: $isNotificationSheetPresented) {
+                        let minSize = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * 0.8
+                        NotificationView(viewModel: viewModel)
+                            .frame(minWidth: minSize, minHeight: minSize)
+                    }
                 }
-            }
-            .sheet(isPresented: $isNotificationSheetPresented) {
-                NotificationView(viewModel: viewModel)
             }
             .task {
                 await viewModel.subscribeToNotificationUpdates()

--- a/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
+++ b/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
@@ -18,6 +18,7 @@ private struct NotificationBell: ViewModifier {
     @StateObject private var viewModel = NotificationViewModel()
 
     @State private var isNotificationSheetPresented = false
+    @Environment(\.horizontalSizeClass) var horizontalSize
 
     func body(content: Content) -> some View {
         content
@@ -32,7 +33,15 @@ private struct NotificationBell: ViewModifier {
                             .overlay(Badge(count: viewModel.newNotificationCount))
                     }
                     .popover(isPresented: $isNotificationSheetPresented) {
-                        let minSize = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * 0.8
+                        let minSize: CGFloat? =
+                        if UIDevice.current.userInterfaceIdiom == .pad && horizontalSize != .compact {
+                            // If not shown as a sheet, we need to set a size.
+                            // Otherwise, it will be too small for its content.
+                            min(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * 0.8
+                        } else {
+                            // If shown as a sheet, the default size works for us
+                            nil
+                        }
                         NotificationView(viewModel: viewModel)
                             .frame(minWidth: minSize, minHeight: minSize)
                     }

--- a/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
+++ b/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
@@ -21,6 +21,8 @@ private struct NotificationBell: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            // Prevent user from accidentally tapping buttons outside the popover while open
+            .disabled(isNotificationSheetPresented)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {


### PR DESCRIPTION
### Problem
On iPad, notifications are currently presented in a big sheet in the center of the screen. This does not make efficient use of space and feels somewhat out of place – you tap an icon in the top left corner to bring up a sheet in the middle of the display.

Additionally, there is no visual indication (close button) on how to dismiss the sheet on iPhone.

### Solution
By presenting the sheet as a popover on iPad, the content appears coming "out of" the button which was pressed, making it clear where this came from.

We also add a "Close" button to dismiss the view.

### Before vs After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/578b2065-1295-412f-ab23-d9e13bb910d1" alt="Before" width="330">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/e1d7c10d-73f3-42d7-a292-82a5ecc984be" alt="After" width="330">


iPhone version:

<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/98a79b92-b3db-4822-ad9a-4900bf8d306f" alt="iPhone version before" width="250">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/353edfe9-8fb7-4352-b376-842e026d2a9b" alt="iPhone version after" width="250">