### PR TITLE
`Notifications`: Fix wrong content in notifications and add missing targets

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "d628c9282f4b486fd01f9361e0f8ce8de83ca19f",
+        "revision" : "b6456ffac746054f34e53a3ea42987b3c06e7c70",
         "version" : "14.0.3"
       }
     },

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "4ddccb661a2a9c01972d97e738872e1dcc8b68f2",
-        "version" : "14.0.2"
+        "revision" : "d628c9282f4b486fd01f9361e0f8ce8de83ca19f",
+        "version" : "14.0.3"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.2")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.0.3")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [


### PR DESCRIPTION
### Problem
Exercise and Lecture Post notifications show the wrong content. We fix this.
<img src="https://github.com/user-attachments/assets/41b6db5b-96d0-42ca-8a06-363858b4f1c5" width="300">

These and reply notifications then show a "This link is not supported by the app" error when opened. We fix this as well.

Same thing for new DM Notifications. These currently show a "Link not supported" error as well – instead we now open the associated conversation.