### PR TITLE
`Communication`: Improve conversations list

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "createChannel" = "Create Channel";
 "createGroupChat" = "Create Group Chat";
 "createOneToOneChat" = "Create OneToOne Chat";
+"createChat" = "Create Chat";
 "noResultForSearch" = "There is no result for your search.";
 "favoritesSection" = "Favorites";
 "hiddenSection" = "Hidden";

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -49,19 +49,34 @@ struct ConversationRow<T: BaseConversation>: View {
             }
         }
         .foregroundStyle((conversation.isMuted ?? false) ? .secondary : .primary)
-        .listRowSeparator(.hidden)
+        .swipeActions(edge: .leading) {
+            favoriteButton
+        }
+        .swipeActions(edge: .trailing) {
+            hideAndMuteButtons
+        }
     }
 }
 
 private extension ConversationRow {
-    @ViewBuilder var contextMenuItems: some View {
+    @ViewBuilder var favoriteButton: some View {
         let isFavorite = conversation.isFavorite ?? false
         Button(isFavorite ? R.string.localizable.unfavorite() : R.string.localizable.favorite(),
                systemImage: isFavorite ? "heart.slash.fill" : "heart.fill") {
             Task(priority: .userInitiated) {
                 await viewModel.setIsConversationFavorite(conversationId: conversation.id, isFavorite: !(conversation.isFavorite ?? false))
             }
-        }
+        }.tint(.orange)
+    }
+
+    @ViewBuilder var hideAndMuteButtons: some View {
+        let isHidden = conversation.isHidden ?? false
+        Button(isHidden ? R.string.localizable.show() : R.string.localizable.hide(),
+               systemImage: isHidden ? "eye.fill" : "eye.slash.fill") {
+            Task(priority: .userInitiated) {
+                await viewModel.setConversationIsHidden(conversationId: conversation.id, isHidden: !(conversation.isHidden ?? false))
+            }
+        }.tint(.gray)
 
         let isMuted = conversation.isMuted ?? false
         Button(isMuted ? R.string.localizable.unmute() : R.string.localizable.mute(),
@@ -69,14 +84,11 @@ private extension ConversationRow {
             Task(priority: .userInitiated) {
                 await viewModel.setIsConversationMuted(conversationId: conversation.id, isMuted: !(conversation.isMuted ?? false))
             }
-        }
-
-        let isHidden = conversation.isHidden ?? false
-        Button(isHidden ? R.string.localizable.show() : R.string.localizable.hide(),
-               systemImage: isHidden ? "eye.fill" : "eye.slash.fill") {
-            Task(priority: .userInitiated) {
-                await viewModel.setConversationIsHidden(conversationId: conversation.id, isHidden: !(conversation.isHidden ?? false))
-            }
-        }
+        }.tint(.indigo)
+    }
+    
+    @ViewBuilder var contextMenuItems: some View {
+        favoriteButton
+        hideAndMuteButtons
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -96,7 +96,7 @@ public struct MessagesAvailableView: View {
                         viewModel: viewModel,
                         conversations: $viewModel.oneToOneChats,
                         sectionTitle: R.string.localizable.directMessages(),
-                        sectionIconName: "message.fill",
+                        sectionIconName: "bubble.left.fill",
                         conversationType: .oneToOneChat)
                     MixedMessageSection(
                         viewModel: viewModel,

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -63,41 +63,35 @@ public struct MessagesAvailableView: View {
                         viewModel: viewModel,
                         conversations: $viewModel.channels,
                         sectionTitle: R.string.localizable.generalTopics(),
-                        sectionIconName: "bubble.left.fill",
-                        conversationType: .channel)
+                        sectionIconName: "bubble.left.fill")
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.exercises,
                         sectionTitle: R.string.localizable.exercises(),
                         sectionIconName: "list.bullet",
-                        conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.lectures,
                         sectionTitle: R.string.localizable.lectures(),
                         sectionIconName: "doc.fill",
-                        conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.exams,
                         sectionTitle: R.string.localizable.exams(),
                         sectionIconName: "graduationcap.fill",
-                        conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.groupChats,
                         sectionTitle: R.string.localizable.groupChats(),
-                        sectionIconName: "bubble.left.and.bubble.right.fill",
-                        conversationType: .groupChat)
+                        sectionIconName: "bubble.left.and.bubble.right.fill")
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.oneToOneChats,
                         sectionTitle: R.string.localizable.directMessages(),
