### PR TITLE
`Communication`: Add pin message button

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "ad51e949c738b9a9d242d436e49d3414b8281b06",
-        "version" : "14.0.0"
+        "revision" : "9b7ed6485832f30f7e8e6c0dbffdc5a6592b026a",
+        "version" : "14.0.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.1")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "deletionErrorLabel" = "Could not delete message. Try again later.";
 "markAsResolving" = "Resolves Post";
 "unmarkAsResolving" = "Doesn't Resolve Post";
+"pinMessage" = "Pin Message";
+"unpinMessage" = "Unpin Message";
 
 // MARK: ConversationView
 "noMessages" = "No Messages";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -61,7 +61,7 @@ protocol MessagesService {
     /**
      * Perform a put request to update a message's display priority in a specific course to the server.
      */
-    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> DataState<any BaseMessage>
 
     /**
      * Perform a put request to update a message in a specific course to the server.

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -59,6 +59,11 @@ protocol MessagesService {
     func deleteAnswerMessage(for courseId: Int, anserMessageId: Int64) async -> NetworkResponse
 
     /**
+     * Perform a put request to update a message's display priority in a specific course to the server.
+     */
+    func updateMessageDisplayPriority(for courseId: Int, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse
+
+    /**
      * Perform a put request to update a message in a specific course to the server.
      */
     func editMessage(for courseId: Int, message: Message) async -> NetworkResponse

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -61,7 +61,7 @@ protocol MessagesService {
     /**
      * Perform a put request to update a message's display priority in a specific course to the server.
      */
-    func updateMessageDisplayPriority(for courseId: Int, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse
 
     /**
      * Perform a put request to update a message in a specific course to the server.

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -311,6 +311,37 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
+    struct UpdateDisplayPriorityRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let courseId: Int64
+        let messageId: Int64
+        let displayPriority: DisplayPriority
+
+        var method: HTTPMethod {
+            return .put
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/messages/\(messageId)/display-priority"
+        }
+
+        var params: [URLQueryItem] {
+            [.init(name: "displayPriority", value: displayPriority.rawValue)]
+        }
+    }
+
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
+        let result = await client.sendRequest(UpdateDisplayPriorityRequest(courseId: courseId, messageId: messageId, displayPriority: displayPriority))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
     struct EditAnswerMessageRequest: APIRequest {
         typealias Response = RawResponse
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -312,7 +312,7 @@ struct MessagesServiceImpl: MessagesService {
     }
 
     struct UpdateDisplayPriorityRequest: APIRequest {
-        typealias Response = RawResponse
+        typealias Response = Message
 
         let courseId: Int64
         let messageId: Int64
@@ -331,14 +331,14 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
-    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> DataState<any BaseMessage> {
         let result = await client.sendRequest(UpdateDisplayPriorityRequest(courseId: courseId, messageId: messageId, displayPriority: displayPriority))
 
         switch result {
-        case .success:
-            return .success
+        case .success((let message, _)):
+            return .done(response: message)
         case let .failure(error):
-            return .failure(error: error)
+            return .failure(error: .init(error: error))
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -133,6 +133,10 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
+    func updateMessageDisplayPriority(for courseId: Int, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
+        .loading
+    }
+
     func editAnswerMessage(for courseId: Int, answerMessage: AnswerMessage) async -> NetworkResponse {
         .loading
     }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -133,7 +133,7 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
-    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> DataState<any BaseMessage> {
         .loading
     }
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -133,7 +133,7 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
-    func updateMessageDisplayPriority(for courseId: Int, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
+    func updateMessageDisplayPriority(for courseId: Int64, messageId: Int64, displayPriority: DisplayPriority) async -> NetworkResponse {
         .loading
     }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -262,7 +262,7 @@ extension ConversationViewModel {
         return false
     }
 
-    func togglePinned(for message: Message) async -> Bool {
+    func togglePinned(for message: Message) async -> DataState<any BaseMessage> {
         isLoading = true
 
         let isPinned = message.displayPriority == .pinned
@@ -271,19 +271,13 @@ extension ConversationViewModel {
         isLoading = false
         switch result {
         case .failure(let error):
-            if let apiClientError = error as? APIClientError {
-                let userFacingError = UserFacingError(error: apiClientError)
-                presentError(userFacingError: userFacingError)
-            } else {
-                let userFacingError = UserFacingError(title: error.localizedDescription)
-                presentError(userFacingError: userFacingError)
-            }
-        case .success:
-            return true
-        default:
-            break
+            presentError(userFacingError: error)
+            return .failure(error: error)
+        case .done(let message):
+            return .done(response: message)
+        case .loading:
+            return .loading
         }
-        return false
     }
 }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -267,7 +267,7 @@ extension ConversationViewModel {
 
         let isPinned = message.displayPriority == .pinned
 
-        let result = await messagesService.updateMessageDisplayPriority(for: course.id, messageId: message.id, displayPriority: isPinned ? .noInformation : .pinned)
+        let result = await messagesService.updateMessageDisplayPriority(for: Int64(course.id), messageId: message.id, displayPriority: isPinned ? .noInformation : .pinned)
         isLoading = false
         switch result {
         case .failure(let error):

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -206,6 +206,50 @@ struct MessageActions: View {
         }
     }
 
+    struct PinButton: View {
+        @Environment(\.allowAutoDismiss) var allowDismiss
+        @Environment(\.dismiss) var dismiss
+        @EnvironmentObject var navigationController: NavigationController
+        @ObservedObject var viewModel: ConversationViewModel
+        @Binding var message: DataState<BaseMessage>
+
+        var isAbleToPin: Bool {
+            guard let message = message.value, message is Message else {
+                return false
+            }
+            let isModerator = (viewModel.conversation.baseConversation as? Channel)?.isChannelModerator ?? false
+            let isCreator = viewModel.conversation.baseConversation.isCreator ?? false
+            guard isModerator || isCreator else {
+                return false
+            }
+
+            return false
+        }
+
+        var body: some View {
+            Group {
+                if isAbleToPin {
+                    Divider()
+
+                    if (message.value as? Message)?.displayPriority == .pinned {
+                        Button(R.string.localizable.unpinMessage(), systemImage: "pin.slash", action: togglePinned)
+                    } else {
+                        Button(R.string.localizable.pinMessage(), systemImage: "pin", action: togglePinned)
+                    }
+                }
+            }
+        }
+
+        func togglePinned() {
+            guard let message = message.value as? Message else { return }
+            Task {
+                if await viewModel.togglePinned(for: message) && allowDismiss {
+                    dismiss()
+                }
+            }
+        }
+    }
+
     struct MarkResolvingButton: View {
         @Environment(\.allowAutoDismiss) var allowDismiss
         @Environment(\.dismiss) var dismiss

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -223,7 +223,7 @@ struct MessageActions: View {
                 return false
             }
 
-            return false
+            return true
         }
 
         var body: some View {
@@ -331,6 +331,9 @@ struct MessageActionSheet: View {
                     .padding(.horizontal)
 
                 MessageActions.EditDeleteSection(viewModel: viewModel, message: $message)
+                    .padding(.horizontal)
+
+                MessageActions.PinButton(viewModel: viewModel, message: $message)
                     .padding(.horizontal)
 
                 MessageActions.MarkResolvingButton(viewModel: viewModel, message: $message)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -243,8 +243,14 @@ struct MessageActions: View {
         func togglePinned() {
             guard let message = message.value as? Message else { return }
             Task {
-                if await viewModel.togglePinned(for: message) && allowDismiss {
-                    dismiss()
+                var result = await viewModel.togglePinned(for: message)
+                let oldRole = message.authorRole
+                if var newMessageResult = result.value as? Message {
+                    newMessageResult.authorRole = oldRole
+                    self.$message.wrappedValue = .done(response: newMessageResult)
+                    if allowDismiss {
+                        dismiss()
+                    }
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -22,6 +22,7 @@ struct MessageActions: View {
         Group {
             ReplyInThreadButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
             CopyTextButton(message: $message)
+            PinButton(viewModel: viewModel, message: $message)
             EditDeleteSection(viewModel: viewModel, message: $message)
         }
         .environment(\.allowAutoDismiss, false)
@@ -336,13 +337,13 @@ struct MessageActionSheet: View {
                 MessageActions.CopyTextButton(message: $message)
                     .padding(.horizontal)
 
-                MessageActions.EditDeleteSection(viewModel: viewModel, message: $message)
-                    .padding(.horizontal)
-
                 MessageActions.PinButton(viewModel: viewModel, message: $message)
                     .padding(.horizontal)
 
                 MessageActions.MarkResolvingButton(viewModel: viewModel, message: $message)
+                    .padding(.horizontal)
+
+                MessageActions.EditDeleteSection(viewModel: viewModel, message: $message)
                     .padding(.horizontal)
 
                 Spacer()

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -218,9 +218,16 @@ struct MessageActions: View {
             guard let message = message.value, message is Message else {
                 return false
             }
+
+            // Channel: Only Moderators can pin
             let isModerator = (viewModel.conversation.baseConversation as? Channel)?.isChannelModerator ?? false
+            if viewModel.conversation.baseConversation is Channel && !isModerator {
+                return false
+            }
+
+            // Group Chat: Only Creator can pin
             let isCreator = viewModel.conversation.baseConversation.isCreator ?? false
-            guard isModerator || isCreator else {
+            if viewModel.conversation.baseConversation is GroupChat && !isCreator {
                 return false
             }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -321,7 +321,7 @@ struct MessageActionSheet: View {
     }
 
     var body: some View {
-        HStack {
+        ScrollView {
             VStack(alignment: .leading, spacing: .l) {
                 HStack(spacing: .m) {
                     EmojiTextButton(viewModel: reactionsViewModel, emoji: "😂")
@@ -352,11 +352,9 @@ struct MessageActionSheet: View {
             .font(.headline)
             .symbolVariant(.fill)
             .imageScale(.large)
-            Spacer()
         }
         .fontWeight(.bold)
-        .padding(.vertical, .xl)
-        .frame(maxHeight: .infinity, alignment: .top)
+        .contentMargins(.vertical, .l)
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -124,6 +124,7 @@ private extension MessageDetailView {
                             .fontWeight(.bold)
                     }
                 }
+                .loadingIndicator(isLoading: $viewModel.isLoading)
             }
             .padding(.horizontal)
             Divider()


### PR DESCRIPTION
### Problem
Pinning/unpinning messages is not possible from the iOS app.

### Solution
We add a button to pin/unpin a message to the MessageActionsSheet as well as the Quick Actions Bar in the MessageDetailView.

<img src="https://github.com/user-attachments/assets/e98b7a45-3f91-4387-9239-d53fd7b63580" alt="Pinning and unpinning demo" width="300">
