### PR TITLE
`Communication`: Refactor Swipe to Reply

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
@@ -23,7 +23,6 @@ final class MessageCellModel {
 
     var isActionSheetPresented = false
     var isDetectingLongPress = false
-    var swipeToReplyState = SwipeToReplyState()
 
     private let messagesService: MessagesService
     private let userSession: UserSession
@@ -62,32 +61,6 @@ extension MessageCellModel {
         let top: CGFloat = isHeaderVisible ? .m : 0
         let bottom: CGFloat = roundBottomCorners ? .m : 0
         return .init(topLeading: top, bottomLeading: bottom, bottomTrailing: bottom, topTrailing: top)
-    }
-
-    func swipeToReplyGesture(openThread: @escaping () -> Void) -> some Gesture {
-        DragGesture(minimumDistance: 20)
-            .onChanged { value in
-                // No swiping in Thread View
-                guard self.conversationPath != nil else { return }
-
-                // Only allow swipe to the left
-                let distance = min(value.translation.width, 0)
-
-                self.swipeToReplyState.update(with: distance)
-            }
-            .onEnded { _ in
-                if self.swipeToReplyState.swiped {
-                    openThread()
-                } else {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        self.resetSwipeToReply()
-                    }
-                }
-            }
-    }
-
-    func resetSwipeToReply() {
-        swipeToReplyState = .init()
     }
 
     // MARK: Navigation
@@ -140,5 +113,14 @@ class SwipeToReplyState {
             swiped = false
             UIImpactFeedbackGenerator(style: .soft).impactOccurred()
         }
+    }
+
+    /// Sets all values back to default
+    func reset() {
+        swiped = false
+        overlayOffset = 100
+        overlayOpacity = 0
+        overlayScale = 0
+        messageBlur = 0
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -52,16 +52,11 @@ struct MessageCell: View {
         .padding(.horizontal, .m)
         .padding(viewModel.isHeaderVisible ? .vertical : .bottom, useFullWidth ? 0 : .m)
         .contentShape(.rect)
-        .gesture(viewModel.swipeToReplyGesture(openThread: onSwipePresentMessage))
-        .blur(radius: viewModel.swipeToReplyState.messageBlur)
-        .overlay(alignment: .trailing) {
-            swipeToReplyOverlay
-        }
+        .modifier(SwipeToReply(enabled: viewModel.conversationPath != nil, onSwipe: onSwipePresentMessage))
         .background(messageBackground, in: .rect(cornerRadii: viewModel.roundedCorners))
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)
         .id(message.value?.id.description)
         .padding(.horizontal, useFullWidth ? 0 : (.m + .l) / 2)
-        .onDisappear(perform: viewModel.resetSwipeToReply)
         .sheet(isPresented: $viewModel.isActionSheetPresented) {
             MessageActionSheet(
                 viewModel: conversationViewModel,
@@ -234,20 +229,6 @@ private extension MessageCell {
                 }
             }
         }
-    }
-
-    @ViewBuilder var swipeToReplyOverlay: some View {
-        Image(systemName: "arrowshape.turn.up.left.circle.fill")
-            .resizable()
-            .scaledToFit()
-            .frame(width: 40)
-            .foregroundStyle(viewModel.swipeToReplyState.swiped ? .blue : .gray)
-            .padding(.horizontal)
-            .offset(x: viewModel.swipeToReplyState.overlayOffset)
-            .scaleEffect(x: viewModel.swipeToReplyState.overlayScale, y: viewModel.swipeToReplyState.overlayScale, anchor: .trailing)
-            .opacity(viewModel.swipeToReplyState.overlayOpacity)
-            .animation(.easeInOut(duration: 0.1), value: viewModel.swipeToReplyState.swiped)
-            .accessibilityHidden(true)
     }
 
     func openThread(showErrorOnFailure: Bool = true, presentKeyboard: Bool = false) {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/SwipeToReply.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/SwipeToReply.swift
@@ -1,0 +1,61 @@
+//
+//  SwipeToReply.swift
+//
+//
+//  Created by Anian Schleyer on 10.08.24.
+//
+
+import SwiftUI
+
+struct SwipeToReply: ViewModifier {
+    @State private var state = SwipeToReplyState()
+
+    let enabled: Bool
+    let onSwipe: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .gesture(swipeToReplyGesture)
+            .blur(radius: state.messageBlur)
+            .overlay(alignment: .trailing) {
+                swipeToReplyOverlay
+            }
+            .onDisappear(perform: state.reset)
+    }
+
+    @ViewBuilder var swipeToReplyOverlay: some View {
+        Image(systemName: "arrowshape.turn.up.left.circle.fill")
+            .resizable()
+            .scaledToFit()
+            .frame(width: 40)
+            .foregroundStyle(state.swiped ? .blue : .gray)
+            .padding(.horizontal)
+            .offset(x: state.overlayOffset)
+            .scaleEffect(x: state.overlayScale, y: state.overlayScale, anchor: .trailing)
+            .opacity(state.overlayOpacity)
+            .animation(.easeInOut(duration: 0.1), value: state.swiped)
+            .accessibilityHidden(true)
+    }
+
+    var swipeToReplyGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onChanged { value in
+                // No swiping in Thread View
+                guard enabled else { return }
+
+                // Only allow swipe to the left
+                let distance = min(value.translation.width, 0)
+
+                self.state.update(with: distance)
+            }
+            .onEnded { _ in
+                if self.state.swiped {
+                    onSwipe()
+                } else {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        self.state.reset()
+                    }
+                }
+            }
+    }
+}


### PR DESCRIPTION
We move SwipeToReply into its own View Modifier so that it could be reused and is separate from the MessageCell.

That way, we don't need to pass around as much data and simplify code in MessageCell by only focusing on displaying a Message.