### PR TITLE
`Lectures`: Adopt new design for lecture list

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -174,7 +174,7 @@ struct BaseLectureUnitCell: View {
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: .l) {
             lectureUnit.baseUnit.image
                 .renderingMode(.template)
                 .resizable()
@@ -185,7 +185,7 @@ struct BaseLectureUnitCell: View {
             Text(lectureUnit.baseUnit.name ?? "")
                 .font(.title3)
 
-            Spacer()
+            Spacer(minLength: 0)
 
             if !(lectureUnit.baseUnit.visibleToStudents ?? false) {
                 Chip(text: R.string.localizable.notReleased(), backgroundColor: .Artemis.badgeWarningColor)

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -199,7 +199,7 @@ struct BaseLectureUnitCell: View {
         }
             .frame(maxWidth: .infinity)
             .padding(.l)
-            .artemisStyleCard()
+            .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
             .onTapGesture {
                 showDetails = true
             }

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -158,7 +158,7 @@ private struct LectureListCellView: View {
             if let startDate = lecture.startDate {
                 Text("\(startDate.dateOnly) (\(startDate.relative ?? "?"))")
             } else {
-                Text(R.string.localizable.noDueDate())
+                Text(R.string.localizable.noDateAssociated())
             }
         }
         .frame(maxWidth: .infinity)

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -163,12 +163,7 @@ private struct LectureListCellView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.l)
-        .cardModifier(
-            backgroundColor: Color.Artemis.exerciseCardBackgroundColor,
-            hasBorder: true,
-            borderColor: Color.Artemis.artemisBlue,
-            cornerRadius: 2
-        )
+        .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
         .onTapGesture {
             navigationController.path.append(LecturePath(lecture: lecture, coursePath: CoursePath(course: course)))
         }


### PR DESCRIPTION
### Problem
Lectures are still shown with the old design in the iOS app, which does not match the style used for exercises and the style on the web app.

### Solution
We use the same design as for exercise cards for a consistent experience. Since Lectures are displayed by their start date, we also display "No date associated" instead of "No due date" in case a lecture has no start date set.

### Before
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/7845a633-8303-4816-8be2-1e55d102054d" alt="Before: Lectures" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/0d447649-5a88-47b7-aa90-15f5cee3e4a7" alt="Before: Lecture Units" width="300">


### After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/dc32de35-c449-443a-8022-985090fd6cf9" alt="After: Lectures" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/b13d9260-63ff-46a1-b2ff-79e507dffa64" alt="After: Lecture Units" width="300">