### PR TITLE
`Communication`: Highlight pinned messages

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/BaseMessage+IsContinuation.swift
+++ b/ArtemisKit/Sources/Messages/Models/BaseMessage+IsContinuation.swift
@@ -21,6 +21,14 @@ extension BaseMessage {
             return false
         }
 
+        // Don't merge pinned messages
+        if (message as? Message)?.displayPriority == .pinned {
+            return false
+        }
+        if (self as? Message)?.displayPriority == .pinned {
+            return false
+        }
+
         return lhs < rhs.addingTimeInterval(TimeInterval(MAX_MINUTES_FOR_GROUPING_MESSAGES * 60))
     }
 }

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "noMessagesDescription" = "Write the first message to kickstart this conversation.";
 "reply" = "reply";
 "new" = "New";
+"pinned" = "Pinned";
 
 // MARK: CreateChannelView
 "channelNameLabel" = "Name";

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -86,10 +86,6 @@ class ReactionsViewModel {
 extension DataState<BaseMessage>: Equatable {
     public static func == (lhs: DataState<BaseMessage>, rhs: DataState<BaseMessage>) -> Bool {
         switch lhs {
-        case .loading:
-            return false
-        case .failure:
-            return false
         case .done(let responseLhs):
             switch rhs {
             case .done(let responseRhs):
@@ -103,12 +99,16 @@ extension DataState<BaseMessage>: Equatable {
                 hashRhs.combine(responseRhs.reactions)
                 hashLhs.combine(responseLhs.updatedDate)
                 hashRhs.combine(responseRhs.updatedDate)
+                hashLhs.combine((responseLhs as? Message)?.displayPriority)
+                hashRhs.combine((responseRhs as? Message)?.displayPriority)
                 hashLhs.combine(responseLhs.content)
                 hashRhs.combine(responseRhs.content)
                 return hashLhs.finalize() == hashRhs.finalize()
             default:
                 return false
             }
+        default:
+            return false
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -27,6 +27,7 @@ struct MessageCell: View {
         VStack(alignment: .leading, spacing: .s) {
             HStack {
                 VStack(alignment: .leading, spacing: .s) {
+                    pinnedIndicator
                     headerIfVisible
                     ArtemisMarkdownView(string: content)
                         .opacity(isMessageOffline ? 0.5 : 1)
@@ -108,6 +109,10 @@ private extension MessageCell {
         message.value?.content ?? ""
     }
 
+    var isPinned: Bool {
+        (message.value as? Message)?.displayPriority == .pinned
+    }
+
     var backgroundOnPress: Color {
         (viewModel.isDetectingLongPress || viewModel.isActionSheetPresented) ? Color.Artemis.messsageCellPressed : Color.clear
     }
@@ -121,6 +126,13 @@ private extension MessageCell {
                 verticalPadding: .s
             )
             .font(.footnote)
+        }
+    }
+
+    @ViewBuilder var pinnedIndicator: some View {
+        if isPinned {
+            Label(R.string.localizable.pinned(), systemImage: "pin")
+                .font(.caption)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -59,7 +59,7 @@ struct MessageCell: View {
             swipeToReplyOverlay
         }
         .background(
-            useFullWidth ? 
+            useFullWidth ?
                 .clear :
                 isPinned ? .orange.opacity(0.3) : Color(uiColor: .secondarySystemBackground),
             in: .rect(cornerRadii: viewModel.roundedCorners)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -58,7 +58,7 @@ struct MessageCell: View {
         .background(
             useFullWidth ?
                 .clear :
-                isPinned ? .orange.opacity(0.3) : Color(uiColor: .secondarySystemBackground),
+                isPinned ? .orange.opacity(0.25) : Color(uiColor: .secondarySystemBackground),
             in: .rect(cornerRadii: viewModel.roundedCorners)
         )
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -36,10 +36,7 @@ struct MessageCell: View {
                 }
                 Spacer()
             }
-            .background {
-                RoundedRectangle(cornerRadius: .m)
-                    .foregroundStyle(backgroundOnPress)
-            }
+            .background(backgroundOnPress, in: .rect(cornerRadius: .m))
             .contentShape(.rect)
             .onTapGesture(perform: onTapPresentMessage)
             .onLongPressGesture(perform: onLongPressPresentActionSheet) { changed in
@@ -123,7 +120,7 @@ private extension MessageCell {
     }
 
     var backgroundOnPress: Color {
-        (viewModel.isDetectingLongPress || viewModel.isActionSheetPresented) ? Color.Artemis.messsageCellPressed : Color.clear
+        (viewModel.isDetectingLongPress || viewModel.isActionSheetPresented) ? Color.primary.opacity(0.1) : Color.clear
     }
 
     @ViewBuilder var roleBadge: some View {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -53,7 +53,9 @@ struct MessageCell: View {
         .padding(.horizontal, .m)
         .padding(viewModel.isHeaderVisible ? .vertical : .bottom, useFullWidth ? 0 : .m)
         .background(
-            useFullWidth ? .clear : Color(uiColor: .secondarySystemBackground),
+            useFullWidth ? 
+                .clear :
+                isPinned ? .orange.opacity(0.3) : Color(uiColor: .secondarySystemBackground),
             in: .rect(cornerRadii: viewModel.roundedCorners)
         )
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)


### PR DESCRIPTION
### Problem
There is no way to see whether a message is pinned on the iOS app, all messages look the same.

### Solution
We add a "pinned" indicator above pinned messages and highlight them by making pinned messages have a coloured background.

### Before vs After
<img src="https://github.com/user-attachments/assets/f03370d9-9d00-4846-8c56-7b313d7be289" alt="Before" width="300">
<img src="https://github.com/user-attachments/assets/89cb7fb2-363e-42c3-bc20-49421ae40ba6" alt="After" width="300">