### PR TITLE
`Courses`: Fix some courses not shown in course enrollment

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "3de4642a5b399003cb218cfdb8ba69b01409bcb5",
-        "version" : "13.1.0"
+        "revision" : "ce0d4e6e74cbb9c55e9dbc8f9ec2d15a8bd1c233",
+        "version" : "13.2.0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "13.1.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "13.2.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/CourseRegistration/CourseRegistrationView.swift
+++ b/ArtemisKit/Sources/CourseRegistration/CourseRegistrationView.swift
@@ -66,14 +66,16 @@ private struct CourseRegistrationListCell: View {
     let course: Course
 
     var body: some View {
-        if let title = course.title,
-           let description = course.description {
+        if let title = course.title {
             VStack(spacing: .m) {
                 VStack(alignment: .leading) {
                     Text(title)
                         .font(.title2)
-                    Text(description)
-                        .font(.caption)
+
+                    if let description = course.description {
+                        Text(description)
+                            .font(.caption)
+                    }
                 }
                 Button(R.string.localizable.course_registration_register_button()) {
                     showSignUpAlert = true

--- a/ArtemisKit/Sources/CourseRegistration/CourseRegistrationView.swift
+++ b/ArtemisKit/Sources/CourseRegistration/CourseRegistrationView.swift
@@ -67,20 +67,23 @@ private struct CourseRegistrationListCell: View {
 
     var body: some View {
         if let title = course.title {
-            VStack(spacing: .m) {
-                VStack(alignment: .leading) {
-                    Text(title)
-                        .font(.title2)
+            VStack(alignment: .leading, spacing: .m) {
+                Text(title)
+                    .font(.title2)
 
-                    if let description = course.description {
-                        Text(description)
-                            .font(.caption)
+                if let description = course.description {
+                    Text(description)
+                        .font(.caption)
+                }
+
+                HStack {
+                    Spacer()
+                    Button(R.string.localizable.course_registration_register_button()) {
+                        showSignUpAlert = true
                     }
+                    .buttonStyle(ArtemisButton())
+                    Spacer()
                 }
-                Button(R.string.localizable.course_registration_register_button()) {
-                    showSignUpAlert = true
-                }
-                .buttonStyle(ArtemisButton())
             }
             .padding(.m)
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
### Problem
Some courses are not shown in the course enrollment view. This is because courses are only shown if they have a title AND description.

### Solution
We can also show courses that don't have a description. That way, users can sign up for any course.

Some alignment issues with too small titles/descriptions have also been fixed.

<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/2d6d8a9a-c361-4450-8bdf-d7c77dd733bd" alt="Before" width="300">
<img src="https://github.com/ls1intum/artemis-ios/assets/98647423/ad79eabb-54d3-434b-aaff-e29ede3af036" alt="After" width="300">

The first image also shows misaligned content for the Machine Learning Course.