### PR TITLE
`Communication`: Add favorite and start DM button to info sheet

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -137,6 +137,7 @@
 "createdOnLabel" = "Created on: %s";
 "addFavorite" = "Add to Favorites";
 "removeFavorite" = "Remove from Favorites";
+"sendMessage" = "Send Message";
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -135,6 +135,8 @@
 "moreInfoLabel" = "More info";
 "createdByLabel" = "Created by: %s";
 "createdOnLabel" = "Created on: %s";
+"addFavorite" = "Add to Favorites";
+"removeFavorite" = "Remove from Favorites";
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -228,7 +228,7 @@ extension ConversationInfoSheetViewModel {
         }
     }
 
-    func setIsConversationFavorite(isFavorite: Bool) async -> Bool {
+    func setIsConversationFavorite(isFavorite: Bool) async {
         isLoading = true
         let result = await messagesService.updateIsConversationFavorite(for: course.id, and: conversation.id, isFavorite: isFavorite)
         isLoading = false
@@ -236,7 +236,7 @@ extension ConversationInfoSheetViewModel {
         case .notStarted, .loading:
             break
         case .success:
-            return true
+            toggleChannelIsFavorite()
         case .failure(let error):
             if let apiClientError = error as? APIClientError {
                 presentError(userFacingError: UserFacingError(error: apiClientError))
@@ -244,6 +244,18 @@ extension ConversationInfoSheetViewModel {
                 presentError(userFacingError: UserFacingError(title: error.localizedDescription))
             }
         }
-        return false
+    }
+
+    private func toggleChannelIsFavorite() {
+        if var convo = conversation.baseConversation as? Channel {
+            convo.isFavorite?.toggle()
+            conversation = .channel(conversation: convo)
+        } else if var convo = conversation.baseConversation as? GroupChat {
+            convo.isFavorite?.toggle()
+            conversation = .groupChat(conversation: convo)
+        } else if var convo = conversation.baseConversation as? OneToOneChat {
+            convo.isFavorite?.toggle()
+            conversation = .oneToOneChat(conversation: convo)
+        }
     }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -10,6 +10,7 @@ import Common
 import UserStore
 import SharedModels
 import SwiftUI
+import APIClient
 
 @MainActor
 class ConversationInfoSheetViewModel: BaseViewModel {
@@ -225,5 +226,24 @@ extension ConversationInfoSheetViewModel {
         case .done(let response):
             conversation = response
         }
+    }
+
+    func setIsConversationFavorite(isFavorite: Bool) async -> Bool {
+        isLoading = true
+        let result = await messagesService.updateIsConversationFavorite(for: course.id, and: conversation.id, isFavorite: isFavorite)
+        isLoading = false
+        switch result {
+        case .notStarted, .loading:
+            break
+        case .success:
+            return true
+        case .failure(let error):
+            if let apiClientError = error as? APIClientError {
+                presentError(userFacingError: UserFacingError(error: apiClientError))
+            } else {
+                presentError(userFacingError: UserFacingError(title: error.localizedDescription))
+            }
+        }
+        return false
     }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -11,6 +11,7 @@ import UserStore
 import SharedModels
 import SwiftUI
 import APIClient
+import Navigation
 
 @MainActor
 class ConversationInfoSheetViewModel: BaseViewModel {
@@ -256,6 +257,18 @@ extension ConversationInfoSheetViewModel {
         } else if var convo = conversation.baseConversation as? OneToOneChat {
             convo.isFavorite?.toggle()
             conversation = .oneToOneChat(conversation: convo)
+        }
+    }
+
+    func sendMessageToUser(with login: String, navigationController: NavigationController, completion: @escaping () -> Void) {
+        isLoading = true
+        Task {
+            let messageCellModel = MessageCellModel(course: course, conversationPath: nil, isHeaderVisible: false, roundBottomCorners: false, retryButtonAction: {})
+            if let conversation = await messageCellModel.getOneToOneChatOrCreate(login: login) {
+                navigationController.path.append(ConversationPath(conversation: conversation, coursePath: CoursePath(course: course)))
+                completion()
+            }
+            isLoading = false
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -137,7 +137,8 @@ private extension ConversationInfoSheetView {
                     ForEach(members, id: \.id) { member in
                         if let name = member.name {
                             Menu {
-                                if let login = member.login {
+                                if let login = member.login,
+                                   !(conversation.baseConversation is OneToOneChat) {
                                     Button(R.string.localizable.sendMessage(), systemImage: "bubble.left.fill") {
                                         viewModel.sendMessageToUser(with: login, navigationController: navigationController) {
                                             dismiss()

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -145,16 +145,7 @@ private extension ConversationInfoSheetView {
                                     }
                                 }
                                 Divider()
-                                if UserSessionFactory.shared.user?.login != member.login,
-                                   viewModel.canRemoveUsers {
-                                    Button(R.string.localizable.removeUserButtonLabel(), systemImage: "person.badge.minus", role: .destructive) {
-                                        viewModel.isLoading = true
-                                        Task {
-                                            await viewModel.removeMemberFromConversation(member: member)
-                                            viewModel.isLoading = false
-                                        }
-                                    }
-                                }
+                                removeUserButton(member: member)
                             } label: {
                                 HStack {
                                     Text(name)
@@ -163,7 +154,10 @@ private extension ConversationInfoSheetView {
                                         Chip(text: R.string.localizable.youLabel(), backgroundColor: .Artemis.artemisBlue)
                                     }
                                 }
-                                .foregroundStyle(.primary)
+                            }
+                            .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing) {
+                                removeUserButton(member: member)
                             }
                         }
                     }
@@ -172,6 +166,20 @@ private extension ConversationInfoSheetView {
                 Text(R.string.localizable.membersLabel(conversation.baseConversation.numberOfMembers ?? 0))
             } footer: {
                 pageActions
+            }
+        }
+    }
+
+    @ViewBuilder
+    func removeUserButton(member: ConversationUser) -> some View {
+        if UserSessionFactory.shared.user?.login != member.login,
+           viewModel.canRemoveUsers {
+            Button(R.string.localizable.removeUserButtonLabel(), systemImage: "person.badge.minus", role: .destructive) {
+                viewModel.isLoading = true
+                Task {
+                    await viewModel.removeMemberFromConversation(member: member)
+                    viewModel.isLoading = false
+                }
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -68,6 +68,18 @@ private extension ConversationInfoSheetView {
                         viewModel.isAddMemberSheetPresented = true
                     }
                 }
+
+                let isFavorite = conversation.baseConversation.isFavorite ?? false
+                Button(isFavorite ? R.string.localizable.removeFavorite() : R.string.localizable.addFavorite(), systemImage: "heart") {
+                    Task {
+                        if await viewModel.setIsConversationFavorite(isFavorite: !isFavorite) {
+                            toggleChannelFavorite()
+                        }
+                    }
+                }
+                .symbolVariant(isFavorite ? .slash.fill : .fill)
+                .foregroundStyle(.orange)
+
                 if let channel = conversation.baseConversation as? Channel,
                    channel.hasChannelModerationRights ?? false {
                     if channel.isArchived ?? false {
@@ -115,6 +127,19 @@ private extension ConversationInfoSheetView {
             } content: {
                 CreateOrAddToChatView(courseId: viewModel.course.id, configuration: .addToChat(conversation))
             }
+        }
+    }
+
+    func toggleChannelFavorite() {
+        if var convo = conversation.baseConversation as? Channel {
+            convo.isFavorite?.toggle()
+            conversation = .channel(conversation: convo)
+        } else if var convo = conversation.baseConversation as? GroupChat {
+            convo.isFavorite?.toggle()
+            conversation = .groupChat(conversation: convo)
+        } else if var convo = conversation.baseConversation as? OneToOneChat {
+            convo.isFavorite?.toggle()
+            conversation = .oneToOneChat(conversation: convo)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -136,17 +136,18 @@ private extension ConversationInfoSheetView {
                 } content: { members in
                     ForEach(members, id: \.id) { member in
                         if let name = member.name {
-                            HStack {
-                                Text(name)
-                                Spacer()
-                                if UserSessionFactory.shared.user?.login == member.login {
-                                    Chip(text: R.string.localizable.youLabel(), backgroundColor: .Artemis.artemisBlue)
+                            Menu {
+                                if let login = member.login {
+                                    Button(R.string.localizable.sendMessage(), systemImage: "bubble.left.fill") {
+                                        viewModel.sendMessageToUser(with: login, navigationController: navigationController) {
+                                            dismiss()
+                                        }
+                                    }
                                 }
-                            }
-                            .contextMenu {
+                                Divider()
                                 if UserSessionFactory.shared.user?.login != member.login,
                                    viewModel.canRemoveUsers {
-                                    Button(R.string.localizable.removeUserButtonLabel()) {
+                                    Button(R.string.localizable.removeUserButtonLabel(), systemImage: "person.badge.minus", role: .destructive) {
                                         viewModel.isLoading = true
                                         Task {
                                             await viewModel.removeMemberFromConversation(member: member)
@@ -154,6 +155,15 @@ private extension ConversationInfoSheetView {
                                         }
                                     }
                                 }
+                            } label: {
+                                HStack {
+                                    Text(name)
+                                    Spacer()
+                                    if UserSessionFactory.shared.user?.login == member.login {
+                                        Chip(text: R.string.localizable.youLabel(), backgroundColor: .Artemis.artemisBlue)
+                                    }
+                                }
+                                .foregroundStyle(.primary)
                             }
                         }
                     }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -72,9 +72,7 @@ private extension ConversationInfoSheetView {
                 let isFavorite = conversation.baseConversation.isFavorite ?? false
                 Button(isFavorite ? R.string.localizable.removeFavorite() : R.string.localizable.addFavorite(), systemImage: "heart") {
                     Task {
-                        if await viewModel.setIsConversationFavorite(isFavorite: !isFavorite) {
-                            toggleChannelFavorite()
-                        }
+                        await viewModel.setIsConversationFavorite(isFavorite: !isFavorite)
                     }
                 }
                 .symbolVariant(isFavorite ? .slash.fill : .fill)
@@ -127,19 +125,6 @@ private extension ConversationInfoSheetView {
             } content: {
                 CreateOrAddToChatView(courseId: viewModel.course.id, configuration: .addToChat(conversation))
             }
-        }
-    }
-
-    func toggleChannelFavorite() {
-        if var convo = conversation.baseConversation as? Channel {
-            convo.isFavorite?.toggle()
-            conversation = .channel(conversation: convo)
-        } else if var convo = conversation.baseConversation as? GroupChat {
-            convo.isFavorite?.toggle()
-            conversation = .groupChat(conversation: convo)
-        } else if var convo = conversation.baseConversation as? OneToOneChat {
-            convo.isFavorite?.toggle()
-            conversation = .oneToOneChat(conversation: convo)
         }
     }
 


### PR DESCRIPTION
### Problem
Two common actions cannot be started from the conversation info sheet: Marking the conversation as favorite, and starting a OneToOne Chat with a user from the member list. Currently, both of these require closing the sheet, navigating back to the conversation list, and then performing the action from there manually.

### Solution
We add one/two click buttons for these actions.

Under Channel Settings, we add a Mark as Favorite button.
<img src="https://github.com/user-attachments/assets/62165e0e-75fb-4c6d-b395-f92b6c4dbe12" alt="Favorite Button" width="250">

For the member list, we add a tap action which presents a Send Message Button. We also introduce a swipe action for removing users.
<img src="https://github.com/user-attachments/assets/ce417287-5429-42ef-b322-2e317161e5b9" alt="New Button" width="250"> <img src="https://github.com/user-attachments/assets/4ae79159-d547-40f7-8d2a-cbb7a342d4e0" alt="New Swipe Gesture" width="250">

