### PR TITLE
`Communication`: Fix header disappearing after deleting first message

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -40,6 +40,7 @@ struct ConversationDaySection: View {
                 .id(index == messages.count - 1 ? nil : message.id)
             }
         }
+        .id(messages)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationDaySection.swift
@@ -40,6 +40,8 @@ struct ConversationDaySection: View {
                 .id(index == messages.count - 1 ? nil : message.id)
             }
         }
+        // We have to reload this view when a message is deleted
+        // to ensure that continuing messages are correctly (un)merged
         .id(messages)
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -164,6 +164,7 @@ private extension MessageDetailView {
                         }
                     }
             }
+            .id(message.answers)
             .environment(\.isOriginalMessageAuthor, message.isCurrentUserAuthor)
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -164,6 +164,8 @@ private extension MessageDetailView {
                         }
                     }
             }
+            // We have to reload this view when a message is deleted
+            // to ensure that continuing messages are correctly (un)merged
             .id(message.answers)
             .environment(\.isOriginalMessageAuthor, message.isCurrentUserAuthor)
         }


### PR DESCRIPTION
### Problem
When deleting the first message of a set of multiple messages that were combined into one (visually), the header disappears as well.

<video src="https://github.com/user-attachments/assets/bb78274d-b135-4ce9-a427-709f2ac2353c" alt="Demo of Bug" width="300"></video>

### Solution
We give the corresponding views an id that changes as soon as a message is deleted. This way, the view has to be re-evaluated.