### PR TITLE
`Communication`: Show unread conversations with bolder title

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -40,6 +40,7 @@ struct ConversationRow<T: BaseConversation>: View {
                 Label {
                     HStack(alignment: .firstTextBaseline) {
                         Text(conversationDisplayName)
+                            .fontWeight(conversation.unreadMessagesCount ?? 0 > 0 ? .semibold : .regular)
                         Spacer()
                         if let unreadCount = conversation.unreadMessagesCount, unreadCount > 0 {
                             Text(unreadCount, format: .number.notation(.compactName))


### PR DESCRIPTION
Conversations currently all look about the same in the conversation list, regardless of whether they have any unread messages or not. With this PR, we add further visual differences to ensure the user can quickly see whether they have unread messages.

### Solution
<img src="https://github.com/user-attachments/assets/fefc7e50-1599-455f-aa5d-081a99fd3901" alt="After" width="250">
<img src="https://github.com/user-attachments/assets/d10b4ebf-a9aa-4a1e-8575-1ff0d0cfe608" alt="After, all chats" width="250">