### PR TITLE
`Communication`: Simplify compose message toolbar

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -14,6 +14,15 @@
 "membersUnavailable" = "No Members";
 "messageAction" = "Message %@";
 "mentionSlideNumber" = "Slide %i";
+"style" = "Style";
+"bold" = "Bold";
+"italic" = "Italic";
+"underline" = "Underline";
+"quote" = "Quote";
+"inlineCode" = "Inline code";
+"codeBlock" = "Code block";
+"code" = "Code";
+"link" = "Link";
 
 // MARK: SendMessageMentionContentView
 "members" = "Members";

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -69,7 +69,7 @@ final class SendMessageViewModel {
     var isMemberPickerSuppressed = false
     var isChannelPickerSuppressed = false
 
-    var isMentionContentViewPresented = false
+    var wantsToAddMessageMentionContentType: MessageMentionContentType? = nil
 
     // MARK: Life cycle
 

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
@@ -18,11 +18,20 @@ struct SendMessageMentionContentView: View {
                 viewModel?.text.append(mention)
                 viewModel?.wantsToAddMessageMentionContentType = nil
             }
-            switch type {
-            case .exercise:
-                SendMessageExercisePicker(delegate: delegate, course: viewModel.course)
-            case .lecture:
-                SendMessageLecturePicker(course: viewModel.course, delegate: delegate)
+            Group {
+                switch type {
+                case .exercise:
+                    SendMessageExercisePicker(delegate: delegate, course: viewModel.course)
+                case .lecture:
+                    SendMessageLecturePicker(course: viewModel.course, delegate: delegate)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(R.string.localizable.cancel()) {
+                        viewModel.wantsToAddMessageMentionContentType = nil
+                    }
+                }
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
@@ -10,41 +10,29 @@ import SwiftUI
 struct SendMessageMentionContentView: View {
 
     @Bindable var viewModel: SendMessageViewModel
+    let type: MessageMentionContentType
 
     var body: some View {
         NavigationStack {
-            List {
-                Button {
-                    viewModel.didTapAtButton()
-                    viewModel.isMentionContentViewPresented.toggle()
-                } label: {
-                    Label(R.string.localizable.members(), systemImage: "at")
-                }
-                Button {
-                    viewModel.didTapNumberButton()
-                    viewModel.isMentionContentViewPresented.toggle()
-                } label: {
-                    Label(R.string.localizable.channels(), systemImage: "number")
-                }
-
-                let delegate = SendMessageMentionContentDelegate { [weak viewModel] mention in
-                    viewModel?.text.append(mention)
-                    viewModel?.isMentionContentViewPresented.toggle()
-                }
-                NavigationLink {
-                    SendMessageExercisePicker(delegate: delegate, course: viewModel.course)
-                } label: {
-                    Label(R.string.localizable.exercises(), systemImage: "list.bullet.clipboard")
-                }
-                NavigationLink {
-                    SendMessageLecturePicker(course: viewModel.course, delegate: delegate)
-                } label: {
-                    Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
-                }
+            let delegate = SendMessageMentionContentDelegate { [weak viewModel] mention in
+                viewModel?.text.append(mention)
+                viewModel?.wantsToAddMessageMentionContentType = nil
             }
-            .listStyle(.plain)
-            .navigationTitle(R.string.localizable.mention())
-            .navigationBarTitleDisplayMode(.inline)
+            switch type {
+            case .exercise:
+                SendMessageExercisePicker(delegate: delegate, course: viewModel.course)
+            case .lecture:
+                SendMessageLecturePicker(course: viewModel.course, delegate: delegate)
+            }
         }
     }
+}
+
+enum MessageMentionContentType: Identifiable {
+    var id: Self {
+        self
+    }
+
+    case exercise
+    case lecture
 }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -178,6 +178,7 @@ private extension SendMessageView {
                         viewModel.didTapLinkButton()
                     } label: {
                         Label(R.string.localizable.link(), systemImage: "link")
+                            .labelStyle(.iconOnly)
                     }
                 }
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -106,7 +106,7 @@ private extension SendMessageView {
     var keyboardToolbarContent: some View {
         HStack {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: .l) {
+                HStack(alignment: .firstTextBaseline, spacing: .l) {
                     Menu {
                         Button {
                             viewModel.didTapAtButton()

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -129,54 +129,55 @@ private extension SendMessageView {
                             Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
                         }
                     } label: {
-                        Label("Mention", systemImage: "plus.circle.fill")
+                        Label(R.string.localizable.mention(), systemImage: "plus.circle.fill")
                             .labelStyle(.iconOnly)
                     }
                     Menu {
                         Button {
                             viewModel.didTapBoldButton()
                         } label: {
-                            Label("Bold", systemImage: "bold")
+                            Label(R.string.localizable.bold(), systemImage: "bold")
                         }
                         Button {
                             viewModel.didTapItalicButton()
                         } label: {
-                            Label("Italic", systemImage: "italic")
+                            Label(R.string.localizable.italic(), systemImage: "italic")
                         }
                         Button {
                             viewModel.didTapUnderlineButton()
                         } label: {
-                            Label("Underline", systemImage: "underline")
+                            Label(R.string.localizable.underline(), systemImage: "underline")
                         }
                     } label: {
                         // TODO: Localize
-                        Label("Format", systemImage: "bold.italic.underline")
+                        Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
                             .labelStyle(.iconOnly)
                     }
                     Button {
                         viewModel.didTapBlockquoteButton()
                     } label: {
-                        Image(systemName: "quote.opening")
+                        Label(R.string.localizable.quote(), systemImage: "quote.opening")
+                            .labelStyle(.iconOnly)
                     }
                     Menu {
                         Button {
                             viewModel.didTapCodeButton()
                         } label: {
-                            Label("Inline code", systemImage: "curlybraces")
+                            Label(R.string.localizable.inlineCode(), systemImage: "curlybraces")
                         }
                         Button {
                             viewModel.didTapCodeBlockButton()
                         } label: {
-                            Label("Code block", systemImage: "curlybraces.square.fill")
+                            Label(R.string.localizable.codeBlock(), systemImage: "curlybraces.square.fill")
                         }
                     } label: {
-                        Label("Code", systemImage: "curlybraces")
+                        Label(R.string.localizable.code(), systemImage: "curlybraces")
                             .labelStyle(.iconOnly)
-                    }.pickerStyle(.palette)
+                    }
                     Button {
                         viewModel.didTapLinkButton()
                     } label: {
-                        Image(systemName: "link")
+                        Label(R.string.localizable.link(), systemImage: "link")
                     }
                 }
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -149,7 +149,6 @@ private extension SendMessageView {
                             Label(R.string.localizable.underline(), systemImage: "underline")
                         }
                     } label: {
-                        // TODO: Localize
                         Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
                             .labelStyle(.iconOnly)
                     }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -112,20 +112,25 @@ private extension SendMessageView {
                     } label: {
                         Image(systemName: "plus.circle.fill")
                     }
-                    Button {
-                        viewModel.didTapBoldButton()
+                    Menu {
+                        Button {
+                            viewModel.didTapBoldButton()
+                        } label: {
+                            Image(systemName: "bold")
+                        }
+                        Button {
+                            viewModel.didTapItalicButton()
+                        } label: {
+                            Image(systemName: "italic")
+                        }
+                        Button {
+                            viewModel.didTapUnderlineButton()
+                        } label: {
+                            Image(systemName: "underline")
+                        }
                     } label: {
-                        Image(systemName: "bold")
-                    }
-                    Button {
-                        viewModel.didTapItalicButton()
-                    } label: {
-                        Image(systemName: "italic")
-                    }
-                    Button {
-                        viewModel.didTapUnderlineButton()
-                    } label: {
-                        Image(systemName: "underline")
+                        // TODO: Localize
+                        Label("Format", systemImage: "bold.italic.underline")
                     }
                     Button {
                         viewModel.didTapBlockquoteButton()

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -116,21 +116,22 @@ private extension SendMessageView {
                         Button {
                             viewModel.didTapBoldButton()
                         } label: {
-                            Image(systemName: "bold")
+                            Label("Bold", systemImage: "bold")
                         }
                         Button {
                             viewModel.didTapItalicButton()
                         } label: {
-                            Image(systemName: "italic")
+                            Label("Italic", systemImage: "italic")
                         }
                         Button {
                             viewModel.didTapUnderlineButton()
                         } label: {
-                            Image(systemName: "underline")
+                            Label("Underline", systemImage: "underline")
                         }
                     } label: {
                         // TODO: Localize
                         Label("Format", systemImage: "bold.italic.underline")
+                            .labelStyle(.iconOnly)
                     }
                     Button {
                         viewModel.didTapBlockquoteButton()

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -51,8 +51,8 @@ struct SendMessageView: View {
                     }
                 }
         )
-        .sheet(isPresented: $viewModel.isMentionContentViewPresented) {
-            SendMessageMentionContentView(viewModel: viewModel)
+        .sheet(item: $viewModel.wantsToAddMessageMentionContentType) { type in
+            SendMessageMentionContentView(viewModel: viewModel, type: type)
                 .presentationDetents([.fraction(0.5), .medium])
         }
     }
@@ -106,11 +106,31 @@ private extension SendMessageView {
     var keyboardToolbarContent: some View {
         HStack {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack {
-                    Button {
-                        viewModel.isMentionContentViewPresented.toggle()
+                HStack(spacing: .l) {
+                    Menu {
+                        Button {
+                            viewModel.didTapAtButton()
+                        } label: {
+                            Label(R.string.localizable.members(), systemImage: "at")
+                        }
+                        Button {
+                            viewModel.didTapNumberButton()
+                        } label: {
+                            Label(R.string.localizable.channels(), systemImage: "number")
+                        }
+                        Button {
+                            viewModel.wantsToAddMessageMentionContentType = .exercise
+                        } label: {
+                            Label(R.string.localizable.exercises(), systemImage: "list.bullet.clipboard")
+                        }
+                        Button {
+                            viewModel.wantsToAddMessageMentionContentType = .lecture
+                        } label: {
+                            Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
+                        }
                     } label: {
-                        Image(systemName: "plus.circle.fill")
+                        Label("Mention", systemImage: "plus.circle.fill")
+                            .labelStyle(.iconOnly)
                     }
                     Menu {
                         Button {
@@ -138,16 +158,21 @@ private extension SendMessageView {
                     } label: {
                         Image(systemName: "quote.opening")
                     }
-                    Button {
-                        viewModel.didTapCodeButton()
+                    Menu {
+                        Button {
+                            viewModel.didTapCodeButton()
+                        } label: {
+                            Label("Inline code", systemImage: "curlybraces")
+                        }
+                        Button {
+                            viewModel.didTapCodeBlockButton()
+                        } label: {
+                            Label("Code block", systemImage: "curlybraces.square.fill")
+                        }
                     } label: {
-                        Image(systemName: "curlybraces")
-                    }
-                    Button {
-                        viewModel.didTapCodeBlockButton()
-                    } label: {
-                        Image(systemName: "curlybraces.square.fill")
-                    }
+                        Label("Code", systemImage: "curlybraces")
+                            .labelStyle(.iconOnly)
+                    }.pickerStyle(.palette)
                     Button {
                         viewModel.didTapLinkButton()
                     } label: {


### PR DESCRIPTION
### Problem
When composing a message, there are lots of tightly spaced buttons above the keyboard for text formatting, mentions, quotes and more. This looks a bit cluttered and makes the individual buttons harder to press.

When pressing the Add mentions button, the keyboard also gets dismissed, which may be unintuitive.

### Solution
By combining similar buttons into sub-menus (that can still be used quickly via swipe gestures), we can remove a few of the buttons and increase the spacing. We also adopt the menu style for the picker for including/mentioning content, since this makes the interaction more seamless by having the options appear right above the button instead of the keyboard.

Through the use of Labels instead of Images we can also ensure a better experience for VoiceOver users.

### Before
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/bf557935-f1af-4cf2-8e18-621d85850249" alt="Before: Toolbar" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/8824482e-ec6b-4fdb-9c9b-bfcdc515b650" alt="Before: Mentions picker" width="300">

### After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/2a4b0321-4993-4a5f-8309-6c471d59d641" alt="After: Toolbar" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/c57926db-b27b-48e7-ba93-22a37b6f3f9f" alt="After: Mentions picker" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/598bd968-f3fa-4c49-9a37-187fdf7cc9e0" alt="After: Menu 1" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/62e9c490-c28f-4cfa-b0f3-bb9de33ef4d8" alt="After: Menu 2" width="300">
