### PR TITLE
`Communication`: Redesign Message Action Sheet

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -28,6 +28,8 @@ class ConversationViewModel: BaseViewModel {
     @Published var offlineMessages: [ConversationOfflineMessageModel] = []
 
     @Published var isConversationInfoSheetPresented = false
+    @Published var selectedMessageId: Int64?
+    var isPerformingMessageAction = false
 
     var isAllowedToPost: Bool {
         guard let channel = conversation.baseConversation as? Channel else {

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
@@ -21,7 +21,7 @@ final class MessageCellModel {
     let roundBottomCorners: Bool
     let retryButtonAction: (() -> Void)?
 
-    var isActionSheetPresented = false
+    var showReactionsPopover = false
     var isDetectingLongPress = false
 
     private let messagesService: MessagesService
@@ -57,9 +57,9 @@ extension MessageCellModel {
         return lastReadDate < creationDate && userSession.user?.id != authorId
     }
 
-    var roundedCorners: RectangleCornerRadii {
-        let top: CGFloat = isHeaderVisible ? .m : 0
-        let bottom: CGFloat = roundBottomCorners ? .m : 0
+    func roundedCorners(isSelected: Bool) -> RectangleCornerRadii {
+        let top: CGFloat = isHeaderVisible || isSelected ? .m : 0
+        let bottom: CGFloat = roundBottomCorners || isSelected ? .m : 0
         return .init(topLeading: top, bottomLeading: bottom, bottomTrailing: bottom, topTrailing: top)
     }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -59,6 +59,7 @@ public struct ConversationView: View {
                         }
                     }
                     .coordinateSpace(name: "pullToRefresh")
+                    .defaultScrollAnchor(.bottom)
                     .onChange(of: viewModel.messages, initial: true) {
                         #warning("does not work correctly when loadFurtherMessages is called -> is called to early")
                         if let id = viewModel.shouldScrollToId {
@@ -67,6 +68,7 @@ public struct ConversationView: View {
                             }
                         }
                     }
+                    .animation(.default, value: viewModel.selectedMessageId)
                 }
             }
             if viewModel.isAllowedToPost {

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -69,6 +69,14 @@ public struct ConversationView: View {
                         }
                     }
                     .animation(.default, value: viewModel.selectedMessageId)
+                    .onChange(of: viewModel.selectedMessageId) { _, newValue in
+                        if let newValue {
+                            // Make sure context menu is on screen
+                            withAnimation {
+                                value.scrollTo(newValue)
+                            }
+                        }
+                    }
                 }
             }
             if viewModel.isAllowedToPost {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -389,6 +389,7 @@ private struct ContextMenuLabelStyle: LabelStyle {
         }
         .padding(.horizontal)
         .padding(.vertical, .s)
+        .contentShape(.rect)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -262,7 +262,7 @@ struct MessageActions: View {
         func togglePinned() {
             guard let message = message.value as? Message else { return }
             Task {
-                var result = await viewModel.togglePinned(for: message)
+                let result = await viewModel.togglePinned(for: message)
                 let oldRole = message.authorRole
                 if var newMessageResult = result.value as? Message {
                     newMessageResult.authorRole = oldRole

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -348,8 +348,6 @@ struct MessageReactionsPopover: View {
         .buttonStyle(.plain)
         .font(.headline)
         .symbolVariant(.fill)
-        .imageScale(.large)
-        .fontWeight(.bold)
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -445,23 +445,6 @@ private struct EmojiPickerButton: View {
     }
 }
 
-// MARK: - Environment+AutoDismiss
-
-private enum SheetAutoDismissEnvironmentKey: EnvironmentKey {
-    static let defaultValue = true
-}
-
-extension EnvironmentValues {
-    var allowAutoDismiss: Bool {
-        get {
-            self[SheetAutoDismissEnvironmentKey.self]
-        }
-        set {
-            self[SheetAutoDismissEnvironmentKey.self] = newValue
-        }
-    }
-}
-
 // MARK: - Environment+OriginalPostAuthor
 
 private enum OriginalPostAuthorEnvironmentKey: EnvironmentKey {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -248,7 +248,7 @@ private extension MessageCell {
                                conversationPath: viewModel.conversationPath)
             .frame(maxWidth: .infinity)
             .padding(.bottom, 5)
-            .transition(.scale(0, anchor: .top))
+            .transition(.scale(0, anchor: .top).combined(with: .opacity))
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -228,7 +228,7 @@ private extension MessageCell {
     @ViewBuilder var replyButtonIfAvailable: some View {
         if let message = message.value as? Message,
            let answerCount = message.answers?.count, answerCount > 0,
-           viewModel.conversationPath != nil {
+           viewModel.conversationPath != nil, !isSelected {
             Button {
                 openThread(showErrorOnFailure: true)
             } label: {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -390,6 +390,12 @@ struct ReactionsPopoverModifier: ViewModifier {
                 .presentationBackgroundInteraction(.enabled)
                 .presentationBackground(.bar)
             }
+            .onChange(of: conversationViewModel.selectedMessageId) {
+                // Reset recations popover presentation when message is no longer selected
+                if conversationViewModel.selectedMessageId == nil && viewModel.showReactionsPopover {
+                    viewModel.showReactionsPopover = false
+                }
+            }
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -62,9 +62,11 @@ struct MessageCell: View {
                                            conversationViewModel: conversationViewModel,
                                            message: $message))
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)
-        .id(message.value?.id.description)
         .padding(.horizontal, useFullWidth ? 0 : (.m + .l) / 2)
         .opacity(opacity)
+        /// Ensure the message is fully visible when selected, space for reactions popover
+        .padding(.top, isSelected ? 100 : 0)
+        .id(message.value?.id.description)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -248,7 +248,7 @@ private extension MessageCell {
                                conversationPath: viewModel.conversationPath)
             .frame(maxWidth: .infinity)
             .padding(.bottom, 5)
-            .transition(.scale)
+            .transition(.scale(0, anchor: .top))
         }
     }
 
@@ -361,7 +361,7 @@ struct ReactionsPopoverModifier: ViewModifier {
     let viewModel: MessageCellModel
     let conversationViewModel: ConversationViewModel
     @Binding var message: DataState<BaseMessage>
-    
+
     func body(content: Content) -> some View {
         content
             .popover(

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -17,7 +17,6 @@ struct MessageDetailView: View {
     @ObservedObject var viewModel: ConversationViewModel
     @Binding private var message: DataState<BaseMessage>
 
-    @State private var isMessageActionSheetPresented = false
     @State private var viewRerenderWorkaround = false
 
     private let messageId: Int64?
@@ -91,15 +90,6 @@ private extension MessageDetailView {
         )
         .environment(\.isEmojiPickerButtonVisible, true)
         .environment(\.messageUseFullWidth, true)
-        .onLongPressGesture(maximumDistance: 30) {
-            let impactMed = UIImpactFeedbackGenerator(style: .heavy)
-            impactMed.impactOccurred()
-            isMessageActionSheetPresented = true
-        }
-        .sheet(isPresented: $isMessageActionSheetPresented) {
-            MessageActionSheet(viewModel: viewModel, message: $message, conversationPath: nil)
-                .presentationDetents([.height(350), .large])
-        }
     }
 
     @ViewBuilder var divider: some View {
@@ -167,6 +157,7 @@ private extension MessageDetailView {
             // We have to reload this view when a message is deleted
             // to ensure that continuing messages are correctly (un)merged
             .id(message.answers)
+            .animation(.default, value: viewModel.selectedMessageId)
             .environment(\.isOriginalMessageAuthor, message.isCurrentUserAuthor)
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -158,6 +158,14 @@ private extension MessageDetailView {
             // to ensure that continuing messages are correctly (un)merged
             .id(message.answers)
             .animation(.default, value: viewModel.selectedMessageId)
+            .onChange(of: viewModel.selectedMessageId) { _, newValue in
+                if let newValue {
+                    // Make sure context menu is on screen
+                    withAnimation {
+                        proxy.scrollTo(newValue)
+                    }
+                }
+            }
             .environment(\.isOriginalMessageAuthor, message.isCurrentUserAuthor)
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -39,6 +39,7 @@ struct MessageDetailView: View {
                         top(message: message)
                         answers(of: message, proxy: proxy)
                     }
+                    .defaultScrollAnchor(.bottom)
                 }
                 if !((viewModel.conversation.baseConversation as? Channel)?.isArchived ?? false),
                    let message = message as? Message {
@@ -131,7 +132,7 @@ private extension MessageDetailView {
                     $0.creationDate ?? .tomorrow < $1.creationDate ?? .yesterday
                 }
                 let totalMessages = sortedArray.count
-                ForEach(Array(sortedArray.enumerated()), id: \.1) { index, answerMessage in
+                ForEach(Array(sortedArray.enumerated()), id: \.1.id) { index, answerMessage in
                     let isHeaderVisible = !answerMessage.isContinuation(of: sortedArray[safe: index - 1])
                     let needsRoundedCorners = !(sortedArray[safe: index + 1]?.isContinuation(of: answerMessage) ?? false)
                     MessageCellWrapper(
@@ -139,7 +140,7 @@ private extension MessageDetailView {
                         answerMessage: answerMessage,
                         isHeaderVisible: isHeaderVisible,
                         roundBottomCorners: needsRoundedCorners)
-                    .id(index == totalMessages - 1 ? nil : answerMessage)
+                    .id(index == totalMessages - 1 ? nil : answerMessage.id)
                 }
                 Spacer()
                     .id("bottom")
@@ -162,7 +163,7 @@ private extension MessageDetailView {
                 if let newValue {
                     // Make sure context menu is on screen
                     withAnimation {
-                        proxy.scrollTo(newValue)
+                        proxy.scrollTo(newValue.description)
                     }
                 }
             }


### PR DESCRIPTION
The current sheet shown with Message Actions does not match the style used in the rest of the app and is different to other messengers like iMessage, Telegram or Signal.

<img src="https://github.com/user-attachments/assets/f5901259-2b0e-4c0d-a76d-4e0ee5b02d7d" alt="Old Sheet" width="300">

### Proposed Solution
<img src="https://github.com/user-attachments/assets/97bb16dc-bd24-4613-a07b-63206254dff9" alt="New Context Menu" width="300">
<img src="https://github.com/user-attachments/assets/e6a5952f-c80a-4d39-9797-0413b98947d6" alt="Demo" width="300">
