### PR TITLE
`Communication`: Update condition for showing Messaging Tab

### DIFF
--- a/ArtemisKit/Sources/CourseView/CourseViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/CourseViewModel.swift
@@ -10,8 +10,7 @@ class CourseViewModel: BaseViewModel {
     private let courseService: CourseService
 
     var isMessagesVisible: Bool {
-        course.courseInformationSharingConfiguration == .communicationAndMessaging
-        || course.courseInformationSharingConfiguration == .messagingOnly
+        course.courseInformationSharingConfiguration != .disabled
     }
 
     init(course: Course, courseService: CourseService = CourseServiceFactory.shared) {

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -31,6 +31,10 @@ class MessagesAvailableViewModel: BaseViewModel {
 
     @Published var hiddenConversations: DataState<[Conversation]> = .loading
 
+    var isDirectMessagingEnabled: Bool {
+        course.courseInformationSharingConfiguration == .communicationAndMessaging
+    }
+
     let course: Course
     let courseId: Int
 

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -81,16 +81,18 @@ public struct MessagesAvailableView: View {
                         sectionTitle: R.string.localizable.exams(),
                         conversationType: .channel,
                         isExpanded: false)
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.groupChats,
-                        sectionTitle: R.string.localizable.groupChats(),
-                        conversationType: .groupChat)
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.oneToOneChats,
-                        sectionTitle: R.string.localizable.directMessages(),
-                        conversationType: .oneToOneChat)
+                    if viewModel.isDirectMessagingEnabled {
+                        MessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.groupChats,
+                            sectionTitle: R.string.localizable.groupChats(),
+                            conversationType: .groupChat)
+                        MessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.oneToOneChats,
+                            sectionTitle: R.string.localizable.directMessages(),
+                            conversationType: .oneToOneChat)
+                    }
                     MixedMessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.hiddenConversations,


### PR DESCRIPTION
### Problem
With [this PR of Artemis](https://github.com/ls1intum/Artemis/pull/8801), Courses can choose the following options for messaging:
- Disabled (no communication)
- Communication only (only channels like announcement, organization …)
- Communication and messaging (channels as well as direct and group messages)

Messaging only will no longer exist.

### Solution
Therefore, we now display the messaging tab whenever communication is not disabled. In the Messaging Tab, we then always show channels, but DMs and Group Messages only when enabled.