### PR TITLE
`Communication`: Add visual context menu to conversation row

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -55,17 +55,25 @@ struct ConversationRow<T: BaseConversation>: View {
 
 private extension ConversationRow {
     @ViewBuilder var contextMenuItems: some View {
-        Button((conversation.isFavorite ?? false) ? R.string.localizable.unfavorite() : R.string.localizable.favorite()) {
+        let isFavorite = conversation.isFavorite ?? false
+        Button(isFavorite ? R.string.localizable.unfavorite() : R.string.localizable.favorite(),
+               systemImage: isFavorite ? "heart.slash.fill" : "heart.fill") {
             Task(priority: .userInitiated) {
                 await viewModel.setIsConversationFavorite(conversationId: conversation.id, isFavorite: !(conversation.isFavorite ?? false))
             }
         }
-        Button((conversation.isMuted ?? false) ? R.string.localizable.unmute() : R.string.localizable.mute()) {
+
+        let isMuted = conversation.isMuted ?? false
+        Button(isMuted ? R.string.localizable.unmute() : R.string.localizable.mute(),
+               systemImage: isMuted ? "bell.fill" : "bell.slash.fill") {
             Task(priority: .userInitiated) {
                 await viewModel.setIsConversationMuted(conversationId: conversation.id, isMuted: !(conversation.isMuted ?? false))
             }
         }
-        Button((conversation.isHidden ?? false) ? R.string.localizable.show() : R.string.localizable.hide()) {
+
+        let isHidden = conversation.isHidden ?? false
+        Button(isHidden ? R.string.localizable.show() : R.string.localizable.hide(),
+               systemImage: isHidden ? "eye.fill" : "eye.slash.fill") {
             Task(priority: .userInitiated) {
                 await viewModel.setConversationIsHidden(conversationId: conversation.id, isHidden: !(conversation.isHidden ?? false))
             }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -36,6 +36,12 @@ struct ConversationRow<T: BaseConversation>: View {
                 if let unreadCount = conversation.unreadMessagesCount {
                     Badge(count: unreadCount)
                 }
+                Menu {
+                    contextMenuItems
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .padding(.m)
+                }
             }
             .opacity((conversation.unreadMessagesCount ?? 0) > 0 ? 1 : 0.7)
             .contextMenu {


### PR DESCRIPTION
### Problem
It is hard to find options to favorite/mute/hide conversations. You need to long press on a conversation, but there is no visual indication to do this.

### Solution
By adding an ellipsis menu to each row, the user has a visual indication that there are more actions as well as a clear place to tap. The old context menu (long pressing) continues to be available as an option.

By also adding icons to these buttons, it makes it easier for users to find the action they need.

### Before
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/043d83e1-660a-4cf0-89e6-dae4e3fd14d4" alt="Before: Row" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/b37c8855-2ae4-4b6a-a8e8-a9db279a9704" alt="Before: Context Menu" width="300">

### After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/0a7728db-09cc-45c6-b513-1f66f1f5ca06" alt="After: Row" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/6b40073e-eb1f-47b8-99f5-42402cea4507" alt="After: New menu" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/3f99cc32-0cc2-40df-861a-82a646026984" alt="After: Context menu" width="300">

