### PR TITLE
`Notifications`: In-app notifications not navigating to correct targets

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "a00a22ce4fec80a6c9c05ba14c7f65fa85206fd5",
+        "revision" : "4ddccb661a2a9c01972d97e738872e1dcc8b68f2",
         "version" : "14.0.2"
       }
     },
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
-        "version" : "1.8.2"
+        "revision" : "678d442c6f7828def400a70ae15968aef67ef52d",
+        "version" : "1.8.3"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
       "state" : {
-        "revision" : "9a8119b37e09a770367eeb26e05267c75d854053",
-        "version" : "2.3.1"
+        "revision" : "55441810c0f678c78ed7e2ebd46dde89228e02fc",
+        "version" : "2.4.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "9b7ed6485832f30f7e8e6c0dbffdc5a6592b026a",
-        "version" : "14.0.1"
+        "revision" : "a00a22ce4fec80a6c9c05ba14c7f65fa85206fd5",
+        "version" : "14.0.2"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.1")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.2")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Navigation/Deeplinks/Handlers/MessageHandler.swift
+++ b/ArtemisKit/Sources/Navigation/Deeplinks/Handlers/MessageHandler.swift
@@ -16,7 +16,7 @@ struct MessageHandler: Deeplink {
         guard let indexOfCourseId = url.pathComponents.firstIndex(where: { $0 == "courses" }),
               url.pathComponents.count > indexOfCourseId + 1,
               let courseId = Int(url.pathComponents[indexOfCourseId + 1]),
-              url.pathComponents.contains("messages"),
+              url.pathComponents.contains("communication"),
               let urlComponent = URLComponents(string: url.absoluteString),
               let conversationIdString = urlComponent.queryItems?.first(where: { $0.name == "conversationId" })?.value,
               let conversationId = Int64(conversationIdString) else { return nil }

--- a/ArtemisKit/Sources/Navigation/Deeplinks/Handlers/MessagesHandler.swift
+++ b/ArtemisKit/Sources/Navigation/Deeplinks/Handlers/MessagesHandler.swift
@@ -15,7 +15,7 @@ struct MessagesHandler: Deeplink {
         guard let indexOfCourseId = url.pathComponents.firstIndex(where: { $0 == "courses" }),
               url.pathComponents.count > indexOfCourseId + 1,
               let courseId = Int(url.pathComponents[indexOfCourseId + 1]),
-              url.pathComponents.contains("messages") else { return nil }
+              url.pathComponents.contains("communication") else { return nil }
 
         return MessagesHandler(courseId: courseId)
     }


### PR DESCRIPTION
### Problem
Some notifications for Messages/Announcements don't navigate to the correct destination inside the app. This is because we still reference `/messages` in some places, but `/communication` in others.

Some notifications are not displayed at all.


### Solution
By unifying everything under `/communication`, navigation works correctly again.

By making sure we use the correct content data, we can show the missing notifications.

- [x] [Core Modules PR](https://github.com/ls1intum/artemis-ios-core-modules/pull/71) needs to be merged and released first, then bump version number here