### PR TITLE
`Exercises`: Adjust spacing of exercise cell content

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -152,7 +152,7 @@ struct ExerciseListCell: View {
         Button {
             navigationController.path.append(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
         } label: {
-            HStack(alignment: .top) {
+            HStack(alignment: .top, spacing: 0) {
                 if let difficulty = exercise.baseExercise.difficulty {
                     Rectangle()
                         .frame(width: .m)
@@ -200,8 +200,7 @@ struct ExerciseListCell: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, .m)
-                .padding(.vertical, .l)
+                .padding(.l)
             }
             .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
         }


### PR DESCRIPTION
### Problem
When an exercise has no difficulty level set, there is uneven spacing in the cells of the exercise list. The contents are too close to the leading edge of the cell.

### Before vs After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/a1a78798-b07c-4b55-9588-7f84f8312918" alt="Before" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/611be981-9acf-4cc7-b1d0-196e6d21ad48" alt="After" width="300">
