### PR TITLE
`Communication`: Fix edit message toolbar/screen

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -203,6 +203,7 @@ struct MessageActions: View {
                     }
                 }
             }
+            .fontWeight(.regular)
             .presentationDetents([.height(200), .medium])
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -33,6 +33,12 @@ struct SendMessageView: View {
             }
             textField
                 .padding(isFocused ? [.horizontal, .bottom] : .all, .l)
+            if viewModel.isEditing && isFocused {
+                keyboardToolbarContent
+                    .padding(.horizontal, .l)
+                    .padding(.vertical, .m)
+                    .background(.bar)
+            }
         }
         .onAppear {
             viewModel.performOnAppear()
@@ -96,8 +102,10 @@ private extension SendMessageView {
             .lineLimit(10)
             .focused($isFocused)
             .toolbar {
-                ToolbarItem(placement: .keyboard) {
-                    keyboardToolbarContent
+                if isFocused && !viewModel.isEditing {
+                    ToolbarItem(placement: .keyboard) {
+                        keyboardToolbarContent
+                    }
                 }
             }
             if !isFocused {


### PR DESCRIPTION
### Problem
The sheet displayed to edit a message has two issues.
1. The Toolbar for styles/mentions doesn't work correctly. It is grayed out, but the buttons are tappable and interact with the wrong text field (the one for sending a message). Thus, it doesn't work for the edit message text field and the changes are inserted elsewhere. This is due to the fact that a toolbar for `.keyboard` can only be placed once.
2. The Buttons and Text are bold.

<video alt="Demo of Bug" width="300" src="https://github.com/user-attachments/assets/89a630b9-00c9-4a67-ab98-5fd428052df6"></video>


### Before vs After
<img src="https://github.com/user-attachments/assets/19eff5d1-29ef-4ac4-97a7-ceddb20cd354" alt="Before" width="300">
<img src="https://github.com/user-attachments/assets/1d962d75-60ca-42d8-833b-f0d911b5b81b" alt="After" width="300">