### PR TITLE
`Communication`: Improve discoverability of message actions

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -59,6 +59,7 @@
 "edited" = "Edited";
 "messageCouldNotBeLoadedError" = "Message could not be loaded.";
 "thread" = "Thread";
+"replies" = "Reply";
 
 // MARK: MessageActionSheet
 "replyInThread" = "Reply in Thread";

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -87,7 +87,7 @@ extension DataState<BaseMessage>: Equatable {
     public static func == (lhs: DataState<BaseMessage>, rhs: DataState<BaseMessage>) -> Bool {
         switch lhs {
         case .loading:
-            return rhs == .loading
+            return false
         case .failure:
             return false
         case .done(let responseLhs):

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -245,9 +245,11 @@ struct MessageActionSheet: View {
             .buttonStyle(.plain)
             .font(.headline)
             .symbolVariant(.fill)
+            .imageScale(.large)
             Spacer()
         }
-        .padding(.vertical, .xxl)
+        .padding(.vertical, .xl)
+        .frame(maxHeight: .infinity, alignment: .top)
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -67,7 +67,7 @@ struct MessageActions: View {
         @State private var showSuccess = false
 
         var body: some View {
-            Button(R.string.localizable.copyText(), systemImage: "clipboard") {
+            Button(R.string.localizable.copyText(), systemImage: "doc.on.doc") {
                 UIPasteboard.general.string = message.value?.content
                 if allowDismiss {
                     dismiss()

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -63,17 +63,35 @@ struct MessageActions: View {
         var allowDismiss = true
         @Environment(\.dismiss) var dismiss
         @Binding var message: DataState<BaseMessage>
+        @State private var showSuccess = false
 
         var body: some View {
             Button(R.string.localizable.copyText(), systemImage: "clipboard") {
                 UIPasteboard.general.string = message.value?.content
                 if allowDismiss {
                     dismiss()
+                } else {
+                    showSuccess = true
                 }
             }
+            .opacity(showSuccess ? 0 : 1)
+            .overlay {
+                if showSuccess {
+                    Label("Copied", systemImage: "checkmark.circle.fill")
+                        .font(.title3.bold())
+                        .foregroundStyle(.green)
+                        .transition(.scale)
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                showSuccess = false
+                            }
+                        }
+                }
+            }
+            .animation(.spring(), value: showSuccess)
         }
     }
-    
+
     struct EditDeleteSection: View {
         var allowDismiss = true
         @Environment(\.dismiss) var dismiss
@@ -107,7 +125,7 @@ struct MessageActions: View {
             Group {
                 if isAbleToEditDelete {
                     Divider()
-                    
+
                     Button(R.string.localizable.editMessage(), systemImage: "pencil") {
                         showEditSheet = true
                     }
@@ -146,7 +164,7 @@ struct MessageActions: View {
                 }
             }
         }
-        
+
         var editMessage: some View {
             NavigationView {
                 Group {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -13,37 +13,182 @@ import Smile
 import SwiftUI
 import UserStore
 
-struct MessageActionSheet: View {
-
-    @EnvironmentObject var navigationController: NavigationController
-    @Environment(\.dismiss) var dismiss
-
+struct MessageActions: View {
     @ObservedObject var viewModel: ConversationViewModel
-
     @Binding var message: DataState<BaseMessage>
     let conversationPath: ConversationPath?
 
-    @State private var showDeleteAlert = false
-    @State private var showEditSheet = false
-
-    var isAbleToEditDelete: Bool {
-        guard let message = message.value else {
-            return false
-        }
-
-        if message.isCurrentUserAuthor {
-            return true
-        }
-
-        guard let channel = viewModel.conversation.baseConversation as? Channel else {
-            return false
-        }
-        if channel.hasChannelModerationRights ?? false && message is Message {
-            return true
-        }
-
-        return false
+    var body: some View {
+        Group {
+            ReplyInThreadButton(allowDismiss: false, viewModel: viewModel, message: $message, conversationPath: conversationPath)
+            CopyTextButton(allowDismiss: false, message: $message)
+            EditDeleteSection(allowDismiss: false, viewModel: viewModel, message: $message)
+        }.lineLimit(1)
     }
+
+    struct ReplyInThreadButton: View {
+        @EnvironmentObject var navigationController: NavigationController
+        @Environment(\.dismiss) var dismiss
+        var allowDismiss = true
+
+        @ObservedObject var viewModel: ConversationViewModel
+        @Binding var message: DataState<BaseMessage>
+        let conversationPath: ConversationPath?
+
+        var body: some View {
+            if message.value is Message,
+               let conversationPath {
+                Divider()
+                Button(R.string.localizable.replyInThread(), systemImage: "text.bubble.fill") {
+                    if let messagePath = MessagePath(
+                        message: $message,
+                        conversationPath: conversationPath,
+                        conversationViewModel: viewModel
+                    ) {
+                        if allowDismiss {
+                            dismiss()
+                        }
+                        navigationController.path.append(messagePath)
+                    } else {
+                        viewModel.presentError(userFacingError: UserFacingError(title: R.string.localizable.detailViewCantBeOpened()))
+                    }
+                }
+            }
+        }
+    }
+
+    struct CopyTextButton: View {
+        var allowDismiss = true
+        @Environment(\.dismiss) var dismiss
+        @Binding var message: DataState<BaseMessage>
+
+        var body: some View {
+            Button(R.string.localizable.copyText(), systemImage: "clipboard.fill") {
+                UIPasteboard.general.string = message.value?.content
+                if allowDismiss {
+                    dismiss()
+                }
+            }
+        }
+    }
+    
+    struct EditDeleteSection: View {
+        var allowDismiss = true
+        @Environment(\.dismiss) var dismiss
+        @EnvironmentObject var navigationController: NavigationController
+        @ObservedObject var viewModel: ConversationViewModel
+        @Binding var message: DataState<BaseMessage>
+
+        @State private var showDeleteAlert = false
+        @State private var showEditSheet = false
+
+        var isAbleToEditDelete: Bool {
+            guard let message = message.value else {
+                return false
+            }
+
+            if message.isCurrentUserAuthor {
+                return true
+            }
+
+            guard let channel = viewModel.conversation.baseConversation as? Channel else {
+                return false
+            }
+            if channel.hasChannelModerationRights ?? false && message is Message {
+                return true
+            }
+
+            return false
+        }
+
+        var body: some View {
+            Group {
+                if isAbleToEditDelete {
+                    Divider()
+                    
+                    Button(R.string.localizable.editMessage(), systemImage: "pencil") {
+                        showEditSheet = true
+                    }
+                    .sheet(isPresented: $showEditSheet) {
+                        editMessage
+                    }
+                    
+                    Button(R.string.localizable.deleteMessage(), systemImage: "trash.fill", role: .destructive) {
+                        showDeleteAlert = true
+                    }
+                    .alert(R.string.localizable.confirmDeletionTitle(), isPresented: $showDeleteAlert) {
+                        Button(R.string.localizable.confirm(), role: .destructive) {
+                            viewModel.isLoading = true
+                            Task(priority: .userInitiated) {
+                                let success: Bool
+                                let tempMessage = message.value
+                                if message.value is AnswerMessage {
+                                    success = await viewModel.deleteAnswerMessage(messageId: message.value?.id)
+                                } else {
+                                    success = await viewModel.deleteMessage(messageId: message.value?.id)
+                                }
+                                viewModel.isLoading = false
+                                if success {
+                                    if allowDismiss {
+                                        dismiss()
+                                    }
+                                    // if we deleted a Message and are in the MessageDetailView we pop it
+                                    if navigationController.path.count == 3 && tempMessage is Message {
+                                        navigationController.path.removeLast()
+                                    }
+                                }
+                            }
+                        }
+                        Button(R.string.localizable.cancel(), role: .cancel) { }
+                    }
+                }
+            }
+        }
+        
+        var editMessage: some View {
+            NavigationView {
+                Group {
+                    if let message = message.value as? Message {
+                        SendMessageView(
+                            viewModel: SendMessageViewModel(
+                                course: viewModel.course,
+                                conversation: viewModel.conversation,
+                                configuration: .editMessage(message, { self.dismiss() }),
+                                delegate: SendMessageViewModelDelegate(viewModel)
+                            )
+                        )
+                    } else if let answerMessage = message.value as? AnswerMessage {
+                        SendMessageView(
+                            viewModel: SendMessageViewModel(
+                                course: viewModel.course,
+                                conversation: viewModel.conversation,
+                                configuration: .editAnswerMessage(answerMessage, { self.dismiss() }),
+                                delegate: SendMessageViewModelDelegate(viewModel)
+                            )
+                        )
+                    } else {
+                        Text(R.string.localizable.loading())
+                    }
+                }
+                .navigationTitle(R.string.localizable.editMessage())
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(R.string.localizable.cancel()) {
+                            showEditSheet = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.height(200), .medium])
+        }
+    }
+}
+
+struct MessageActionSheet: View {
+    @ObservedObject var viewModel: ConversationViewModel
+    @Binding var message: DataState<BaseMessage>
+    let conversationPath: ConversationPath?
 
     var body: some View {
         HStack {
@@ -56,147 +201,24 @@ struct MessageActionSheet: View {
                     EmojiPickerButton(viewModel: viewModel, message: $message)
                 }
                 .padding(.l)
-                if message.value is Message,
-                   let conversationPath {
-                    Divider()
-                    Button {
-                        if let messagePath = MessagePath(
-                            message: $message,
-                            conversationPath: conversationPath,
-                            conversationViewModel: viewModel
-                        ) {
-                            dismiss()
-                            navigationController.path.append(messagePath)
-                        } else {
-                            viewModel.presentError(userFacingError: UserFacingError(title: R.string.localizable.detailViewCantBeOpened()))
-                        }
-                    } label: {
-                        ButtonContent(title: R.string.localizable.replyInThread(), icon: "text.bubble.fill")
-                    }
-                }
+                MessageActions.ReplyInThreadButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
+                    .padding(.horizontal)
                 Divider()
-                Button {
-                    UIPasteboard.general.string = message.value?.content
-                    dismiss()
-                } label: {
-                    ButtonContent(title: R.string.localizable.copyText(), icon: "clipboard.fill")
-                }
+                MessageActions.CopyTextButton(message: $message)
+                    .padding(.horizontal)
 
-                editDeleteSection
+                MessageActions.EditDeleteSection(viewModel: viewModel, message: $message)
+                    .padding(.horizontal)
 
                 Spacer()
             }
+            .buttonStyle(.plain)
+            .font(.headline)
             Spacer()
         }
         .padding(.vertical, .xxl)
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
-    }
-}
-
-private extension MessageActionSheet {
-    var editDeleteSection: some View {
-        Group {
-            if isAbleToEditDelete {
-                Divider()
-
-                Button {
-                    showEditSheet = true
-                } label: {
-                    ButtonContent(title: R.string.localizable.editMessage(), icon: "pencil")
-                }
-                .sheet(isPresented: $showEditSheet) {
-                    editMessage
-                }
-
-                Button {
-                    showDeleteAlert = true
-                } label: {
-                    ButtonContent(title: R.string.localizable.deleteMessage(), icon: "trash.fill")
-                        .foregroundColor(.red)
-                }
-                .alert(R.string.localizable.confirmDeletionTitle(), isPresented: $showDeleteAlert) {
-                    Button(R.string.localizable.confirm(), role: .destructive) {
-                        viewModel.isLoading = true
-                        Task(priority: .userInitiated) {
-                            let success: Bool
-                            let tempMessage = message.value
-                            if message.value is AnswerMessage {
-                                success = await viewModel.deleteAnswerMessage(messageId: message.value?.id)
-                            } else {
-                                success = await viewModel.deleteMessage(messageId: message.value?.id)
-                            }
-                            viewModel.isLoading = false
-                            if success {
-                                dismiss()
-                                // if we deleted a Message and are in the MessageDetailView we pop it
-                                if navigationController.path.count == 3 && tempMessage is Message {
-                                    navigationController.path.removeLast()
-                                }
-                            }
-                        }
-                    }
-                    Button(R.string.localizable.cancel(), role: .cancel) { }
-                }
-            }
-        }
-    }
-
-    var editMessage: some View {
-        NavigationView {
-            Group {
-                if let message = message.value as? Message {
-                    SendMessageView(
-                        viewModel: SendMessageViewModel(
-                            course: viewModel.course,
-                            conversation: viewModel.conversation,
-                            configuration: .editMessage(message, { self.dismiss() }),
-                            delegate: SendMessageViewModelDelegate(viewModel)
-                        )
-                    )
-                } else if let answerMessage = message.value as? AnswerMessage {
-                    SendMessageView(
-                        viewModel: SendMessageViewModel(
-                            course: viewModel.course,
-                            conversation: viewModel.conversation,
-                            configuration: .editAnswerMessage(answerMessage, { self.dismiss() }),
-                            delegate: SendMessageViewModelDelegate(viewModel)
-                        )
-                    )
-                } else {
-                    Text(R.string.localizable.loading())
-                }
-            }
-            .navigationTitle(R.string.localizable.editMessage())
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(R.string.localizable.cancel()) {
-                        showEditSheet = false
-                    }
-                }
-            }
-        }
-        .presentationDetents([.height(200), .medium])
-    }
-}
-
-private struct ButtonContent: View {
-
-    let title: String
-    let icon: String
-
-    var body: some View {
-        HStack(spacing: .s) {
-            Image(systemName: icon)
-                .resizable()
-                .scaledToFit()
-                .frame(width: .mediumImage, height: .smallImage)
-            Text(title)
-                .font(.headline)
-        }
-        .padding(.horizontal, .l)
-        .foregroundColor(.Artemis.primaryLabel)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -20,10 +20,11 @@ struct MessageActions: View {
 
     var body: some View {
         Group {
-            ReplyInThreadButton(allowDismiss: false, viewModel: viewModel, message: $message, conversationPath: conversationPath)
-            CopyTextButton(allowDismiss: false, message: $message)
-            EditDeleteSection(allowDismiss: false, viewModel: viewModel, message: $message)
+            ReplyInThreadButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
+            CopyTextButton(message: $message)
+            EditDeleteSection(viewModel: viewModel, message: $message)
         }
+        .environment(\.allowAutoDismiss, false)
         .lineLimit(1)
         .font(.title3.bold())
     }
@@ -31,7 +32,7 @@ struct MessageActions: View {
     struct ReplyInThreadButton: View {
         @EnvironmentObject var navigationController: NavigationController
         @Environment(\.dismiss) var dismiss
-        var allowDismiss = true
+        @Environment(\.allowAutoDismiss) var allowDismiss
 
         @ObservedObject var viewModel: ConversationViewModel
         @Binding var message: DataState<BaseMessage>
@@ -60,7 +61,7 @@ struct MessageActions: View {
     }
 
     struct CopyTextButton: View {
-        var allowDismiss = true
+        @Environment(\.allowAutoDismiss) var allowDismiss
         @Environment(\.dismiss) var dismiss
         @Binding var message: DataState<BaseMessage>
         @State private var showSuccess = false
@@ -93,7 +94,7 @@ struct MessageActions: View {
     }
 
     struct EditDeleteSection: View {
-        var allowDismiss = true
+        @Environment(\.allowAutoDismiss) var allowDismiss
         @Environment(\.dismiss) var dismiss
         @EnvironmentObject var navigationController: NavigationController
         @ObservedObject var viewModel: ConversationViewModel
@@ -318,6 +319,23 @@ private struct EmojiPickerButton: View {
                     dismiss()
                 }
             }
+        }
+    }
+}
+
+// MARK: - Environment+AutoDismiss
+
+private enum SheetAutoDismissEnvironmentKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var allowAutoDismiss: Bool {
+        get {
+            self[SheetAutoDismissEnvironmentKey.self]
+        }
+        set {
+            self[SheetAutoDismissEnvironmentKey.self] = newValue
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -131,6 +131,7 @@ struct MessageActions: View {
                     }
                     .sheet(isPresented: $showEditSheet) {
                         editMessage
+                            .font(nil)
                     }
 
                     Button(R.string.localizable.deleteMessage(), systemImage: "trash", role: .destructive) {
@@ -210,7 +211,7 @@ struct MessageActionSheet: View {
     @Binding var message: DataState<BaseMessage>
     let conversationPath: ConversationPath?
     @State var reactionsViewModel: ReactionsViewModel
-    
+
     init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>, conversationPath: ConversationPath?) {
         self.viewModel = viewModel
         self._message = message

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -23,7 +23,9 @@ struct MessageActions: View {
             ReplyInThreadButton(allowDismiss: false, viewModel: viewModel, message: $message, conversationPath: conversationPath)
             CopyTextButton(allowDismiss: false, message: $message)
             EditDeleteSection(allowDismiss: false, viewModel: viewModel, message: $message)
-        }.lineLimit(1)
+        }
+        .lineLimit(1)
+        .font(.title3.bold())
     }
 
     struct ReplyInThreadButton: View {
@@ -39,7 +41,7 @@ struct MessageActions: View {
             if message.value is Message,
                let conversationPath {
                 Divider()
-                Button(R.string.localizable.replyInThread(), systemImage: "text.bubble.fill") {
+                Button(R.string.localizable.replyInThread(), systemImage: "text.bubble") {
                     if let messagePath = MessagePath(
                         message: $message,
                         conversationPath: conversationPath,
@@ -63,7 +65,7 @@ struct MessageActions: View {
         @Binding var message: DataState<BaseMessage>
 
         var body: some View {
-            Button(R.string.localizable.copyText(), systemImage: "clipboard.fill") {
+            Button(R.string.localizable.copyText(), systemImage: "clipboard") {
                 UIPasteboard.general.string = message.value?.content
                 if allowDismiss {
                     dismiss()
@@ -112,8 +114,8 @@ struct MessageActions: View {
                     .sheet(isPresented: $showEditSheet) {
                         editMessage
                     }
-                    
-                    Button(R.string.localizable.deleteMessage(), systemImage: "trash.fill", role: .destructive) {
+
+                    Button(R.string.localizable.deleteMessage(), systemImage: "trash", role: .destructive) {
                         showDeleteAlert = true
                     }
                     .alert(R.string.localizable.confirmDeletionTitle(), isPresented: $showDeleteAlert) {
@@ -214,6 +216,7 @@ struct MessageActionSheet: View {
             }
             .buttonStyle(.plain)
             .font(.headline)
+            .symbolVariant(.fill)
             Spacer()
         }
         .padding(.vertical, .xxl)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -14,6 +14,7 @@ import SwiftUI
 
 struct MessageCell: View {
     @Environment(\.isMessageOffline) var isMessageOffline: Bool
+    @Environment(\.messageUseFullWidth) var useFullWidth: Bool
     @EnvironmentObject var navigationController: NavigationController
 
     @ObservedObject var conversationViewModel: ConversationViewModel
@@ -48,14 +49,14 @@ struct MessageCell: View {
             replyButtonIfAvailable
         }
         .padding(.horizontal, .m)
-        .padding(viewModel.isHeaderVisible ? .vertical : .bottom, .m)
+        .padding(viewModel.isHeaderVisible ? .vertical : .bottom, useFullWidth ? 0 : .m)
         .background(
-            Color(uiColor: .secondarySystemBackground),
+            useFullWidth ? .clear : Color(uiColor: .secondarySystemBackground),
             in: .rect(cornerRadii: viewModel.roundedCorners)
         )
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)
         .id(message.value?.id.description)
-        .padding(.horizontal, .l)
+        .padding(.horizontal, useFullWidth ? 0 : .l)
         .sheet(isPresented: $viewModel.isActionSheetPresented) {
             MessageActionSheet(
                 viewModel: conversationViewModel,
@@ -276,6 +277,9 @@ private extension MessageCell {
 private enum IsMessageOfflineEnvironmentKey: EnvironmentKey {
     static let defaultValue = false
 }
+private enum MessageFullWidthEnvironmentKey: EnvironmentKey {
+    static let defaultValue = false
+}
 
 extension EnvironmentValues {
     var isMessageOffline: Bool {
@@ -284,6 +288,14 @@ extension EnvironmentValues {
         }
         set {
             self[IsMessageOfflineEnvironmentKey.self] = newValue
+        }
+    }
+    var messageUseFullWidth: Bool {
+        get {
+            self[MessageFullWidthEnvironmentKey.self]
+        }
+        set {
+            self[MessageFullWidthEnvironmentKey.self] = newValue
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -31,6 +31,7 @@ struct MessageCell: View {
                     ArtemisMarkdownView(string: content)
                         .opacity(isMessageOffline ? 0.5 : 1)
                         .environment(\.openURL, OpenURLAction(handler: handle))
+                    editedLabel
                 }
                 Spacer()
             }
@@ -131,26 +132,31 @@ private extension MessageCell {
                     .bold()
                     .redacted(reason: isMessageOffline ? .placeholder : [])
                 if let creationDate {
-                    Group {
-                        Text(creationDate, formatter: DateFormatter.timeOnly)
-
-                        if message.value?.updatedDate != nil {
-                            Text(R.string.localizable.edited())
-                                .foregroundColor(.Artemis.secondaryLabel)
-                        }
+                    let formatter: DateFormatter = viewModel.conversationPath == nil ? .superShortDateAndTime : .timeOnly
+                    Text(creationDate, formatter: formatter)
+                        .font(.caption)
+                    if viewModel.isChipVisible(creationDate: creationDate, authorId: message.value?.author?.id) {
+                        Chip(
+                            text: R.string.localizable.new(),
+                            backgroundColor: .Artemis.artemisBlue,
+                            padding: .s
+                        )
+                        .font(.footnote)
                     }
-                    .font(.caption)
-                    Chip(
-                        text: R.string.localizable.new(),
-                        backgroundColor: .Artemis.artemisBlue,
-                        padding: .s
-                    )
-                    .font(.footnote)
-                    .opacity(
-                        viewModel.isChipVisible(creationDate: creationDate, authorId: message.value?.author?.id) ? 1 : 0
-                    )
                 }
             }
+        }
+    }
+
+    @ViewBuilder var editedLabel: some View {
+        if let updatedDate = message.value?.updatedDate {
+            Group {
+                Text(R.string.localizable.edited() + " (") +
+                Text(updatedDate, formatter: DateFormatter.superShortDateAndTime) +
+                Text(")")
+            }
+            .font(.caption)
+            .foregroundColor(.Artemis.secondaryLabel)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -54,7 +54,7 @@ struct MessageDetailView: View {
                 }
             }
         }
-        .navigationTitle(R.string.localizable.thread())
+        .navigationTitle(R.string.localizable.thread() + " (\(viewModel.conversation.baseConversation.conversationName))")
         .task {
             if message.value == nil {
                 await reloadMessage()

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -88,7 +88,7 @@ private extension MessageDetailView {
     @ViewBuilder var divider: some View {
         VStack {
             Divider()
-            HStack(alignment: .bottom) {
+            HStack {
                 let replies = (message.value as? Message)?.answers?.count ?? 0
                 Text("^[\(replies) \(R.string.localizable.replies())](inflect:true)")
                     .foregroundStyle(.secondary)
@@ -100,7 +100,7 @@ private extension MessageDetailView {
                     HStack {
                         MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
                     }
-                    HStack {
+                    HStack(spacing: .l) {
                         MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
                             .labelStyle(.iconOnly)
                     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -85,11 +85,37 @@ private extension MessageDetailView {
         }
     }
 
+    @ViewBuilder var divider: some View {
+        VStack {
+            Divider()
+            HStack(alignment: .bottom) {
+                let replies = (message.value as? Message)?.answers?.count ?? 0
+                Text("^[\(replies) \(R.string.localizable.replies())](inflect:true)")
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                // Only display labels if we have enough space
+                ViewThatFits(in: .horizontal) {
+                    HStack {
+                        MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
+                    }
+                    HStack {
+                        MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
+                            .labelStyle(.iconOnly)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            Divider()
+        }.padding(.top, .s)
+    }
+
     @ViewBuilder
     func answers(of message: BaseMessage, proxy: ScrollViewProxy) -> some View {
         if let message = message as? Message {
-            Divider()
-                .padding(.top, .s)
+            divider
+
             VStack(spacing: 0) {
                 let sortedArray = (message.answers ?? []).sorted {
                     $0.creationDate ?? .tomorrow < $1.creationDate ?? .yesterday

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -74,6 +74,7 @@ private extension MessageDetailView {
             roundBottomCorners: true
         )
         .environment(\.isEmojiPickerButtonVisible, true)
+        .environment(\.messageUseFullWidth, true)
         .onLongPressGesture(maximumDistance: 30) {
             let impactMed = UIImpactFeedbackGenerator(style: .heavy)
             impactMed.impactOccurred()
@@ -92,6 +93,7 @@ private extension MessageDetailView {
                 let replies = (message.value as? Message)?.answers?.count ?? 0
                 Text("^[\(replies) \(R.string.localizable.replies())](inflect:true)")
                     .foregroundStyle(.secondary)
+                    .padding(.top, .s)
 
                 Spacer()
 


### PR DESCRIPTION
### Problem
It can be hard to find actions for messages, such as copying, editing or deleting.

### Solution
In the MessageDetailView, we introduce a bar with useful elements below the selected message. It shows how many replies there are, and allows a user to quickly use the copy/edit/delete buttons without needing to long press a message.

By also making the top message take up the full space without a background, it appears more prominent.

We also fix some alignment issues with the current Message Actions Sheet and made sure to display more useful dates.

### Before vs After
<img src="https://github.com/user-attachments/assets/614b9dfc-4e22-4f8c-820c-46a4267a09b0" alt="Before" width="300">
<img src="https://github.com/user-attachments/assets/22c982d3-faba-41ef-972f-133d81416c47" alt="After" width="300">

