### PR TITLE
`Communication`: Change NavLink Title from Discussion to Communication

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -225,7 +225,7 @@ private extension ExerciseDetailView {
                     .frame(height: 1.0)
                     .overlay(Color.Artemis.artemisBlue)
 
-                ExerciseDetailCell(descriptionText: R.string.localizable.discussion() + ":") {
+                ExerciseDetailCell(descriptionText: R.string.localizable.communication() + ":") {
                     NavigationLink(value: ConversationPath(conversation: .channel(conversation: channel),
                                                            coursePath: .init(id: viewModel.courseId))) {
                         Text("\(channel.conversationName) \(Image(systemName: "chevron.forward"))")

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -60,7 +60,7 @@ public struct LectureDetailView: View {
                             }
                         }
                         if let channel = viewModel.channel.value {
-                            Text(R.string.localizable.discussion())
+                            Text(R.string.localizable.communication())
                                 .font(.headline)
                             ChannelCell(courseId: viewModel.courseId, channel: channel)
                         }

--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -96,4 +96,4 @@
 "lectureUnits" = "Lecture Units";
 "lecturesGroupTitle" = "%s (Lectures: %i)";
 "attachments" = "Attachments";
-"discussion" = "Discussion";
+"communication" = "Communication";


### PR DESCRIPTION
We want to use consistent wording between the iOS app and the web client, thus we refer to a channel associated to a lecture/exercise with "Communication" instead of "Channel".