### PR TITLE
`Communication`: Add sheet for viewing reaction authors

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 
 // MARK: ReactionsView
 "emojis" = "Emojis";
+"all" = "All (%i)";
 
 // MARK: MessagesTabView
 "browseChannels" = "Browse Channels";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -30,7 +30,6 @@
 
 // MARK: ReactionsView
 "emojis" = "Emojis";
-"close" = "Close";
 
 // MARK: MessagesTabView
 "browseChannels" = "Browse Channels";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 
 // MARK: ReactionsView
 "emojis" = "Emojis";
+"close" = "Close";
 
 // MARK: MessagesTabView
 "browseChannels" = "Browse Channels";

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -15,6 +15,8 @@ import SwiftUI
 class ReactionsViewModel {
     private var conversationViewModel: ConversationViewModel
     private var message: Binding<DataState<BaseMessage>>
+    var showAuthorsSheet = false
+    var selectedReactionSheet = ""
 
     init(conversationViewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
         self.conversationViewModel = conversationViewModel

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -16,7 +16,7 @@ class ReactionsViewModel {
     private var conversationViewModel: ConversationViewModel
     private var message: Binding<DataState<BaseMessage>>
     var showAuthorsSheet = false
-    var selectedReactionSheet = ""
+    var selectedReactionSheet = "All"
 
     init(conversationViewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
         self.conversationViewModel = conversationViewModel

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -14,17 +14,21 @@ import SwiftUI
 @Observable
 class ReactionsViewModel {
     private var conversationViewModel: ConversationViewModel
-    private var message: Binding<DataState<BaseMessage>>
     var showAuthorsSheet = false
     var selectedReactionSheet = "All"
 
+    // Binding to pass updates back to ConversationViewModel
+    private var messageBinding: Binding<DataState<BaseMessage>>
+    // Regular variable to take advantage of automatic Observable updates
+    var message: DataState<BaseMessage>
+
     init(conversationViewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
         self.conversationViewModel = conversationViewModel
-        self.message = message
+        self.messageBinding = message
+        self.message = message.wrappedValue
     }
 
-    // We need to explicitly pass message to this, otherwise it will not update
-    func mappedReaction(message: DataState<BaseMessage>) -> [String: [Reaction]] {
+    var mappedReaction: [String: [Reaction]] {
         var reactions = [String: [Reaction]]()
 
         message.value?.reactions?.forEach {
@@ -42,25 +46,68 @@ class ReactionsViewModel {
 
     @MainActor
     func addReaction(emojiId: String) async {
-        if let message = message.wrappedValue.value as? Message {
+        if let message = message.value as? Message {
             let result = await conversationViewModel.addReactionToMessage(for: message, emojiId: emojiId)
             switch result {
             case .loading:
-                self.message.wrappedValue = .loading
+                self.messageBinding.wrappedValue = .loading
             case .failure(let error):
-                self.message.wrappedValue = .failure(error: error)
+                self.messageBinding.wrappedValue = .failure(error: error)
             case .done(let response):
-                self.message.wrappedValue = .done(response: response)
+                self.messageBinding.wrappedValue = .done(response: response)
             }
-        } else if let answerMessage = message.wrappedValue.value as? AnswerMessage {
+        } else if let answerMessage = message.value as? AnswerMessage {
             let result = await conversationViewModel.addReactionToAnswerMessage(for: answerMessage, emojiId: emojiId)
             switch result {
             case .loading:
-                self.message.wrappedValue = .loading
+                self.messageBinding.wrappedValue = .loading
             case .failure(let error):
-                self.message.wrappedValue = .failure(error: error)
+                self.messageBinding.wrappedValue = .failure(error: error)
             case .done(let response):
-                self.message.wrappedValue = .done(response: response)
+                self.messageBinding.wrappedValue = .done(response: response)
+            }
+        }
+    }
+
+    func isMyReaction(_ emoji: String) -> Bool {
+        guard let emojiId = Smile.alias(emoji: emoji),
+              let message = message.value else {
+            return false
+        }
+
+        return message.containsReactionFromMe(emojiId: emojiId)
+    }
+}
+
+// MARK: DataState<BaseMessage>+Equatable
+
+/// We need conformance of DataState to Equatable for this ViewModel
+/// to receive updates to `message` using SwiftUI's `onChange` modifier.
+extension DataState<BaseMessage>: Equatable {
+    public static func == (lhs: DataState<BaseMessage>, rhs: DataState<BaseMessage>) -> Bool {
+        switch lhs {
+        case .loading:
+            return rhs == .loading
+        case .failure:
+            return false
+        case .done(let responseLhs):
+            switch rhs {
+            case .done(let responseRhs):
+                var hashLhs = Hasher()
+                var hashRhs = Hasher()
+                hashLhs.combine(responseLhs.id)
+                hashRhs.combine(responseRhs.id)
+                hashLhs.combine(responseLhs.author)
+                hashRhs.combine(responseRhs.author)
+                hashLhs.combine(responseLhs.reactions)
+                hashRhs.combine(responseRhs.reactions)
+                hashLhs.combine(responseLhs.updatedDate)
+                hashRhs.combine(responseRhs.updatedDate)
+                hashLhs.combine(responseLhs.content)
+                hashRhs.combine(responseRhs.content)
+                return hashLhs.finalize() == hashRhs.finalize()
+            default:
+                return false
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -1,0 +1,65 @@
+//
+//  ReactionsViewModel.swift
+//
+//
+//  Created by Anian Schleyer on 17.07.24.
+//
+
+import Common
+import Foundation
+import SharedModels
+import Smile
+import SwiftUI
+
+@Observable
+class ReactionsViewModel {
+    private var conversationViewModel: ConversationViewModel
+    private var message: Binding<DataState<BaseMessage>>
+
+    init(conversationViewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
+        self.conversationViewModel = conversationViewModel
+        self.message = message
+    }
+
+    // We need to explicitly pass message to this, otherwise it will not update
+    func mappedReaction(message: DataState<BaseMessage>) -> [String: [Reaction]] {
+        var reactions = [String: [Reaction]]()
+
+        message.value?.reactions?.forEach {
+            guard let emoji = Smile.emoji(alias: $0.emojiId) else {
+                return
+            }
+            if reactions[emoji] != nil {
+                reactions[emoji]?.append($0)
+            } else {
+                reactions[emoji] = [$0]
+            }
+        }
+        return reactions
+    }
+
+    @MainActor
+    func addReaction(emojiId: String) async {
+        if let message = message.wrappedValue.value as? Message {
+            let result = await conversationViewModel.addReactionToMessage(for: message, emojiId: emojiId)
+            switch result {
+            case .loading:
+                self.message.wrappedValue = .loading
+            case .failure(let error):
+                self.message.wrappedValue = .failure(error: error)
+            case .done(let response):
+                self.message.wrappedValue = .done(response: response)
+            }
+        } else if let answerMessage = message.wrappedValue.value as? AnswerMessage {
+            let result = await conversationViewModel.addReactionToAnswerMessage(for: answerMessage, emojiId: emojiId)
+            switch result {
+            case .loading:
+                self.message.wrappedValue = .loading
+            case .failure(let error):
+                self.message.wrappedValue = .failure(error: error)
+            case .done(let response):
+                self.message.wrappedValue = .done(response: response)
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -39,7 +39,7 @@ struct ReactionsView: View {
                 EmojiPickerButton(viewModel: viewModel, viewRerenderWorkaround: $viewRerenderWorkaround)
             }
         }
-        .popover(isPresented: $viewModel.showAuthorsSheet) {
+        .popover(isPresented: $viewModel.showAuthorsSheet, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
             ReactionAuthorsSheet(viewModel: viewModel, message: $message)
         }
     }
@@ -111,7 +111,7 @@ struct ReactionAuthorsSheet: View {
             VStack {
                 let mappedReactions = viewModel.mappedReaction(message: message)
 
-                ScrollView(.horizontal) {
+                ScrollView(.horizontal, showsIndicators: false) {
                     filterRow(mappedReactions: mappedReactions)
                 }
                 .frame(height: 40, alignment: .top)
@@ -125,19 +125,23 @@ struct ReactionAuthorsSheet: View {
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
             }
+            .padding(UIDevice.current.userInterfaceIdiom != .pad ? [] : [.top])
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        viewModel.showAuthorsSheet = false
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
+                if UIDevice.current.userInterfaceIdiom != .pad {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button {
+                            viewModel.showAuthorsSheet = false
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                        }
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
                     }
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
                 }
             }
         }
         .presentationDetents([.medium, .large])
+        .frame(minWidth: 250, minHeight: 300)
     }
 
     @ViewBuilder

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -20,7 +20,7 @@ struct ReactionsView: View {
 
     @State private var viewRerenderWorkaround = false
 
-    let columns = [ GridItem(.adaptive(minimum: 45)) ]
+    let columns = [ GridItem(.adaptive(minimum: 50)) ]
 
     init(
         viewModel: ConversationViewModel,
@@ -115,7 +115,7 @@ struct ReactionAuthorsSheet: View {
             }
             .frame(height: 40, alignment: .top)
             .contentMargins(.leading, .l, for: .scrollContent)
-            .contentMargins(.trailing, UIDevice.current.userInterfaceIdiom != .pad ? 90 : .l, for: .scrollContent)
+            .contentMargins(.trailing, 90, for: .scrollContent)
             .overlay(alignment: .trailing) {
                 closeButton
             }
@@ -134,30 +134,28 @@ struct ReactionAuthorsSheet: View {
     }
 
     @ViewBuilder var closeButton: some View {
-        if UIDevice.current.userInterfaceIdiom != .pad {
-            ZStack(alignment: .trailing) {
-                LinearGradient(
-                    stops: [
-                        .init(color: .clear, location: 0),
-                        .init(color: .init(
-                            uiColor: .systemBackground
-                        ), location: 0.4)
-                    ],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-                .frame(width: 90)
-                Button {
-                    viewModel.showAuthorsSheet = false
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .resizable()
-                        .padding(5)
-                        .frame(width: 40, height: 40)
-                }
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, .m)
+        ZStack(alignment: .trailing) {
+            LinearGradient(
+                stops: [
+                    .init(color: .clear, location: 0),
+                    .init(color: .init(
+                        uiColor: .systemBackground
+                    ), location: 0.4)
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: 90)
+            Button {
+                viewModel.showAuthorsSheet = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .resizable()
+                    .padding(5)
+                    .frame(width: 40, height: 40)
             }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, .m)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -264,31 +264,10 @@ extension EnvironmentValues {
 }
 
 #Preview {
-//    ReactionsView(
-//        viewModel: ConversationViewModel(
-//            course: MessagesServiceStub.course,
-//            conversation: MessagesServiceStub.conversation),
-//        message: Binding.constant(DataState<BaseMessage>.done(response: MessagesServiceStub.message))
-//    )
-    ReactionAuthorsSheet(
-        viewModel: .init(
-            conversationViewModel: 
-                    .init(
-                        course: .mock,
-                        conversation: .channel(
-                            conversation: .mock
-                        )
-                    ),
-            message: Binding.constant(
-                DataState<BaseMessage>.done(
-                    response: MessagesServiceStub.message
-                )
-            )
-        ),
-        message: Binding.constant(
-            DataState<BaseMessage>.done(
-                response: MessagesServiceStub.message
-            )
-        )
+    ReactionsView(
+        viewModel: ConversationViewModel(
+            course: MessagesServiceStub.course,
+            conversation: MessagesServiceStub.conversation),
+        message: Binding.constant(DataState<BaseMessage>.done(response: MessagesServiceStub.message))
     )
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -110,12 +110,19 @@ struct ReactionAuthorsSheet: View {
         VStack {
             let mappedReactions = viewModel.mappedReaction(message: message)
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                filterRow(mappedReactions: mappedReactions)
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    filterRow(mappedReactions: mappedReactions)
+                }
+                .frame(height: 40, alignment: .top)
+                .contentMargins(.leading, .l, for: .scrollContent)
+                .contentMargins(.trailing, 90, for: .scrollContent)
+                .onChange(of: viewModel.selectedReactionSheet, initial: true) { _, newValue in
+                    withAnimation {
+                        proxy.scrollTo(newValue)
+                    }
+                }
             }
-            .frame(height: 40, alignment: .top)
-            .contentMargins(.leading, .l, for: .scrollContent)
-            .contentMargins(.trailing, 90, for: .scrollContent)
             .overlay(alignment: .trailing) {
                 closeButton
             }
@@ -146,6 +153,8 @@ struct ReactionAuthorsSheet: View {
                 endPoint: .trailing
             )
             .frame(width: 90)
+            .allowsHitTesting(false)
+
             Button {
                 viewModel.showAuthorsSheet = false
             } label: {
@@ -155,7 +164,7 @@ struct ReactionAuthorsSheet: View {
                     .frame(width: 40, height: 40)
             }
             .foregroundStyle(.secondary)
-            .padding(.horizontal, .m)
+            .padding(.trailing, .m)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -173,7 +173,7 @@ struct ReactionAuthorsSheet: View {
                     let total = mappedReactions.reduce(0) { partialResult, pair in
                         partialResult + pair.1.count
                     }
-                    Text(key == "All" ? "All (\(total))" : key)
+                    Text(key == "All" ? R.string.localizable.all(total) : key)
                         .containerRelativeFrame(.vertical)
                         .padding(.horizontal, .m)
                         .font(key == "All" ? .body : .title)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -108,13 +108,13 @@ struct ReactionAuthorsSheet: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
+            VStack {
                 let mappedReactions = viewModel.mappedReaction(message: message)
 
                 ScrollView(.horizontal) {
                     filterRow(mappedReactions: mappedReactions)
                 }
-                .frame(height: .mediumImage, alignment: .top)
+                .frame(height: 40, alignment: .top)
                 .contentMargins(.horizontal, .l, for: .scrollContent)
 
                 TabView(selection: $viewModel.selectedReactionSheet) {
@@ -137,7 +137,7 @@ struct ReactionAuthorsSheet: View {
 
     @ViewBuilder
     func filterRow(mappedReactions: [String: [Reaction]]) -> some View {
-        LazyHStack {
+        LazyHStack(alignment: .top) {
             ForEach(["All"] + mappedReactions.keys.sorted(), id: \.self) { key in
                 Button {
                     withAnimation {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -129,7 +129,6 @@ struct ReactionAuthorsSheet: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(R.string.localizable.close()) {
                         viewModel.showAuthorsSheet = false
-                        viewModel.selectedReactionSheet = ""
                     }
                 }
             }
@@ -137,7 +136,7 @@ struct ReactionAuthorsSheet: View {
     }
 
     @ViewBuilder
-    func filterRow(mappedReactions: Dictionary<String, [Reaction]>) -> some View {
+    func filterRow(mappedReactions: [String: [Reaction]]) -> some View {
         LazyHStack {
             ForEach(["All"] + mappedReactions.keys.sorted(), id: \.self) { key in
                 Button {
@@ -146,9 +145,9 @@ struct ReactionAuthorsSheet: View {
                     }
                 } label: {
                     Text(key == "All" ? "All (\(mappedReactions.count))" : key)
+                        .containerRelativeFrame(.vertical) { size, _ in size - .m }
                         .padding(.horizontal, .m)
-                        .padding(.vertical, .s)
-                        .font(.title)
+                        .font(key == "All" ? .body : .title)
                         .background(key == viewModel.selectedReactionSheet ? .gray.opacity(0.5) : .clear, in: .capsule)
                 }
                 .buttonStyle(.plain)
@@ -165,13 +164,13 @@ struct ReactionAuthorsSheet: View {
                     ForEach(reactions, id: \.id) { reaction in
                         if let name = reaction.user?.name {
                             Text("\(key) \(name)")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .lineLimit(1)
+                                .padding([.top, .horizontal])
                         }
                     }
                 }
             }
-            .lineLimit(1)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding([.top, .horizontal])
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -107,41 +107,58 @@ struct ReactionAuthorsSheet: View {
     @Binding var message: DataState<BaseMessage>
 
     var body: some View {
-        NavigationStack {
-            VStack {
-                let mappedReactions = viewModel.mappedReaction(message: message)
+        VStack {
+            let mappedReactions = viewModel.mappedReaction(message: message)
 
-                ScrollView(.horizontal, showsIndicators: false) {
-                    filterRow(mappedReactions: mappedReactions)
-                }
-                .frame(height: 40, alignment: .top)
-                .contentMargins(.horizontal, .l, for: .scrollContent)
-
-                TabView(selection: $viewModel.selectedReactionSheet) {
-                    ForEach(["All"] + mappedReactions.keys.sorted(), id: \.self) { key in
-                        reactionsList(for: key, mappedReactions: mappedReactions)
-                            .tag(key)
-                    }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
+            ScrollView(.horizontal, showsIndicators: false) {
+                filterRow(mappedReactions: mappedReactions)
             }
-            .padding(UIDevice.current.userInterfaceIdiom != .pad ? [] : [.top])
-            .toolbar {
-                if UIDevice.current.userInterfaceIdiom != .pad {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button {
-                            viewModel.showAuthorsSheet = false
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                        }
-                        .font(.title2)
-                        .foregroundStyle(.secondary)
-                    }
+            .frame(height: 40, alignment: .top)
+            .contentMargins(.leading, .l, for: .scrollContent)
+            .contentMargins(.trailing, UIDevice.current.userInterfaceIdiom != .pad ? 90 : .l, for: .scrollContent)
+            .overlay(alignment: .trailing) {
+                closeButton
+            }
+
+            TabView(selection: $viewModel.selectedReactionSheet) {
+                ForEach(["All"] + mappedReactions.keys.sorted(), id: \.self) { key in
+                    reactionsList(for: key, mappedReactions: mappedReactions)
+                        .tag(key)
                 }
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
         }
+        .padding(.top)
         .presentationDetents([.medium, .large])
         .frame(minWidth: 250, minHeight: 300)
+    }
+
+    @ViewBuilder var closeButton: some View {
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            ZStack(alignment: .trailing) {
+                LinearGradient(
+                    stops: [
+                        .init(color: .clear, location: 0),
+                        .init(color: .init(
+                            uiColor: .systemBackground
+                        ), location: 0.4)
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: 90)
+                Button {
+                    viewModel.showAuthorsSheet = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .resizable()
+                        .padding(5)
+                        .frame(width: 40, height: 40)
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, .m)
+            }
+        }
     }
 
     @ViewBuilder

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -149,8 +149,11 @@ struct ReactionAuthorsSheet: View {
                         viewModel.selectedReactionSheet = key
                     }
                 } label: {
-                    Text(key == "All" ? "All (\(mappedReactions.count))" : key)
-                        .containerRelativeFrame(.vertical) { size, _ in size - .m }
+                    let total = mappedReactions.reduce(0) { partialResult, pair in
+                        partialResult + pair.1.count
+                    }
+                    Text(key == "All" ? "All (\(total))" : key)
+                        .containerRelativeFrame(.vertical)
                         .padding(.horizontal, .m)
                         .font(key == "All" ? .body : .title)
                         .background(key == viewModel.selectedReactionSheet ? .gray.opacity(0.5) : .clear, in: .capsule)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ReactionsView.swift
@@ -39,7 +39,7 @@ struct ReactionsView: View {
                 EmojiPickerButton(viewModel: viewModel, viewRerenderWorkaround: $viewRerenderWorkaround)
             }
         }
-        .sheet(isPresented: $viewModel.showAuthorsSheet) {
+        .popover(isPresented: $viewModel.showAuthorsSheet) {
             ReactionAuthorsSheet(viewModel: viewModel, message: $message)
         }
     }
@@ -127,12 +127,17 @@ struct ReactionAuthorsSheet: View {
             }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(R.string.localizable.close()) {
+                    Button {
                         viewModel.showAuthorsSheet = false
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
                     }
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
                 }
             }
         }
+        .presentationDetents([.medium, .large])
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Problem
It is currently not possible to view who reactions are from on the iOS App.

### Solution
We add a sheet that shows who reacted with which emoji. Users can open this sheet by long pressing on a reaction just like on other Apps like Slack or Discord. On this sheet, reactions are organized/filtered and the user can either tap or swipe between them.

<img src="https://github.com/user-attachments/assets/9b2c8104-05d2-481d-94c9-d18755fcba23" alt="Reactions Sheet Medium" width="300">
<img src="https://github.com/user-attachments/assets/f29e991a-b0ce-4edf-92f2-6d6721bb2eac" alt="Reactions Sheet Large" width="300">


<video src="https://github.com/user-attachments/assets/ce1d8fab-da9e-453a-9121-0b006366b8b3">

