### PR TITLE
`Communication`,`Lectures`: Add Navigation to associated Channels

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailViewModel.swift
@@ -14,6 +14,7 @@ class LectureDetailViewModel: BaseViewModel {
 
     @Published var lecture: DataState<Lecture> = .loading
     @Published var course: DataState<Course> = .loading
+    @Published var channel: DataState<Channel> = .loading
 
     let lectureId: Int
     let courseId: Int
@@ -53,6 +54,13 @@ class LectureDetailViewModel: BaseViewModel {
         case .done(let response):
             course = .done(response: response.course)
         }
+    }
+
+    func loadAssociatedChannel() async {
+        // We only have a channel if communication is enabled
+        guard course.value?.courseInformationSharingConfiguration != .disabled else { return }
+
+        channel = await LectureServiceFactory.shared.getAssociatedChannel(for: lectureId, in: courseId)
     }
 
     func updateLectureUnitCompletion(lectureUnit: LectureUnit, completed: Bool) async -> LectureUnit {

--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -96,3 +96,4 @@
 "lectureUnits" = "Lecture Units";
 "lecturesGroupTitle" = "%s (Lectures: %i)";
 "attachments" = "Attachments";
+"discussion" = "Discussion";

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureService.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureService.swift
@@ -13,6 +13,7 @@ protocol LectureService {
     func getLectureDetails(lectureId: Int) async -> DataState<Lecture>
     func getAttachmentFile(link: String) async -> DataState<URL>
     func updateLectureUnitCompletion(lectureId: Int, lectureUnitId: Int64, completed: Bool) async -> NetworkResponse
+    func getAssociatedChannel(for lectureId: Int, in courseId: Int) async -> DataState<Channel>
 }
 
 enum LectureServiceFactory {

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
@@ -84,4 +84,30 @@ class LectureServiceImpl: LectureService {
             return .failure(error: UserFacingError(title: error.localizedDescription))
         }
     }
+
+    struct GetLectureChannelRequest: APIRequest {
+        typealias Response = Channel
+
+        let courseId: Int
+        let lectureId: Int
+
+        var method: HTTPMethod {
+            .get
+        }
+
+        var resourceName: String {
+            "api/courses/\(courseId)/lectures/\(lectureId)/channel"
+        }
+    }
+
+    func getAssociatedChannel(for lectureId: Int, in courseId: Int) async -> DataState<Channel> {
+        let result = await client.sendRequest(GetLectureChannelRequest(courseId: courseId, lectureId: lectureId))
+
+        switch result {
+        case let .success((response, _)):
+            return .done(response: response)
+        case let .failure(error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
 }


### PR DESCRIPTION
### Problem
It isn't currently possible to directly access a channel related to a lecture from the details screen of that lecture. Users need to navigate back to the Lecture List, switch to the Messages Tab, expand the Lectures section, find the corresponding channel and then tap it. That's 5 steps.

### Solution
We add a button to directly navigate to a Lecture's channel from within the details view. That's one step.

<img src="https://github.com/user-attachments/assets/a89fa106-102d-4421-b382-87d60f02c3b0" alt="Lecture Details" width="300">

### New vs Old
<video src="https://github.com/user-attachments/assets/f005a8db-04fe-483c-9246-fa10db8e69b7">