### PR TITLE
`Communication`: Improve Conversation View

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "ce0d4e6e74cbb9c55e9dbc8f9ec2d15a8bd1c233",
-        "version" : "13.2.0"
+        "revision" : "ad51e949c738b9a9d242d436e49d3414b8281b06",
+        "version" : "14.0.0"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
-        "version" : "5.1.2"
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
       }
     }
   ],

--- a/Artemis/Supporting/Info.plist
+++ b/Artemis/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "13.2.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Models/BaseMessage+IsContinuation.swift
+++ b/ArtemisKit/Sources/Messages/Models/BaseMessage+IsContinuation.swift
@@ -13,13 +13,22 @@ private let MAX_MINUTES_FOR_GROUPING_MESSAGES = 5
 
 extension BaseMessage {
     /// Whether the same author messaged multiple times within 5 minutes.
-    func isContinuation(of message: some BaseMessage) -> Bool {
-        guard author == message.author,
+    func isContinuation(of message: BaseMessage?) -> Bool {
+        guard let message,
+              author == message.author,
               let lhs = creationDate,
               let rhs = message.creationDate else {
             return false
         }
 
         return lhs < rhs.addingTimeInterval(TimeInterval(MAX_MINUTES_FOR_GROUPING_MESSAGES * 60))
+    }
+}
+
+// https://stackoverflow.com/a/30593673
+extension Collection {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
     }
 }

--- a/ArtemisKit/Sources/Messages/Models/OfflineMessageOrAnswer.swift
+++ b/ArtemisKit/Sources/Messages/Models/OfflineMessageOrAnswer.swift
@@ -15,7 +15,7 @@ struct OfflineMessageOrAnswer: BaseMessage {
     var updatedDate: Date?
     var content: String?
     var tokenizedContent: String?
-    var authorRoleTransient: UserRole?
+    var authorRole: UserRole?
     var reactions: [Reaction]?
 }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -115,6 +115,7 @@ extension ConversationViewModel {
             guard let message = messages.first(where: { $0.id == messageId }) else {
                 return .failure(UserFacingError(title: R.string.localizable.messageCouldNotBeLoadedError()))
             }
+            self.messages.update(with: .message(message))
             return .success(message)
         }
     }
@@ -127,6 +128,9 @@ extension ConversationViewModel {
                   let answerMessage = message.answers?.first(where: { $0.id == answerMessageId }) else {
                 return .failure(UserFacingError(title: R.string.localizable.messageCouldNotBeLoadedError()))
             }
+            // For some reason, self.messages no longer has values for all attributes
+            // when this is called after adding a reaction. We re-add them here
+            self.messages.update(with: .message(message))
             return .success(answerMessage)
         }
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Navigation
 import SharedModels
+import SwiftUI
 import UserStore
 
 @MainActor
@@ -17,6 +18,7 @@ final class MessageCellModel {
 
     let conversationPath: ConversationPath?
     let isHeaderVisible: Bool
+    let roundBottomCorners: Bool
     let retryButtonAction: (() -> Void)?
 
     var isActionSheetPresented = false
@@ -29,6 +31,7 @@ final class MessageCellModel {
         course: Course,
         conversationPath: ConversationPath?,
         isHeaderVisible: Bool,
+        roundBottomCorners: Bool,
         retryButtonAction: (() -> Void)?,
         messagesService: MessagesService = MessagesServiceFactory.shared,
         userSession: UserSession = UserSessionFactory.shared
@@ -36,6 +39,7 @@ final class MessageCellModel {
         self.course = course
         self.conversationPath = conversationPath
         self.isHeaderVisible = isHeaderVisible
+        self.roundBottomCorners = roundBottomCorners
         self.retryButtonAction = retryButtonAction
         self.messagesService = messagesService
         self.userSession = userSession
@@ -51,6 +55,12 @@ extension MessageCellModel {
         }
 
         return lastReadDate < creationDate && userSession.user?.id != authorId
+    }
+
+    var roundedCorners: RectangleCornerRadii {
+        let top: CGFloat = isHeaderVisible ? .m : 0
+        let bottom: CGFloat = roundBottomCorners ? .m : 0
+        return .init(topLeading: top, bottomLeading: bottom, bottomTrailing: bottom, topTrailing: top)
     }
 
     // MARK: Navigation

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -20,10 +20,10 @@ struct ConversationDaySection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             Text(day, formatter: DateFormatter.dateOnly)
                 .font(.headline)
-                .padding(.top, .m)
+                .padding(.vertical, .m)
                 .padding(.horizontal, .l)
             Divider()
                 .padding(.horizontal, .l)
@@ -35,8 +35,22 @@ struct ConversationDaySection: View {
                     message: message,
                     conversationPath: conversationPath,
                     isHeaderVisible: index == 0 || !message.isContinuation(of: messages[index - 1]))
+                .padding(.top, topMessagePadding(for: message, at: index))
             }
         }