-                        sectionIconName: "bubble.left.fill",
-                        conversationType: .oneToOneChat)
+                        sectionIconName: "bubble.left.fill")
                     MixedMessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.hiddenConversations,
@@ -278,8 +272,7 @@ private struct MixedMessageSection: View {
                             sectionTitle: sectionTitle,
                             sectionIconName: sectionIconName,
                             sectionUnreadCount: sectionUnreadCount,
-                            isUnreadCountVisible: !isExpanded,
-                            conversationType: nil)
+                            isUnreadCountVisible: !isExpanded)
                     }
                 }
             }
@@ -295,8 +288,6 @@ private struct SectionDisclosureLabel: View {
     let sectionIconName: String
     let sectionUnreadCount: Int
     let isUnreadCountVisible: Bool
-
-    let conversationType: ConversationType?
 
     var body: some View {
         HStack {
@@ -322,7 +313,6 @@ private struct MessageSection<T: BaseConversation>: View {
 
     let sectionTitle: String
     let sectionIconName: String
-    var conversationType: ConversationType
 
     var sectionUnreadCount: Int {
         (conversations.value ?? []).reduce(0) {
@@ -335,14 +325,12 @@ private struct MessageSection<T: BaseConversation>: View {
         conversations: Binding<DataState<[T]>>,
         sectionTitle: String,
         sectionIconName: String,
-        conversationType: ConversationType,
         isExpanded: Bool = true
     ) {
         self.viewModel = viewModel
         self._conversations = conversations
         self.sectionTitle = sectionTitle
         self.sectionIconName = sectionIconName
-        self.conversationType = conversationType
         self._isExpanded = State(wrappedValue: isExpanded)
     }
 
@@ -368,8 +356,7 @@ private struct MessageSection<T: BaseConversation>: View {
                     sectionTitle: sectionTitle,
                     sectionIconName: sectionIconName,
                     sectionUnreadCount: sectionUnreadCount,
-                    isUnreadCountVisible: !isExpanded,
-                    conversationType: conversationType)
+                    isUnreadCountVisible: !isExpanded)
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -198,19 +198,11 @@ private struct MixedMessageSection: View {
                 Section {
                     DisclosureGroup(isExpanded: $isExpanded) {
                         ForEach(
-                            conversations.filter { !($0.baseConversation.isMuted ?? false) }
+                            conversations.sorted {
+                                // Show non-muted conversations above muted ones
+                                ($0.baseConversation.isMuted ?? false ? 0 : 1) > ($1.baseConversation.isMuted ?? false ? 0 : 1)
+                            }
                         ) { conversation in
-                            if let channel = conversation.baseConversation as? Channel {
-                                ConversationRow(viewModel: viewModel, conversation: channel)
-                            }
-                            if let groupChat = conversation.baseConversation as? GroupChat {
-                                ConversationRow(viewModel: viewModel, conversation: groupChat)
-                            }
-                            if let oneToOneChat = conversation.baseConversation as? OneToOneChat {
-                                ConversationRow(viewModel: viewModel, conversation: oneToOneChat)
-                            }
-                        }
-                        ForEach(conversations.filter({ $0.baseConversation.isMuted ?? false })) { conversation in
                             if let channel = conversation.baseConversation as? Channel {
                                 ConversationRow(viewModel: viewModel, conversation: channel)
                             }
@@ -345,13 +337,10 @@ private struct MessageSection<T: BaseConversation>: View {
                     await viewModel.loadConversations()
                 } content: { conversations in
                     ForEach(
-                        conversations.filter { !($0.isMuted ?? false) },
-                        id: \.id
-                    ) { conversation in
-                        ConversationRow(viewModel: viewModel, conversation: conversation)
-                    }
-                    ForEach(
-                        conversations.filter { $0.isMuted ?? false },
+                        conversations.sorted {
+                            // Show non-muted conversations above muted ones
+                            ($0.isMuted ?? false ? 0 : 1) > ($1.isMuted ?? false ? 0 : 1)
+                        },
                         id: \.id
                     ) { conversation in
                         ConversationRow(viewModel: viewModel, conversation: conversation)

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -57,44 +57,52 @@ public struct MessagesAvailableView: View {
                     MixedMessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.favoriteConversations,
-                        sectionTitle: R.string.localizable.favoritesSection())
+                        sectionTitle: R.string.localizable.favoritesSection(),
+                        sectionIconName: "heart.fill")
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.channels,
                         sectionTitle: R.string.localizable.channels(),
+                        sectionIconName: "bubble.left.fill",
                         conversationType: .channel)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.exercises,
                         sectionTitle: R.string.localizable.exercises(),
+                        sectionIconName: "list.bullet",
                         conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.lectures,
                         sectionTitle: R.string.localizable.lectures(),
+                        sectionIconName: "doc.fill",
                         conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.exams,
                         sectionTitle: R.string.localizable.exams(),
+                        sectionIconName: "graduationcap.fill",
                         conversationType: .channel,
                         isExpanded: false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.groupChats,
                         sectionTitle: R.string.localizable.groupChats(),
+                        sectionIconName: "bubble.left.and.bubble.right.fill",
                         conversationType: .groupChat)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.oneToOneChats,
                         sectionTitle: R.string.localizable.directMessages(),
+                        sectionIconName: "message.fill",
                         conversationType: .oneToOneChat)
                     MixedMessageSection(
                         viewModel: viewModel,
                         conversations: $viewModel.hiddenConversations,
                         sectionTitle: R.string.localizable.hiddenSection(),
+                        sectionIconName: "nosign",
                         isExpanded: false)
                 }
                 .listRowSeparator(.visible, edges: .top)
@@ -158,16 +166,19 @@ private struct MixedMessageSection: View {
     @State private var isExpanded = true
 
     private let sectionTitle: String
+    private let sectionIconName: String
 
     init(
         viewModel: MessagesAvailableViewModel,
         conversations: Binding<DataState<[Conversation]>>,
         sectionTitle: String,
+        sectionIconName: String,
         isExpanded: Bool = true
     ) {
         self.viewModel = viewModel
         self._conversations = conversations
         self.sectionTitle = sectionTitle
+        self.sectionIconName = sectionIconName
         self._isExpanded = State(wrappedValue: isExpanded)
     }
 
@@ -211,6 +222,7 @@ private struct MixedMessageSection: View {
                     SectionDisclosureLabel(
                         viewModel: viewModel,
                         sectionTitle: sectionTitle,
+                        sectionIconName: sectionIconName,
                         sectionUnreadCount: sectionUnreadCount,
                         isUnreadCountVisible: !isExpanded,
                         conversationType: nil)
@@ -230,6 +242,7 @@ private struct SectionDisclosureLabel: View {
     @State private var isCreateChannelPresented = false
 
     let sectionTitle: String
+    let sectionIconName: String
     let sectionUnreadCount: Int
     let isUnreadCountVisible: Bool
 
@@ -237,8 +250,9 @@ private struct SectionDisclosureLabel: View {
 
     var body: some View {
         HStack {
-            Text(sectionTitle)
+            Label(sectionTitle, systemImage: sectionIconName)
                 .font(.headline)
+                .foregroundStyle(.primary)
             Spacer()
             if isUnreadCountVisible {
                 Badge(count: sectionUnreadCount)
@@ -258,6 +272,7 @@ private struct SectionDisclosureLabel: View {
                     }
             }
         }
+        .padding(.vertical, .m)
         .sheet(isPresented: $isCreateNewConversationPresented) {
             CreateOrAddToChatView(courseId: viewModel.courseId, configuration: .createChat)
         }
@@ -294,7 +309,8 @@ private struct MessageSection<T: BaseConversation>: View {
 
     @State private var isExpanded = true
 
-    var sectionTitle: String
+    let sectionTitle: String
+    let sectionIconName: String
     var conversationType: ConversationType
 
     var sectionUnreadCount: Int {
@@ -307,12 +323,14 @@ private struct MessageSection<T: BaseConversation>: View {
         viewModel: MessagesAvailableViewModel,
         conversations: Binding<DataState<[T]>>,
         sectionTitle: String,
+        sectionIconName: String,
         conversationType: ConversationType,
         isExpanded: Bool = true
     ) {
         self.viewModel = viewModel
         self._conversations = conversations
         self.sectionTitle = sectionTitle
+        self.sectionIconName = sectionIconName
         self.conversationType = conversationType
         self._isExpanded = State(wrappedValue: isExpanded)
     }
@@ -339,6 +357,7 @@ private struct MessageSection<T: BaseConversation>: View {
             SectionDisclosureLabel(
                 viewModel: viewModel,
                 sectionTitle: sectionTitle,
+                sectionIconName: sectionIconName,
                 sectionUnreadCount: sectionUnreadCount,
                 isUnreadCountVisible: !isExpanded,
                 conversationType: conversationType)

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -172,15 +172,15 @@ private struct CreateOrAddChannelButton: View {
     var body: some View {
         Menu {
             if viewModel.course.isAtLeastTutorInCourse {
-                Button(R.string.localizable.createChannel()) {
+                Button(R.string.localizable.createChannel(), systemImage: "plus.bubble.fill") {
                     isCreateChannelPresented = true
                 }
             }
-            Button(R.string.localizable.browseChannels()) {
+            Button(R.string.localizable.browseChannels(), systemImage: "number") {
                 isBrowseChannelsPresented = true
             }
             if viewModel.course.courseInformationSharingConfiguration == .communicationAndMessaging {
-                Button(R.string.localizable.createChat()) {
+                Button(R.string.localizable.createChat(), systemImage: "bubble.left.fill") {
                     isCreateNewConversationPresented = true
                 }
             }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -170,27 +170,21 @@ private struct CreateOrAddChannelButton: View {
     @State private var isCreateChannelPresented = false
 
     var body: some View {
-        Menu {
-            if viewModel.course.isAtLeastTutorInCourse {
-                Button(R.string.localizable.createChannel(), systemImage: "plus.bubble.fill") {
-                    isCreateChannelPresented = true
+        Group {
+            if viewModel.course.courseInformationSharingConfiguration == .communicationOnly && !viewModel.course.isAtLeastTutorInCourse {
+                // If DMs are disabled and we are no instructor, we can only browse channels
+                Button {
+                    isBrowseChannelsPresented = true
+                } label: {
+                    menuIcon
+                }
+            } else {
+                Menu {
+                    menuContent
+                } label: {
+                    menuIcon
                 }
             }
-            Button(R.string.localizable.browseChannels(), systemImage: "number") {
-                isBrowseChannelsPresented = true
-            }
-            if viewModel.course.courseInformationSharingConfiguration == .communicationAndMessaging {
-                Button(R.string.localizable.createChat(), systemImage: "bubble.left.fill") {
-                    isCreateNewConversationPresented = true
-                }
-            }
-        } label: {
-            Image(systemName: "plus.bubble")
-                .foregroundStyle(.white)
-                .font(.title2)
-                .padding()
-                .background(Color.Artemis.artemisBlue, in: .circle)
-                .shadow(color: Color.gray.opacity(0.2), radius: .m)
         }
         .sheet(isPresented: $isCreateNewConversationPresented) {
             CreateOrAddToChatView(courseId: viewModel.courseId, configuration: .createChat)
@@ -209,6 +203,31 @@ private struct CreateOrAddChannelButton: View {
         } content: {
             BrowseChannelsView(courseId: viewModel.courseId)
         }
+    }
+
+    @ViewBuilder private var menuContent: some View {
+        if viewModel.course.isAtLeastTutorInCourse {
+            Button(R.string.localizable.createChannel(), systemImage: "plus.bubble.fill") {
+                isCreateChannelPresented = true
+            }
+        }
+        Button(R.string.localizable.browseChannels(), systemImage: "number") {
+            isBrowseChannelsPresented = true
+        }
+        if viewModel.course.courseInformationSharingConfiguration == .communicationAndMessaging {
+            Button(R.string.localizable.createChat(), systemImage: "bubble.left.fill") {
+                isCreateNewConversationPresented = true
+            }
+        }
+    }
+
+    private var menuIcon: some View {
+        Image(systemName: "plus.bubble")
+            .foregroundStyle(.white)
+            .font(.title2)
+            .padding()
+            .background(Color.Artemis.artemisBlue, in: .circle)
+            .shadow(color: Color.gray.opacity(0.2), radius: .m)
     }
 }
 


### PR DESCRIPTION
### Problem
The current conversations list can be improved in a few ways, such as swipe gestures for marking a conversation as favorite, the layout, and parts of the code can also be simplified.

There are also multiple Buttons that look the same but perform different actions.

### Before
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/0218d18f-226b-4706-94e7-5c5faa4edb35" alt="Before" width="300">

### After
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/d5a6aa15-fd45-4756-87a3-6c7a07a64fd2)" alt="After: Conversations List" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/c784278a-f619-4f8b-be35-8c941b00f28b" alt="After: Swipe Action (Favorite)" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/885eabe8-672d-4070-8aec-7d87b90bc3dc" alt="After: Swipe Action (Hide, Mute)" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/035748d1-e43a-47c4-8c4f-42577a52c1df " alt="After: Create New Channel Menu" width="300">

The button in the lower right corner functions as a "Browse Channel" button if this is the only option available, otherwise it opens a menu as shown. 