### PR TITLE
`Communication`,`Exercises`: Navigate to associated channels

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -47,6 +47,7 @@ public struct ExerciseDetailView: View {
         }
         .task {
             await viewModel.loadExercise()
+            await viewModel.loadAssociatedChannel()
         }
         .refreshable {
             await viewModel.refreshExercise()
@@ -215,6 +216,19 @@ private extension ExerciseDetailView {
                 ExerciseDetailCell(descriptionText: R.string.localizable.categories()) {
                     ForEach(categories, id: \.category) { category in
                         Chip(text: category.category, backgroundColor: UIColor(hexString: category.colorCode).suColor, padding: .s)
+                    }
+                }
+            }
+
+            if let channel = viewModel.channel.value {
+                Divider()
+                    .frame(height: 1.0)
+                    .overlay(Color.Artemis.artemisBlue)
+
+                ExerciseDetailCell(descriptionText: R.string.localizable.discussion() + ":") {
+                    NavigationLink(value: ConversationPath(conversation: .channel(conversation: channel),
+                                                           coursePath: .init(id: viewModel.courseId))) {
+                        Text("\(channel.conversationName) \(Image(systemName: "chevron.forward"))")
                     }
                 }
             }

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailViewModel.swift
@@ -17,6 +17,7 @@ final class ExerciseDetailViewModel {
     let exerciseId: Int
 
     var exercise: DataState<Exercise>
+    var channel: DataState<Channel> = .loading
 
     var isFeedbackPresented = false
     var latestResultId: Int?
@@ -75,6 +76,10 @@ final class ExerciseDetailViewModel {
         }
         // Force WebView to reload
         webViewId = UUID()
+    }
+
+    func loadAssociatedChannel() async {
+        channel = await ExerciseChannelServiceFactory.shared.getAssociatedChannel(for: exerciseId, in: courseId)
     }
 
     private func setParticipationAndResultId(from exercise: Exercise) {

--- a/ArtemisKit/Sources/CourseView/Services/ExerciseService/ExerciseChannelService.swift
+++ b/ArtemisKit/Sources/CourseView/Services/ExerciseService/ExerciseChannelService.swift
@@ -1,0 +1,18 @@
+//
+//  ExerciseChannelService.swift
+//  
+//
+//  Created by Anian Schleyer on 18.08.24.
+//
+
+import Foundation
+import Common
+import SharedModels
+
+protocol ExerciseChannelService {
+    func getAssociatedChannel(for exerciseId: Int, in courseId: Int) async -> DataState<Channel>
+}
+
+enum ExerciseChannelServiceFactory {
+    static let shared: ExerciseChannelService = ExerciseChannelServiceImpl()
+}

--- a/ArtemisKit/Sources/CourseView/Services/ExerciseService/ExerciseChannelServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseView/Services/ExerciseService/ExerciseChannelServiceImpl.swift
@@ -1,0 +1,41 @@
+//
+//  ExerciseChannelServiceImpl.swift
+//
+//
+//  Created by Anian Schleyer on 18.08.24.
+//
+
+import APIClient
+import Common
+import SharedModels
+
+struct ExerciseChannelServiceImpl: ExerciseChannelService {
+
+    let client = APIClient()
+
+    struct GetExerciseChannelRequest: APIRequest {
+        typealias Response = Channel
+
+        let courseId: Int
+        let exerciseId: Int
+
+        var method: HTTPMethod {
+            .get
+        }
+
+        var resourceName: String {
+            "api/courses/\(courseId)/exercises/\(exerciseId)/channel"
+        }
+    }
+
+    func getAssociatedChannel(for exerciseId: Int, in courseId: Int) async -> DataState<Channel> {
+        let result = await client.sendRequest(GetExerciseChannelRequest(courseId: courseId, exerciseId: exerciseId))
+
+        switch result {
+        case let .success((response, _)):
+            return .done(response: response)
+        case let .failure(error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+}


### PR DESCRIPTION
### Problem
It isn't currently possible to directly access a channel related to an exercise from the details screen of that exercise. Users need to navigate back to the Exercise List, switch to the Messages Tab, expand the Exercise section, find the corresponding channel and then tap it. That's 5 steps.

### Solution
We add a button to directly navigate to an Exercises's channel from within the details view. That's one step.

<img src="https://github.com/user-attachments/assets/38d843ad-a778-4cba-b8ae-4baf06ab6b3f" alt="Exercise Details" width="300">

### New vs Old
<video src="https://github.com/user-attachments/assets/acdf0a3b-3530-4c92-a3a1-8f729603b2ff">