### PR TITLE
`Communication`: Improve conversation title bars

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -161,7 +161,7 @@ private extension ConversationInfoSheetView {
             if (conversation.baseConversation.numberOfMembers ?? 0) > PAGINATION_SIZE || viewModel.page > 0 {
                 HStack(spacing: .l) {
                     Spacer()
-                    Text("< \(R.string.localizable.previous())")
+                    Text("\(Image(systemName: "chevron.backward")) \(R.string.localizable.previous())")
                         .onTapGesture {
                             Task {
                                 await viewModel.loadPreviousMemberPage()
@@ -170,7 +170,7 @@ private extension ConversationInfoSheetView {
                         .disabled(viewModel.page == 0)
                         .foregroundColor(viewModel.page == 0 ? .Artemis.buttonDisabledColor : .Artemis.artemisBlue)
                     Text("\(viewModel.page + 1)")
-                    Text("\(R.string.localizable.next()) >")
+                    Text("\(R.string.localizable.next()) \(Image(systemName: "chevron.forward"))")
                         .onTapGesture {
                             Task {
                                 await viewModel.loadNextMemberPage()

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -17,6 +17,7 @@ private var PAGINATION_SIZE = 20
 
 struct ConversationInfoSheetView: View {
     @EnvironmentObject var navigationController: NavigationController
+    @Environment(\.dismiss) var dismiss
 
     @StateObject private var viewModel: ConversationInfoSheetViewModel
 
@@ -39,6 +40,13 @@ struct ConversationInfoSheetView: View {
                 await viewModel.loadMembers()
             }
             .navigationTitle(conversation.baseConversation.conversationName)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(R.string.localizable.done()) {
+                        dismiss()
+                    }
+                }
+            }
             .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
             .loadingIndicator(isLoading: $viewModel.isLoading)
         }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -64,14 +64,14 @@ private extension ConversationInfoSheetView {
         Group {
             Section(R.string.localizable.settings()) {
                 if viewModel.canAddUsers {
-                    Button(R.string.localizable.addUsers()) {
+                    Button(R.string.localizable.addUsers(), systemImage: "person.fill.badge.plus") {
                         viewModel.isAddMemberSheetPresented = true
                     }
                 }
                 if let channel = conversation.baseConversation as? Channel,
                    channel.hasChannelModerationRights ?? false {
                     if channel.isArchived ?? false {
-                        Button(R.string.localizable.unarchiveChannelButtonLabel()) {
+                        Button(R.string.localizable.unarchiveChannelButtonLabel(), systemImage: "archivebox.fill") {
                             viewModel.isLoading = true
                             Task {
                                 await viewModel.unarchiveChannel()
@@ -80,7 +80,7 @@ private extension ConversationInfoSheetView {
                         }
                         .foregroundColor(.Artemis.badgeWarningColor)
                     } else {
-                        Button(R.string.localizable.archiveChannelButtonLabel()) {
+                        Button(R.string.localizable.archiveChannelButtonLabel(), systemImage: "archivebox.fill") {
                             viewModel.isLoading = true
                             Task {
                                 await viewModel.archiveChannel()
@@ -91,7 +91,7 @@ private extension ConversationInfoSheetView {
                     }
                 }
                 if viewModel.canLeaveConversation {
-                    Button(R.string.localizable.leaveConversationButtonLabel()) {
+                    Button(R.string.localizable.leaveConversationButtonLabel(), systemImage: "rectangle.portrait.and.arrow.forward") {
                         viewModel.isLoading = true
                         Task {
                             let success = await viewModel.leaveConversation()

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -85,9 +85,18 @@ public struct ConversationView: View {
                 Button {
                     viewModel.isConversationInfoSheetPresented = true
                 } label: {
-                    Text(viewModel.conversation.baseConversation.conversationName)
-                        .foregroundStyle(Color.Artemis.primaryLabel)
-                        .fontWeight(.semibold)
+                    HStack(alignment: .center, spacing: .m) {
+                        viewModel.conversation.baseConversation.icon?
+                            .renderingMode(.template)
+                            .resizable()
+                            .scaledToFit()
+                            .padding(.vertical, .m * 1.5)
+                            .containerRelativeFrame(.vertical)
+                        Text(viewModel.conversation.baseConversation.conversationName)
+                            .fontWeight(.semibold)
+                    }
+                    .padding(.horizontal, .l)
+                    .foregroundStyle(Color.Artemis.primaryLabel)
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -90,8 +90,7 @@ public struct ConversationView: View {
                             .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
-                            .padding(.vertical, .m * 1.5)
-                            .containerRelativeFrame(.vertical)
+                            .frame(height: 20)
                         Text(viewModel.conversation.baseConversation.conversationName)
                             .fontWeight(.semibold)
                     }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -95,8 +95,15 @@ public struct ConversationView: View {
                         Text(viewModel.conversation.baseConversation.conversationName)
                             .fontWeight(.semibold)
                     }
-                    .padding(.horizontal, .l)
+                    .padding(.horizontal, .m)
                     .foregroundStyle(Color.Artemis.primaryLabel)
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    viewModel.isConversationInfoSheetPresented = true
+                } label: {
+                    Image(systemName: "info.circle")
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -81,13 +81,13 @@ public struct ConversationView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .principal) {
+            ToolbarItem(placement: .topBarLeading) {
                 Button {
                     viewModel.isConversationInfoSheetPresented = true
                 } label: {
                     Text(viewModel.conversation.baseConversation.conversationName)
-                        .foregroundColor(.Artemis.primaryLabel)
-                        .frame(width: UIScreen.main.bounds.size.width * 0.6)
+                        .foregroundStyle(Color.Artemis.primaryLabel)
+                        .fontWeight(.semibold)
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -93,6 +93,9 @@ public struct ConversationView: View {
                             .frame(height: 20)
                         Text(viewModel.conversation.baseConversation.conversationName)
                             .fontWeight(.semibold)
+                        Image(systemName: "chevron.forward")
+                            .font(.caption2)
+                            .offset(x: -5, y: 1)
                     }
                     .padding(.horizontal, .m)
                     .foregroundStyle(Color.Artemis.primaryLabel)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -55,7 +55,22 @@ struct MessageDetailView: View {
                 }
             }
         }
-        .navigationTitle(R.string.localizable.thread() + " (\(viewModel.conversation.baseConversation.conversationName))")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(R.string.localizable.thread())
+                        .fontWeight(.semibold)
+                    HStack(spacing: .s) {
+                        viewModel.conversation.baseConversation.icon?
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: .m * 1.5)
+                        Text(viewModel.conversation.baseConversation.conversationName)
+                    }
+                    .font(.footnote)
+                }.padding(.leading, .m)
+            }
+        }
         .task {
             if message.value == nil {
                 await reloadMessage()


### PR DESCRIPTION
### Problem
Some of the title bars as well as associated actions are not intuitive and can be improved. For example, a user might not know that they can access channel details by tapping on the conversation name, and the Thread view can be improved as well.

### Solution
We display the channel's icon and bolder text on the leading side like in most messengers, as well as an `i` icon on the trailing side of the title bar. On the details sheet, we add missing icons and a close button.

In a thread, we display the Thread and channel name below each other.

### Before
<img src="https://github.com/user-attachments/assets/b0dd465c-c4e2-45de-aebe-5489d813a1b0" alt="Conversation Before" width="200">
<img src="https://github.com/user-attachments/assets/47f5310e-a3f4-4c00-b3fb-84887cddb543" alt="Thread Before" width="200">
<img src="https://github.com/user-attachments/assets/d8b06048-5986-4bbd-a1c4-08109147a308" alt="Info sheet Before" width="200">

### After
<img src="https://github.com/user-attachments/assets/43bb8842-0839-45da-a0b8-23627a925519" alt="Conversation After" width="200">
<img src="https://github.com/user-attachments/assets/113e91a3-89da-4794-b99a-211ca2cf5086" alt="Thread After" width="200">
<img src="https://github.com/user-attachments/assets/14460136-31ea-4292-bcc1-2bbdbdd8b6a5" alt="Info sheet After" width="200">