+    }
+}
+
+private extension ConversationDaySection {
+    /// Calculates whether there should be space in between the current and previous message
+    func topMessagePadding(for message: Message, at index: Int) -> CGFloat {
+        if index == 0 {
+            return .s
+        }
+        if message.isContinuation(of: messages[index - 1]) {
+            return 0
+        }
+        return .m
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -28,16 +28,16 @@ struct ConversationDaySection: View {
             Divider()
                 .padding(.horizontal, .l)
                 .padding(.bottom, .s)
-            let totalMessages = messages.count
             ForEach(Array(messages.enumerated()), id: \.1.id) { index, message in
-                let needsRoundedCorners = index == totalMessages - 1 || !messages[index + 1].isContinuation(of: message)
+                let needsRoundedCorners = !(messages[safe: index + 1]?.isContinuation(of: message) ?? false)
                 MessageCellWrapper(
                     viewModel: viewModel,
                     day: day,
                     message: message,
                     conversationPath: conversationPath,
-                    isHeaderVisible: index == 0 || !message.isContinuation(of: messages[index - 1]),
+                    isHeaderVisible: !message.isContinuation(of: messages[safe: index - 1]),
                     roundBottomCorners: needsRoundedCorners)
+                .id(index == messages.count - 1 ? nil : message.id)
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -28,29 +28,18 @@ struct ConversationDaySection: View {
             Divider()
                 .padding(.horizontal, .l)
                 .padding(.bottom, .s)
+            let totalMessages = messages.count
             ForEach(Array(messages.enumerated()), id: \.1.id) { index, message in
+                let needsRoundedCorners = index == totalMessages - 1 || !messages[index + 1].isContinuation(of: message)
                 MessageCellWrapper(
                     viewModel: viewModel,
                     day: day,
                     message: message,
                     conversationPath: conversationPath,
-                    isHeaderVisible: index == 0 || !message.isContinuation(of: messages[index - 1]))
-                .padding(.top, topMessagePadding(for: message, at: index))
+                    isHeaderVisible: index == 0 || !message.isContinuation(of: messages[index - 1]),
+                    roundBottomCorners: needsRoundedCorners)
             }
         }
-    }
-}
-
-private extension ConversationDaySection {
-    /// Calculates whether there should be space in between the current and previous message
-    func topMessagePadding(for message: Message, at index: Int) -> CGFloat {
-        if index == 0 {
-            return .s
-        }
-        if message.isContinuation(of: messages[index - 1]) {
-            return 0
-        }
-        return .m
     }
 }
 
@@ -61,6 +50,7 @@ private struct MessageCellWrapper: View {
     let message: Message
     let conversationPath: ConversationPath
     let isHeaderVisible: Bool
+    let roundBottomCorners: Bool
 
     private var messageBinding: Binding<DataState<BaseMessage>> {
         Binding {
@@ -81,7 +71,8 @@ private struct MessageCellWrapper: View {
             conversationViewModel: viewModel,
             message: messageBinding,
             conversationPath: conversationPath,
-            isHeaderVisible: isHeaderVisible)
+            isHeaderVisible: isHeaderVisible,
+            roundBottomCorners: roundBottomCorners)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -27,6 +27,7 @@ struct ConversationDaySection: View {
                 .padding(.horizontal, .l)
             Divider()
                 .padding(.horizontal, .l)
+                .padding(.bottom, .s)
             ForEach(Array(messages.enumerated()), id: \.1.id) { index, message in
                 MessageCellWrapper(
                     viewModel: viewModel,

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationOfflineSection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationOfflineSection.swift
@@ -20,6 +20,7 @@ struct ConversationOfflineSection: View {
                 message: Binding.constant(DataState<BaseMessage>.done(response: OfflineMessageOrAnswer(viewModel.message))),
                 conversationPath: nil,
                 isHeaderVisible: viewModel.taskDidFail,
+                roundBottomCorners: true,
                 retryButtonAction: viewModel.retryButtonAction
             )
             .task {
@@ -33,7 +34,8 @@ struct ConversationOfflineSection: View {
                     conversationViewModel: conversationViewModel,
                     message: Binding.constant(DataState<BaseMessage>.done(response: OfflineMessageOrAnswer(message))),
                     conversationPath: nil,
-                    isHeaderVisible: false
+                    isHeaderVisible: false,
+                    roundBottomCorners: false
                 )
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -24,11 +24,7 @@ struct MessageCell: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: .m) {
-            Image(systemName: "person")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 40, height: viewModel.isHeaderVisible ? 40 : 0)
-                .padding(.top, .s)
+            roleBadge
             VStack(alignment: .leading, spacing: .xs) {
                 HStack {
                     VStack(alignment: .leading, spacing: .xs) {
@@ -92,6 +88,10 @@ private extension MessageCell {
         message.value?.author?.name ?? ""
     }
 
+    private var authorRole: UserRole? {
+        message.value?.authorRole
+    }
+
     var creationDate: Date? {
         message.value?.creationDate
     }
@@ -102,6 +102,16 @@ private extension MessageCell {
 
     var backgroundOnPress: Color {
         (viewModel.isDetectingLongPress || viewModel.isActionSheetPresented) ? Color.Artemis.messsageCellPressed : Color.clear
+    }
+
+    @ViewBuilder var roleBadge: some View {
+        if let authorRole, viewModel.isHeaderVisible {
+            Text(authorRole.displayName)
+                .padding(.horizontal, .s)
+                .padding(.vertical, .xs)
+                .background(authorRole.badgeColor, in: .rect(cornerRadius: .s))
+                .foregroundStyle(.white)
+        }
     }
 
     @ViewBuilder var headerIfVisible: some View {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -47,6 +47,9 @@ struct MessageCell: View {
             retryButtonIfAvailable
             replyButtonIfAvailable
         }
+        .padding(.horizontal, .m)
+        .padding(viewModel.isHeaderVisible ? .vertical : .bottom, .m)
+        .background(Color(uiColor: .secondarySystemBackground))
         .id(message.value?.id.description)
         .padding(.horizontal, .l)
         .sheet(isPresented: $viewModel.isActionSheetPresented) {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -23,9 +23,9 @@ struct MessageCell: View {
     @State var viewModel: MessageCellModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: .xs) {
+        VStack(alignment: .leading, spacing: .s) {
             HStack {
-                VStack(alignment: .leading, spacing: .xs) {
+                VStack(alignment: .leading, spacing: .s) {
                     headerIfVisible
                     ArtemisMarkdownView(string: content)
                         .opacity(isMessageOffline ? 0.5 : 1)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -103,11 +103,13 @@ private extension MessageCell {
 
     @ViewBuilder var roleBadge: some View {
         if let authorRole {
-            Text(authorRole.displayName)
-                .padding(.horizontal, .s)
-                .padding(.vertical, .xs)
-                .background(authorRole.badgeColor, in: .rect(cornerRadius: .s))
-                .foregroundStyle(.white)
+            Chip(
+                text: authorRole.displayName,
+                backgroundColor: authorRole.badgeColor,
+                horizontalPadding: .m,
+                verticalPadding: .s
+            )
+            .font(.footnote)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -49,7 +49,11 @@ struct MessageCell: View {
         }
         .padding(.horizontal, .m)
         .padding(viewModel.isHeaderVisible ? .vertical : .bottom, .m)
-        .background(Color(uiColor: .secondarySystemBackground))
+        .background(
+            Color(uiColor: .secondarySystemBackground),
+            in: .rect(cornerRadii: viewModel.roundedCorners)
+        )
+        .padding(.top, viewModel.isHeaderVisible ? .m : 0)
         .id(message.value?.id.description)
         .padding(.horizontal, .l)
         .sheet(isPresented: $viewModel.isActionSheetPresented) {
@@ -69,6 +73,7 @@ extension MessageCell {
         message: Binding<DataState<BaseMessage>>,
         conversationPath: ConversationPath?,
         isHeaderVisible: Bool,
+        roundBottomCorners: Bool,
         retryButtonAction: (() -> Void)? = nil
     ) {
         self.init(
@@ -78,6 +83,7 @@ extension MessageCell {
                 course: conversationViewModel.course,
                 conversationPath: conversationPath,
                 isHeaderVisible: isHeaderVisible,
+                roundBottomCorners: roundBottomCorners,
                 retryButtonAction: retryButtonAction)
         )
     }
@@ -292,6 +298,7 @@ extension EnvironmentValues {
             conversation: MessagesServiceStub.conversation,
             coursePath: CoursePath(course: MessagesServiceStub.course)
         ),
-        isHeaderVisible: true
+        isHeaderVisible: true,
+        roundBottomCorners: true
     )
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -23,34 +23,31 @@ struct MessageCell: View {
     @State var viewModel: MessageCellModel
 
     var body: some View {
-        HStack(alignment: .top, spacing: .m) {
-            roleBadge
-            VStack(alignment: .leading, spacing: .xs) {
-                HStack {
-                    VStack(alignment: .leading, spacing: .xs) {
-                        headerIfVisible
-                        ArtemisMarkdownView(string: content)
-                            .opacity(isMessageOffline ? 0.5 : 1)
-                            .environment(\.openURL, OpenURLAction(handler: handle))
-                    }
-                    Spacer()
+        VStack(alignment: .leading, spacing: .xs) {
+            HStack {
+                VStack(alignment: .leading, spacing: .xs) {
+                    headerIfVisible
+                    ArtemisMarkdownView(string: content)
+                        .opacity(isMessageOffline ? 0.5 : 1)
+                        .environment(\.openURL, OpenURLAction(handler: handle))
                 }
-                .background {
-                    RoundedRectangle(cornerRadius: .m)
-                        .foregroundStyle(backgroundOnPress)
-                }
-                .contentShape(.rect)
-                .onTapGesture(perform: onTapPresentMessage)
-                .onLongPressGesture(perform: onLongPressPresentActionSheet) { changed in
-                    viewModel.isDetectingLongPress = changed
-                }
-
-                ReactionsView(viewModel: conversationViewModel, message: $message)
-                retryButtonIfAvailable
-                replyButtonIfAvailable
+                Spacer()
             }
-            .id(message.value?.id.description)
+            .background {
+                RoundedRectangle(cornerRadius: .m)
+                    .foregroundStyle(backgroundOnPress)
+            }
+            .contentShape(.rect)
+            .onTapGesture(perform: onTapPresentMessage)
+            .onLongPressGesture(perform: onLongPressPresentActionSheet) { changed in
+                viewModel.isDetectingLongPress = changed
+            }
+
+            ReactionsView(viewModel: conversationViewModel, message: $message)
+            retryButtonIfAvailable
+            replyButtonIfAvailable
         }
+        .id(message.value?.id.description)
         .padding(.horizontal, .l)
         .sheet(isPresented: $viewModel.isActionSheetPresented) {
             MessageActionSheet(
@@ -105,7 +102,7 @@ private extension MessageCell {
     }
 
     @ViewBuilder var roleBadge: some View {
-        if let authorRole, viewModel.isHeaderVisible {
+        if let authorRole {
             Text(authorRole.displayName)
                 .padding(.horizontal, .s)
                 .padding(.vertical, .xs)
@@ -117,6 +114,7 @@ private extension MessageCell {
     @ViewBuilder var headerIfVisible: some View {
         if viewModel.isHeaderVisible {
             HStack(alignment: .firstTextBaseline, spacing: .m) {
+                roleBadge
                 Text(isMessageOffline ? "Redacted" : author)
                     .bold()
                     .redacted(reason: isMessageOffline ? .placeholder : [])

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -70,7 +70,8 @@ private extension MessageDetailView {
             conversationViewModel: viewModel,
             message: Binding.constant(DataState<BaseMessage>.done(response: message)),
             conversationPath: nil,
-            isHeaderVisible: true
+            isHeaderVisible: true,
+            roundBottomCorners: true
         )
         .environment(\.isEmojiPickerButtonVisible, true)
         .onLongPressGesture(maximumDistance: 30) {
@@ -92,13 +93,15 @@ private extension MessageDetailView {
                 let sortedArray = (message.answers ?? []).sorted {
                     $0.creationDate ?? .tomorrow < $1.creationDate ?? .yesterday
                 }
+                let totalMessages = sortedArray.count
                 ForEach(Array(sortedArray.enumerated()), id: \.1) { index, answerMessage in
                     let isHeaderVisible = index == 0 || !answerMessage.isContinuation(of: sortedArray[index - 1])
+                    let needsRoundedCorners = index == totalMessages - 1 || !sortedArray[index + 1].isContinuation(of: answerMessage)
                     MessageCellWrapper(
                         viewModel: viewModel,
                         answerMessage: answerMessage,
-                        isHeaderVisible: isHeaderVisible)
-                    .padding(.top, isHeaderVisible ? .m : 0)
+                        isHeaderVisible: isHeaderVisible,
+                        roundBottomCorners: needsRoundedCorners)
                 }
                 Spacer()
                     .id("bottom")
@@ -138,6 +141,7 @@ private struct MessageCellWrapper: View {
 
     let answerMessage: AnswerMessage
     let isHeaderVisible: Bool
+    let roundBottomCorners: Bool
 
     private var answerMessageBinding: Binding<DataState<BaseMessage>> {
 
@@ -170,7 +174,8 @@ private struct MessageCellWrapper: View {
             conversationViewModel: viewModel,
             message: answerMessageBinding,
             conversationPath: nil,
-            isHeaderVisible: isHeaderVisible)
+            isHeaderVisible: isHeaderVisible,
+            roundBottomCorners: roundBottomCorners)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -89,19 +89,21 @@ private extension MessageDetailView {
     func answers(of message: BaseMessage, proxy: ScrollViewProxy) -> some View {
         if let message = message as? Message {
             Divider()
+                .padding(.top, .s)
             VStack(spacing: 0) {
                 let sortedArray = (message.answers ?? []).sorted {
                     $0.creationDate ?? .tomorrow < $1.creationDate ?? .yesterday
                 }
                 let totalMessages = sortedArray.count
                 ForEach(Array(sortedArray.enumerated()), id: \.1) { index, answerMessage in
-                    let isHeaderVisible = index == 0 || !answerMessage.isContinuation(of: sortedArray[index - 1])
-                    let needsRoundedCorners = index == totalMessages - 1 || !sortedArray[index + 1].isContinuation(of: answerMessage)
+                    let isHeaderVisible = !answerMessage.isContinuation(of: sortedArray[safe: index - 1])
+                    let needsRoundedCorners = !(sortedArray[safe: index + 1]?.isContinuation(of: answerMessage) ?? false)
                     MessageCellWrapper(
                         viewModel: viewModel,
                         answerMessage: answerMessage,
                         isHeaderVisible: isHeaderVisible,
                         roundBottomCorners: needsRoundedCorners)
+                    .id(index == totalMessages - 1 ? nil : answerMessage)
                 }
                 Spacer()
                     .id("bottom")

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -88,15 +88,17 @@ private extension MessageDetailView {
     func answers(of message: BaseMessage, proxy: ScrollViewProxy) -> some View {
         if let message = message as? Message {
             Divider()
-            VStack {
+            VStack(spacing: 0) {
                 let sortedArray = (message.answers ?? []).sorted {
                     $0.creationDate ?? .tomorrow < $1.creationDate ?? .yesterday
                 }
                 ForEach(Array(sortedArray.enumerated()), id: \.1) { index, answerMessage in
+                    let isHeaderVisible = index == 0 || !answerMessage.isContinuation(of: sortedArray[index - 1])
                     MessageCellWrapper(
                         viewModel: viewModel,
                         answerMessage: answerMessage,
-                        isHeaderVisible: index == 0 || !answerMessage.isContinuation(of: sortedArray[index - 1]))
+                        isHeaderVisible: isHeaderVisible)
+                    .padding(.top, isHeaderVisible ? .m : 0)
                 }
                 Spacer()
                     .id("bottom")

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -75,7 +75,7 @@ private struct EmojiTextButton: View {
             }
         } label: {
             Text("\(pair.0) \(pair.1.count)")
-                .font(.caption)
+                .font(.footnote)
                 .foregroundColor(isMyReaction ? Color.Artemis.artemisBlue : Color.Artemis.primaryLabel)
                 .frame(height: .extraSmallImage)
                 .padding(.m)


### PR DESCRIPTION
### Problem
The Conversation View can be improved in multiple ways for consistency and better looks:
- Display User Role Badges like in Web App
- Remove Profile Pictures (they are always empty)
- Differentiate messages from background
- Visually merge continuous messages

There is also room for improvement in other ways, such as discoverability of actions, swipe to reply, seeing who reactions are from, and more, which will be in a separate PR.

### Before vs After
<img src="https://github.com/user-attachments/assets/1bcf92a2-4cae-4228-a1ab-23959c3a8ed8" alt="Before" width="300">
<img src="https://github.com/user-attachments/assets/11cb0d18-d30d-4963-94e9-2c5784a70598" alt="After" width="300">
