### PR TITLE
`Courses`: Add Split View Navigation

### DIFF
--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -116,6 +116,9 @@ let package = Package(
                 .product(name: "SharedModels", package: "artemis-ios-core-modules"),
                 .product(name: "SharedServices", package: "artemis-ios-core-modules"),
                 .product(name: "UserStore", package: "artemis-ios-core-modules")
+            ],
+            plugins: [
+                .plugin(name: "RswiftGeneratePublicResources", package: "R.swift")
             ]),
         .target(
             name: "Notifications",

--- a/ArtemisKit/Sources/ArtemisKit/RootView.swift
+++ b/ArtemisKit/Sources/ArtemisKit/RootView.swift
@@ -26,12 +26,12 @@ public struct RootView: View {
             } else {
                 if viewModel.isLoggedIn {
                     if viewModel.didSetupNotifications {
-                        NavigationStack(path: $navigationController.path) {
+                        NavigationStack(path: $navigationController.outerPath) {
                             DashboardView()
                                 .modifier(NavigationDestinationRootViewModifier())
                         }
-                        .onChange(of: navigationController.path) {
-                            log.debug("NavigationController count: \(navigationController.path.count)")
+                        .onChange(of: navigationController.outerPath) {
+                            log.debug("NavigationController count: \(navigationController.outerPath.count)")
                         }
                         .environmentObject(navigationController)
                         .onOpenURL { url in

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -49,6 +49,12 @@ public struct CourseView: View {
         .onChange(of: navigationController.courseTab) {
             searchText = ""
         }
+        .onDisappear {
+            if navigationController.outerPath.count < 2 {
+                // Reset selection if navigating back
+                navigationController.selectedPath = nil
+            }
+        }
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -55,6 +55,15 @@ public struct CourseView: View {
                 navigationController.selectedPath = nil
             }
         }
+        .onAppear {
+            // On iPad, always make Tab Bar opaque
+            // This prevents an issue where the tab bar has content behind it but is transparent
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                let appearance = UITabBarAppearance()
+                appearance.configureWithDefaultBackground()
+                UITabBar.appearance().scrollEdgeAppearance = appearance
+            }
+        }
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -14,6 +14,7 @@ import UserStore
 
 public struct ExerciseDetailView: View {
     @EnvironmentObject var navigationController: NavigationController
+    @Environment(\.horizontalSizeClass) var sizeClass
 
     @State private var viewModel: ExerciseDetailViewModel
 
@@ -52,6 +53,9 @@ public struct ExerciseDetailView: View {
         .refreshable {
             await viewModel.refreshExercise()
         }
+        .navigationBarTitleDisplayMode(.inline)
+        // Hide the course Tab Bar when inside an exercise on iPhone
+        .toolbar(sizeClass == .compact ? .hidden : .automatic, for: .tabBar)
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -224,14 +224,19 @@ private extension ExerciseDetailView {
                 }
             }
 
+            // Communication
             if let channel = viewModel.channel.value {
                 Divider()
                     .frame(height: 1.0)
                     .overlay(Color.Artemis.artemisBlue)
 
                 ExerciseDetailCell(descriptionText: R.string.localizable.communication() + ":") {
-                    NavigationLink(value: ConversationPath(conversation: .channel(conversation: channel),
-                                                           coursePath: .init(id: viewModel.courseId))) {
+                    Button {
+                        navigationController.outerPath.append(
+                            ConversationPath(conversation: .channel(conversation: channel),
+                                             coursePath: .init(id: viewModel.courseId))
+                        )
+                    } label: {
                         let name = channel.conversationName
                         let displayName = name
                             .suffix(name.starts(with: "exercise-") ? name.count - 9 : name.count)

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -150,7 +150,7 @@ struct ExerciseListCell: View {
 
     var body: some View {
         Button {
-            navigationController.path.append(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
+            navigationController.outerPath.append(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
         } label: {
             HStack(alignment: .top, spacing: 0) {
                 if let difficulty = exercise.baseExercise.difficulty {

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -76,8 +76,7 @@ struct ExerciseListView: View {
                         }
                         .id(path.id)
                     } else {
-                        #warning("TODO: Localize")
-                        Text("Select an Exercise")
+                        SelectDetailView()
                     }
                 }
                 .navigationDestination(for: ExercisePath.self) { exercisePath in

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -59,16 +59,7 @@ struct ExerciseListView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        navController.popToRoot()
-                    } label: {
-                        HStack(spacing: .s) {
-                            Image(systemName: "chevron.backward")
-                                .fontWeight(.semibold)
-                            Text("Back")
-                        }
-                        .offset(x: -8)
-                    }
+                    BackToRootButton()
                 }
             }
         } detail: {

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -6,46 +6,100 @@ import Navigation
 import DesignLibrary
 
 struct ExerciseListView: View {
+    @EnvironmentObject var navController: NavigationController
     @ObservedObject var viewModel: CourseViewModel
+    @State private var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
 
     @Binding var searchText: String
 
+    private var selectedExercise: Binding<ExercisePath?> {
+        navController.selectedPathBinding($navController.selectedPath)
+    }
+
     var body: some View {
-        ScrollViewReader { value in
-            List {
-                if searchText.isEmpty {
-                    if weeklyExercises.isEmpty {
-                        ContentUnavailableView(R.string.localizable.exercisesUnavailable(), systemImage: "list.bullet.clipboard")
-                            .listRowSeparator(.hidden)
+        NavigationSplitView(columnVisibility: $columnVisibilty) {
+            ScrollViewReader { value in
+                List(selection: selectedExercise) {
+                    if searchText.isEmpty {
+                        if weeklyExercises.isEmpty {
+                            ContentUnavailableView(R.string.localizable.exercisesUnavailable(), systemImage: "list.bullet.clipboard")
+                                .listRowSeparator(.hidden)
+                        } else {
+                            ForEach(weeklyExercises) { weeklyExercise in
+                                ExerciseListSection(course: viewModel.course, weeklyExercise: weeklyExercise)
+                                    .id(weeklyExercise.id)
+                            }
+                        }
                     } else {
-                        ForEach(weeklyExercises) { weeklyExercise in
-                            ExerciseListSection(course: viewModel.course, weeklyExercise: weeklyExercise)
-                                .id(weeklyExercise.id)
+                        if searchResults.isEmpty {
+                            ContentUnavailableView.search(text: searchText)
+                                .listRowSeparator(.hidden)
+                        } else {
+                            ForEach(searchResults) { exercise in
+                                ExerciseListCell(course: viewModel.course, exercise: exercise)
+                            }
                         }
                     }
-                } else {
-                    if searchResults.isEmpty {
-                        ContentUnavailableView.search(text: searchText)
-                            .listRowSeparator(.hidden)
-                    } else {
-                        ForEach(searchResults) { exercise in
-                            ExerciseListCell(course: viewModel.course, exercise: exercise)
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+                .listRowSpacing(.m)
+                .refreshable {
+                    await viewModel.refreshCourse()
+                }
+                .onChange(of: weeklyExercises) { _, newValue in
+                    withAnimation {
+                        if let id = newValue.first(where: { $0.exercises.first?.baseExercise.dueDate ?? .tomorrow > .now })?.id {
+                            value.scrollTo(id, anchor: .top)
                         }
                     }
                 }
             }
-            .listStyle(.plain)
-            .refreshable {
-                await viewModel.refreshCourse()
+            .navigationTitle(viewModel.course.title ?? R.string.localizable.loading())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        navController.popToRoot()
+                    } label: {
+                        HStack(spacing: .s) {
+                            Image(systemName: "chevron.backward")
+                                .fontWeight(.semibold)
+                            Text("Back")
+                        }
+                        .offset(x: -8)
+                    }
+                }
             }
-            .onChange(of: weeklyExercises) { _, newValue in
-                withAnimation {
-                    if let id = newValue.first(where: { $0.exercises.first?.baseExercise.dueDate ?? .tomorrow > .now })?.id {
-                        value.scrollTo(id, anchor: .top)
+        } detail: {
+            NavigationStack(path: $navController.tabPath) {
+                Group {
+                    if let path = navController.selectedPath as? ExercisePath {
+                        Group {
+                            if let course = path.coursePath.course,
+                               let exercise = path.exercise {
+                                ExerciseDetailView(course: course, exercise: exercise)
+                            } else {
+                                ExerciseDetailView(courseId: path.coursePath.id, exerciseId: path.id)
+                            }
+                        }
+                        .id(path.id)
+                    } else {
+                        #warning("TODO: Localize")
+                        Text("Select an Exercise")
+                    }
+                }
+                .navigationDestination(for: ExercisePath.self) { exercisePath in
+                    if let course = exercisePath.coursePath.course,
+                       let exercise = exercisePath.exercise {
+                        ExerciseDetailView(course: course, exercise: exercise)
+                    } else {
+                        ExerciseDetailView(courseId: exercisePath.coursePath.id, exerciseId: exercisePath.id)
                     }
                 }
             }
         }
+        .toolbar(.hidden, for: .navigationBar)
     }
 }
 
@@ -119,15 +173,12 @@ struct ExerciseListSection: View {
             "\(weeklyExercise.id.description) (Exercises: \(weeklyExercise.exercises.count))",
             isExpanded: $isExpanded
         ) {
-            LazyVStack(spacing: .m) {
-                ForEach(weeklyExercise.exercises) { exercise in
-                    ExerciseListCell(course: course, exercise: exercise)
-                }
+            ForEach(weeklyExercise.exercises) { exercise in
+                ExerciseListCell(course: course, exercise: exercise)
             }
-            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: .l))
         }
         .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: .m, leading: .l, bottom: .m, trailing: .l))
+        .listRowInsets(EdgeInsets(top: .m, leading: 0, bottom: .m, trailing: 0))
     }
 }
 
@@ -149,9 +200,7 @@ struct ExerciseListCell: View {
     }
 
     var body: some View {
-        Button {
-            navigationController.outerPath.append(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
-        } label: {
+        NavigationLink(value: ExercisePath(exercise: exercise, coursePath: CoursePath(course: course))) {
             HStack(alignment: .top, spacing: 0) {
                 if let difficulty = exercise.baseExercise.difficulty {
                     Rectangle()
@@ -165,7 +214,6 @@ struct ExerciseListCell: View {
                             .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
-                            .foregroundColor(Color.Artemis.primaryLabel)
                             .frame(width: .smallImage)
                         Text(exercise.baseExercise.title ?? "")
                             .font(.title3)
@@ -202,10 +250,11 @@ struct ExerciseListCell: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.l)
             }
-            .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
+            .foregroundColor(Color.Artemis.primaryLabel)
         }
-        // Make button style explicit, otherwise, multiple cells may activate a navigation link.
-        .buttonStyle(.plain)
+        .tag(ExercisePath(exercise: exercise, coursePath: CoursePath(course: course)))
+        .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: .m * -1))
+        .listRowBackground(Color.Artemis.exerciseCardBackgroundColor)
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -94,7 +94,7 @@ private struct ChannelCell: View {
 
     var body: some View {
         Button {
-            navigationController.path.append(ConversationPath(id: channel.id, coursePath: CoursePath(id: courseId)))
+            navigationController.outerPath.append(ConversationPath(id: channel.id, coursePath: CoursePath(id: courseId)))
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: .l) {

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -15,6 +15,7 @@ import Navigation
 public struct LectureDetailView: View {
 
     @StateObject private var viewModel: LectureDetailViewModel
+    @Environment(\.horizontalSizeClass) var sizeClass
 
     public init(course: Course, lectureId: Int) {
         self._viewModel = StateObject(wrappedValue: LectureDetailViewModel(course: course, lectureId: lectureId))
@@ -77,12 +78,14 @@ public struct LectureDetailView: View {
                 }
             }
         }
-            .navigationTitle(viewModel.lecture.value?.title ?? R.string.localizable.loading())
-            .navigationBarTitleDisplayMode(.inline)
-            .task {
-                await viewModel.loadLecture()
-            }
-            .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+        .navigationTitle(viewModel.lecture.value?.title ?? R.string.localizable.loading())
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadLecture()
+        }
+        .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+        // Hide the course Tab Bar when inside a lecture on iPhone
+        .toolbar(sizeClass == .compact ? .hidden : .automatic, for: .tabBar)
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -82,8 +82,7 @@ struct LectureListView: View {
                         }
                         .id(path.id)
                     } else {
-                        #warning("TODO: Localize")
-                        Text("Select a Lecture")
+                        SelectDetailView()
                     }
                 }
                 .navigationDestination(for: LecturePath.self) { lecturePath in

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -66,16 +66,7 @@ struct LectureListView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        navController.popToRoot()
-                    } label: {
-                        HStack(spacing: .s) {
-                            Image(systemName: "chevron.backward")
-                                .fontWeight(.semibold)
-                            Text("Back")
-                        }
-                        .offset(x: -8)
-                    }
+                    BackToRootButton()
                 }
             }
         } detail: {

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -211,7 +211,8 @@ private struct LectureListCellView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .padding(.m)
+            .padding(.horizontal, .m)
+            .padding(.vertical, .l)
         }
         .foregroundColor(Color.Artemis.primaryLabel)
         .listRowInsets(EdgeInsets(top: 0, leading: .m * -1, bottom: 0, trailing: .m * -1))

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -11,48 +11,100 @@ import SharedModels
 import SwiftUI
 
 struct LectureListView: View {
+    @EnvironmentObject var navController: NavigationController
     @ObservedObject var viewModel: CourseViewModel
+    @State private var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
 
     @Binding var searchText: String
 
+    private var selectedLecture: Binding<LecturePath?> {
+        navController.selectedPathBinding($navController.selectedPath)
+    }
+
     var body: some View {
-        ScrollViewReader { value in
-            List {
-                if searchText.isEmpty {
-                    if weeklyLectures.isEmpty {
-                        ContentUnavailableView(R.string.localizable.lecturesUnavailable(), systemImage: "character.book.closed")
-                            .listRowSeparator(.hidden)
+        NavigationSplitView(columnVisibility: $columnVisibilty) {
+            ScrollViewReader { value in
+                List(selection: selectedLecture) {
+                    if searchText.isEmpty {
+                        if weeklyLectures.isEmpty {
+                            ContentUnavailableView(R.string.localizable.lecturesUnavailable(), systemImage: "character.book.closed")
+                                .listRowSeparator(.hidden)
+                        } else {
+                            ForEach(weeklyLectures) { weeklyLecture in
+                                LectureListSectionView(course: viewModel.course, weeklyLecture: weeklyLecture)
+                            }
+                        }
                     } else {
-                        ForEach(weeklyLectures) { weeklyLecture in
-                            LectureListSectionView(course: viewModel.course, weeklyLecture: weeklyLecture)
+                        if searchResults.isEmpty {
+                            ContentUnavailableView.search(text: searchText)
+                                .listRowSeparator(.hidden)
+                        } else {
+                            ForEach(searchResults) { lecture in
+                                LectureListCellView(course: viewModel.course, lecture: lecture)
+                            }
                         }
                     }
-                } else {
-                    if searchResults.isEmpty {
-                        ContentUnavailableView.search(text: searchText)
-                            .listRowSeparator(.hidden)
-                    } else {
-                        ForEach(searchResults) { lecture in
-                            LectureListCellView(course: viewModel.course, lecture: lecture)
+                }
+                .listRowSpacing(.m)
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+                .refreshable {
+                    await viewModel.refreshCourse()
+                }
+                .onChange(of: weeklyLectures) { _, newValue in
+                    withAnimation {
+                        let lecture = newValue.first {
+                            $0.lectures.first?.startDate ?? .tomorrow > .now
+                        }
+                        if let id = lecture?.id {
+                            value.scrollTo(id, anchor: .top)
                         }
                     }
                 }
             }
-            .listStyle(.plain)
-            .refreshable {
-                await viewModel.refreshCourse()
-            }
-            .onChange(of: weeklyLectures) { _, newValue in
-                withAnimation {
-                    let lecture = newValue.first {
-                        $0.lectures.first?.startDate ?? .tomorrow > .now
+            .navigationTitle(viewModel.course.title ?? R.string.localizable.loading())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        navController.popToRoot()
+                    } label: {
+                        HStack(spacing: .s) {
+                            Image(systemName: "chevron.backward")
+                                .fontWeight(.semibold)
+                            Text("Back")
+                        }
+                        .offset(x: -8)
                     }
-                    if let id = lecture?.id {
-                        value.scrollTo(id, anchor: .top)
+                }
+            }
+        } detail: {
+            NavigationStack(path: $navController.tabPath) {
+                Group {
+                    if let path = navController.selectedPath as? LecturePath {
+                        Group {
+                            if let course = path.coursePath.course {
+                                LectureDetailView(course: course, lectureId: path.id)
+                            } else {
+                                LectureDetailView(courseId: path.coursePath.id, lectureId: path.id)
+                            }
+                        }
+                        .id(path.id)
+                    } else {
+                        #warning("TODO: Localize")
+                        Text("Select a Lecture")
+                    }
+                }
+                .navigationDestination(for: LecturePath.self) { lecturePath in
+                    if let course = lecturePath.coursePath.course {
+                        LectureDetailView(course: course, lectureId: lecturePath.id)
+                    } else {
+                        LectureDetailView(courseId: lecturePath.coursePath.id, lectureId: lecturePath.id)
                     }
                 }
             }
         }
+        .toolbar(.hidden, for: .navigationBar)
     }
 }
 
@@ -120,15 +172,12 @@ private struct LectureListSectionView: View {
             R.string.localizable.lecturesGroupTitle(weeklyLecture.id.description, weeklyLecture.lectures.count),
             isExpanded: $isExpanded
         ) {
-            LazyVStack(spacing: .m) {
-                ForEach(weeklyLecture.lectures, id: \.id) { lecture in
-                    LectureListCellView(course: course, lecture: lecture)
-                }
+            ForEach(weeklyLecture.lectures, id: \.id) { lecture in
+                LectureListCellView(course: course, lecture: lecture)
             }
-            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: .l))
         }
         .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: .m, leading: .l, bottom: .m, trailing: .l))
+        .listRowInsets(EdgeInsets())
     }
 }
 
@@ -143,30 +192,31 @@ private struct LectureListCellView: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: .m) {
-            HStack(spacing: .l) {
-                lecture.image
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .foregroundColor(Color.Artemis.primaryLabel)
-                    .frame(width: .smallImage)
-                Text(lecture.title ?? "Unknown")
-                    .font(.title3)
-                Spacer()
+        NavigationLink(value: LecturePath(lecture: lecture, coursePath: CoursePath(course: course))) {
+            VStack(alignment: .leading, spacing: .m) {
+                HStack(spacing: .l) {
+                    lecture.image
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: .smallImage)
+                    Text(lecture.title ?? "Unknown")
+                        .font(.title3)
+                    Spacer()
+                }
+                if let startDate = lecture.startDate {
+                    Text("\(startDate.dateOnly) (\(startDate.relative ?? "?"))")
+                } else {
+                    Text(R.string.localizable.noDateAssociated())
+                }
             }
-            if let startDate = lecture.startDate {
-                Text("\(startDate.dateOnly) (\(startDate.relative ?? "?"))")
-            } else {
-                Text(R.string.localizable.noDateAssociated())
-            }
+            .frame(maxWidth: .infinity)
+            .padding(.m)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.l)
-        .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
-        .onTapGesture {
-            navigationController.outerPath.append(LecturePath(lecture: lecture, coursePath: CoursePath(course: course)))
-        }
+        .foregroundColor(Color.Artemis.primaryLabel)
+        .listRowInsets(EdgeInsets(top: 0, leading: .m * -1, bottom: 0, trailing: .m * -1))
+        .listRowBackground(Color.Artemis.exerciseCardBackgroundColor)
+        .tag(LecturePath(lecture: lecture, coursePath: CoursePath(course: course)))
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -165,7 +165,7 @@ private struct LectureListCellView: View {
         .padding(.l)
         .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
         .onTapGesture {
-            navigationController.path.append(LecturePath(lecture: lecture, coursePath: CoursePath(course: course)))
+            navigationController.outerPath.append(LecturePath(lecture: lecture, coursePath: CoursePath(course: course)))
         }
     }
 }

--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -31,7 +31,7 @@ struct CourseGridCell: View {
 
     var body: some View {
         Button {
-            navigationController.path.append(CoursePath(id: courseForDashboard.id))
+            navigationController.outerPath.append(CoursePath(id: courseForDashboard.id))
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 header

--- a/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
@@ -13,6 +13,7 @@ import SwiftUI
 public struct ConversationPathView<Content: View>: View {
     @State var viewModel: ConversationPathViewModel
     let content: (Course, Conversation) -> Content
+    @Environment(\.horizontalSizeClass) var sizeClass
 
     public var body: some View {
         DataStateView(data: $viewModel.conversation) {
@@ -25,6 +26,8 @@ public struct ConversationPathView<Content: View>: View {
         .task {
             await viewModel.loadConversation()
         }
+        // Hide the course Tab Bar when inside a conversation on iPhone
+        .toolbar(sizeClass == .compact ? .hidden : .automatic, for: .tabBar)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -265,7 +265,7 @@ extension ConversationInfoSheetViewModel {
         Task {
             let messageCellModel = MessageCellModel(course: course, conversationPath: nil, isHeaderVisible: false, roundBottomCorners: false, retryButtonAction: {})
             if let conversation = await messageCellModel.getOneToOneChatOrCreate(login: login) {
-                navigationController.path.append(ConversationPath(conversation: conversation, coursePath: CoursePath(course: course)))
+                navigationController.outerPath.append(ConversationPath(conversation: conversation, coursePath: CoursePath(course: course)))
                 completion()
             }
             isLoading = false

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -123,6 +123,7 @@ public struct ConversationView: View {
             }
         }
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -117,7 +117,7 @@ public struct ConversationView: View {
             await viewModel.loadMessages()
         }
         .onDisappear {
-            if navigationController.path.count < 2 {
+            if navigationController.outerPath.count < 2 {
                 // only cancel task if we navigate back
                 viewModel.subscription?.cancel()
             }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActionSheet.swift
@@ -52,7 +52,7 @@ struct MessageActions: View {
                         if allowDismiss {
                             dismiss()
                         }
-                        navigationController.path.append(messagePath)
+                        navigationController.outerPath.append(messagePath)
                     } else {
                         viewModel.presentError(userFacingError: UserFacingError(title: R.string.localizable.detailViewCantBeOpened()))
                     }
@@ -156,8 +156,8 @@ struct MessageActions: View {
                                         dismiss()
                                     }
                                     // if we deleted a Message and are in the MessageDetailView we pop it
-                                    if navigationController.path.count == 3 && tempMessage is Message {
-                                        navigationController.path.removeLast()
+                                    if navigationController.outerPath.count == 3 && tempMessage is Message {
+                                        navigationController.outerPath.removeLast()
                                     }
                                 }
                             }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -45,7 +45,7 @@ struct MessageActions: View {
                         conversationPath: conversationPath,
                         conversationViewModel: viewModel
                     ) {
-                        navigationController.outerPath.append(messagePath)
+                        navigationController.tabPath.append(messagePath)
                     } else {
                         viewModel.presentError(userFacingError: UserFacingError(title: R.string.localizable.detailViewCantBeOpened()))
                     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -306,7 +306,7 @@ private extension MessageCell {
             case let .attachment(id, lectureId):
                 navigationController.outerPath.append(LecturePath(id: lectureId, coursePath: coursePath))
             case let .channel(id):
-                navigationController.outerPath.append(ConversationPath(id: id, coursePath: coursePath))
+                navigationController.tabPath.append(ConversationPath(id: id, coursePath: coursePath))
             case let .exercise(id):
                 navigationController.outerPath.append(ExercisePath(id: id, coursePath: coursePath))
             case let .lecture(id):
@@ -325,7 +325,7 @@ private extension MessageCell {
             case let .member(login):
                 Task {
                     if let conversation = await viewModel.getOneToOneChatOrCreate(login: login) {
-                        navigationController.outerPath.append(ConversationPath(conversation: conversation, coursePath: coursePath))
+                        navigationController.tabPath.append(ConversationPath(conversation: conversation, coursePath: coursePath))
                     }
                 }
             case let .message(id):
@@ -337,7 +337,7 @@ private extension MessageCell {
                     break
                 }
 
-                navigationController.outerPath.append(messagePath)
+                navigationController.tabPath.append(messagePath)
             case let .slide(number, attachmentUnit):
                 Task {
                     let delegate = SendMessageLecturePickerViewModel(course: conversationViewModel.course)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -240,7 +240,7 @@ private extension MessageCell {
             conversationViewModel: conversationViewModel,
             presentKeyboardOnAppear: presentKeyboard
         ) {
-            navigationController.path.append(messagePath)
+            navigationController.tabPath.append(messagePath)
         } else if showErrorOnFailure {
             conversationViewModel.presentError(userFacingError: UserFacingError(title: R.string.localizable.detailViewCantBeOpened()))
         }
@@ -272,13 +272,13 @@ private extension MessageCell {
             let coursePath = CoursePath(course: conversationViewModel.course)
             switch mention {
             case let .attachment(id, lectureId):
-                navigationController.path.append(LecturePath(id: lectureId, coursePath: coursePath))
+                navigationController.outerPath.append(LecturePath(id: lectureId, coursePath: coursePath))
             case let .channel(id):
-                navigationController.path.append(ConversationPath(id: id, coursePath: coursePath))
+                navigationController.outerPath.append(ConversationPath(id: id, coursePath: coursePath))
             case let .exercise(id):
-                navigationController.path.append(ExercisePath(id: id, coursePath: coursePath))
+                navigationController.outerPath.append(ExercisePath(id: id, coursePath: coursePath))
             case let .lecture(id):
-                navigationController.path.append(LecturePath(id: id, coursePath: coursePath))
+                navigationController.outerPath.append(LecturePath(id: id, coursePath: coursePath))
             case let .lectureUnit(id, attachmentUnit):
                 Task {
                     let delegate = SendMessageLecturePickerViewModel(course: conversationViewModel.course)
@@ -286,14 +286,14 @@ private extension MessageCell {
                     await delegate.loadLecturesWithSlides()
 
                     if let lecture = delegate.firstLectureContains(attachmentUnit: attachmentUnit) {
-                        navigationController.path.append(LecturePath(id: lecture.id, coursePath: coursePath))
+                        navigationController.outerPath.append(LecturePath(id: lecture.id, coursePath: coursePath))
                         return
                     }
                 }
             case let .member(login):
                 Task {
                     if let conversation = await viewModel.getOneToOneChatOrCreate(login: login) {
-                        navigationController.path.append(ConversationPath(conversation: conversation, coursePath: coursePath))
+                        navigationController.outerPath.append(ConversationPath(conversation: conversation, coursePath: coursePath))
                     }
                 }
             case let .message(id):
@@ -305,7 +305,7 @@ private extension MessageCell {
                     break
                 }
 
-                navigationController.path.append(messagePath)
+                navigationController.outerPath.append(messagePath)
             case let .slide(number, attachmentUnit):
                 Task {
                     let delegate = SendMessageLecturePickerViewModel(course: conversationViewModel.course)
@@ -313,7 +313,7 @@ private extension MessageCell {
                     await delegate.loadLecturesWithSlides()
 
                     if let lecture = delegate.firstLectureContains(attachmentUnit: attachmentUnit) {
-                        navigationController.path.append(LecturePath(id: lecture.id, coursePath: coursePath))
+                        navigationController.outerPath.append(LecturePath(id: lecture.id, coursePath: coursePath))
                         return
                     }
                 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -77,6 +77,7 @@ struct MessageDetailView: View {
             }
         }
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct ConversationRow<T: BaseConversation>: View {
 
+    @Environment(\.horizontalSizeClass) var sizeClass
     @EnvironmentObject var navigationController: NavigationController
 
     @ObservedObject var viewModel: MessagesAvailableViewModel
@@ -30,50 +31,53 @@ struct ConversationRow<T: BaseConversation>: View {
     }
 
     var body: some View {
-        Button {
-            // should always be non-optional
-            if let conversation = Conversation(conversation: conversation) {
-                navigationController.path.append(ConversationPath(conversation: conversation, coursePath: CoursePath(course: viewModel.course)))
-            }
-        } label: {
-            HStack {
-                Label {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text(conversationDisplayName)
-                            .fontWeight(conversation.unreadMessagesCount ?? 0 > 0 ? .semibold : .regular)
-                        Spacer()
-                        if let unreadCount = conversation.unreadMessagesCount, unreadCount > 0 {
-                            Text(unreadCount, format: .number.notation(.compactName))
-                                .font(.footnote)
-                                .foregroundStyle(.white)
-                                .padding(.vertical, .s)
-                                .padding(.horizontal, .m)
-                                .background(Color.Artemis.artemisBlue, in: .capsule)
+        // should always be non-optional
+        if let conversationForPath = Conversation(conversation: conversation) {
+            NavigationLink(value: ConversationPath(conversation: conversationForPath, coursePath: CoursePath(course: viewModel.course))) {
+                HStack {
+                    Label {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(conversationDisplayName)
+                                .fontWeight(conversation.unreadMessagesCount ?? 0 > 0 ? .semibold : .regular)
+                            Spacer()
+                            if let unreadCount = conversation.unreadMessagesCount, unreadCount > 0 {
+                                Text(unreadCount, format: .number.notation(.compactName))
+                                    .font(.footnote)
+                                    .foregroundStyle(.white)
+                                    .padding(.vertical, .s)
+                                    .padding(.horizontal, .m)
+                                    .background(Color.Artemis.artemisBlue, in: .capsule)
+                            }
                         }
+                    } icon: {
+                        conversationIcon
                     }
-                } icon: {
-                    conversationIcon
+                    Spacer()
+                    Menu {
+                        contextMenuItems
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .padding(.m)
+                    }
                 }
-                Spacer()
-                Menu {
+                .opacity((conversation.unreadMessagesCount ?? 0) > 0 ? 1 : 0.7)
+                .contextMenu {
                     contextMenuItems
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .padding(.m)
                 }
             }
-            .opacity((conversation.unreadMessagesCount ?? 0) > 0 ? 1 : 0.7)
-            .contextMenu {
-                contextMenuItems
+            .tag(ConversationPath(conversation: conversationForPath, coursePath: CoursePath(course: viewModel.course)))
+            .foregroundStyle((conversation.isMuted ?? false) ? .secondary : .primary)
+            .listRowInsets(EdgeInsets(top: 0,
+                                      leading: .s * -1,
+                                      bottom: 0,
+                                      // We need to move the chevron off screen if it exists
+                                      trailing: .m * (sizeClass == .compact ? -1 : 1)))
+            .swipeActions(edge: .leading) {
+                favoriteButton
             }
-        }
-        .foregroundStyle((conversation.isMuted ?? false) ? .secondary : .primary)
-        .listRowInsets(EdgeInsets(top: 0, leading: .s * -1, bottom: 0, trailing: .m))
-        .swipeActions(edge: .leading) {
-            favoriteButton
-        }
-        .swipeActions(edge: .trailing) {
-            hideAndMuteButtons
+            .swipeActions(edge: .trailing) {
+                hideAndMuteButtons
+            }
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -184,8 +184,7 @@ public struct MessagesAvailableView: View {
                         ConversationPathView(path: path)
                             .id(path.id)
                     } else {
-                        #warning("TODO: Localize")
-                        Text("Select a Conversation")
+                        SelectDetailView()
                     }
                 }
                 .navigationDestination(for: ConversationPath.self, destination: ConversationPathView.init)

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -13,7 +13,11 @@ import SwiftUI
 
 public struct MessagesAvailableView: View {
 
+    @EnvironmentObject var navController: NavigationController
     @StateObject private var viewModel: MessagesAvailableViewModel
+
+    @State var selectedConversation: ConversationPath?
+    @State var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
 
     @Binding private var searchText: String
 
@@ -34,133 +38,169 @@ public struct MessagesAvailableView: View {
     }
 
     public var body: some View {
-        List {
-            if !searchText.isEmpty {
-                if searchResults.isEmpty {
-                    Text(R.string.localizable.noResultForSearch())
-                        .padding(.l)
-                        .listRowSeparator(.hidden)
-                }
-                ForEach(searchResults) { conversation in
-                    if let channel = conversation.baseConversation as? Channel {
-                        ConversationRow(viewModel: viewModel, conversation: channel)
+        NavigationSplitView(columnVisibility: $columnVisibilty) {
+            List(selection: $selectedConversation) {
+                if !searchText.isEmpty {
+                    if searchResults.isEmpty {
+                        Text(R.string.localizable.noResultForSearch())
+                            .padding(.l)
+                            .listRowSeparator(.hidden)
                     }
-                    if let groupChat = conversation.baseConversation as? GroupChat {
-                        ConversationRow(viewModel: viewModel, conversation: groupChat)
-                    }
-                    if let oneToOneChat = conversation.baseConversation as? OneToOneChat {
-                        ConversationRow(viewModel: viewModel, conversation: oneToOneChat)
-                    }
-                }.listRowBackground(Color.clear)
-            } else {
-                filterBar
+                    ForEach(searchResults) { conversation in
+                        if let channel = conversation.baseConversation as? Channel {
+                            ConversationRow(viewModel: viewModel, conversation: channel)
+                        }
+                        if let groupChat = conversation.baseConversation as? GroupChat {
+                            ConversationRow(viewModel: viewModel, conversation: groupChat)
+                        }
+                        if let oneToOneChat = conversation.baseConversation as? OneToOneChat {
+                            ConversationRow(viewModel: viewModel, conversation: oneToOneChat)
+                        }
+                    }.listRowBackground(Color.clear)
+                } else {
+                    filterBar
 
-                Group {
-                    MixedMessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.favoriteConversations,
-                        sectionTitle: R.string.localizable.favoritesSection(),
-                        sectionIconName: "heart.fill")
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.channels,
-                        sectionTitle: R.string.localizable.generalTopics(),
-                        sectionIconName: "bubble.left.fill")
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.exercises,
-                        sectionTitle: R.string.localizable.exercises(),
-                        sectionIconName: "list.bullet",
-                        isExpanded: false)
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.lectures,
-                        sectionTitle: R.string.localizable.lectures(),
-                        sectionIconName: "doc.fill",
-                        isExpanded: false)
-                    MessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.exams,
-                        sectionTitle: R.string.localizable.exams(),
-                        sectionIconName: "graduationcap.fill",
-                        isExpanded: false)
-                    if viewModel.isDirectMessagingEnabled {
+                    Group {
+                        MixedMessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.favoriteConversations,
+                            sectionTitle: R.string.localizable.favoritesSection(),
+                            sectionIconName: "heart.fill")
                         MessageSection(
                             viewModel: viewModel,
-                            conversations: $viewModel.groupChats,
-                            sectionTitle: R.string.localizable.groupChats(),
-                            sectionIconName: "bubble.left.and.bubble.right.fill")
-                        MessageSection(
-                            viewModel: viewModel,
-                            conversations: $viewModel.oneToOneChats,
-                            sectionTitle: R.string.localizable.directMessages(),
+                            conversations: $viewModel.channels,
+                            sectionTitle: R.string.localizable.generalTopics(),
                             sectionIconName: "bubble.left.fill")
-                    }
-                    MixedMessageSection(
-                        viewModel: viewModel,
-                        conversations: $viewModel.hiddenConversations,
-                        sectionTitle: R.string.localizable.hiddenSection(),
-                        sectionIconName: "nosign",
-                        isExpanded: false)
-                }
-                .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets(top: 0, leading: .s, bottom: 0, trailing: .s))
-
-                HStack {
-                    Spacer()
-                    Button {
-                        isCodeOfConductPresented = true
-                    } label: {
-                        HStack {
-                            Image(systemName: "info.circle")
-                            Text(R.string.localizable.codeOfConduct())
+                        MessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.exercises,
+                            sectionTitle: R.string.localizable.exercises(),
+                            sectionIconName: "list.bullet",
+                            isExpanded: false)
+                        MessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.lectures,
+                            sectionTitle: R.string.localizable.lectures(),
+                            sectionIconName: "doc.fill",
+                            isExpanded: false)
+                        MessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.exams,
+                            sectionTitle: R.string.localizable.exams(),
+                            sectionIconName: "graduationcap.fill",
+                            isExpanded: false)
+                        if viewModel.isDirectMessagingEnabled {
+                            MessageSection(
+                                viewModel: viewModel,
+                                conversations: $viewModel.groupChats,
+                                sectionTitle: R.string.localizable.groupChats(),
+                                sectionIconName: "bubble.left.and.bubble.right.fill")
+                            MessageSection(
+                                viewModel: viewModel,
+                                conversations: $viewModel.oneToOneChats,
+                                sectionTitle: R.string.localizable.directMessages(),
+                                sectionIconName: "bubble.left.fill")
                         }
+                        MixedMessageSection(
+                            viewModel: viewModel,
+                            conversations: $viewModel.hiddenConversations,
+                            sectionTitle: R.string.localizable.hiddenSection(),
+                            sectionIconName: "nosign",
+                            isExpanded: false)
                     }
-                    Spacer()
-                }
-                .listRowBackground(Color.clear)
-
-                // Empty row so that there is always space for floating button
-                Spacer()
                     .listRowBackground(Color.clear)
-            }
-        }
-        .scrollContentBackground(.hidden)
-        .listRowSpacing(0.01)
-        .listSectionSpacing(.compact)
-        .refreshable {
-            await viewModel.loadConversations()
-        }
-        .task {
-            await viewModel.loadConversations()
-        }
-        .task {
-            await viewModel.subscribeToConversationMembershipTopic()
-        }
-        .overlay(alignment: .bottomTrailing) {
-            CreateOrAddChannelButton(viewModel: viewModel)
-                .padding()
-        }
-        .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
-        .loadingIndicator(isLoading: $viewModel.isLoading)
-        .sheet(isPresented: $isCodeOfConductPresented) {
-            NavigationStack {
-                ScrollView {
-                    CodeOfConductView(course: viewModel.course)
-                }
-                .contentMargins(.l, for: .scrollContent)
-                .navigationTitle(R.string.localizable.codeOfConduct())
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
+                    .listRowInsets(EdgeInsets(top: 0, leading: .s, bottom: 0, trailing: .s))
+
+                    HStack {
+                        Spacer()
                         Button {
-                            isCodeOfConductPresented = false
+                            isCodeOfConductPresented = true
                         } label: {
-                            Text(R.string.localizable.done())
+                            HStack {
+                                Image(systemName: "info.circle")
+                                Text(R.string.localizable.codeOfConduct())
+                            }
+                        }
+                        Spacer()
+                    }
+                    .listRowBackground(Color.clear)
+
+                    // Empty row so that there is always space for floating button
+                    Spacer()
+                        .listRowBackground(Color.clear)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .listRowSpacing(0.01)
+            .listSectionSpacing(.compact)
+            .refreshable {
+                await viewModel.loadConversations()
+            }
+            .task {
+                await viewModel.loadConversations()
+            }
+            .task {
+                await viewModel.subscribeToConversationMembershipTopic()
+            }
+            .overlay(alignment: .bottomTrailing) {
+                CreateOrAddChannelButton(viewModel: viewModel)
+                    .padding()
+            }
+            .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+            .loadingIndicator(isLoading: $viewModel.isLoading)
+            .sheet(isPresented: $isCodeOfConductPresented) {
+                NavigationStack {
+                    ScrollView {
+                        CodeOfConductView(course: viewModel.course)
+                    }
+                    .contentMargins(.l, for: .scrollContent)
+                    .navigationTitle(R.string.localizable.codeOfConduct())
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button {
+                                isCodeOfConductPresented = false
+                            } label: {
+                                Text(R.string.localizable.done())
+                            }
                         }
                     }
                 }
             }
+            .navigationTitle(viewModel.course.title ?? R.string.localizable.loading())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        navController.popToRoot()
+                    } label: {
+                        HStack(spacing: .s) {
+                            Image(systemName: "chevron.backward")
+                                .fontWeight(.semibold)
+                            Text("Back")
+                        }
+                        .offset(x: -8)
+                    }
+                }
+            }
+        } detail: {
+            NavigationStack(path: $navController.tabPath) {
+                Group {
+                    if let selectedConversation {
+                        ConversationPathView(path: selectedConversation)
+                            .id(selectedConversation.id)
+                    } else {
+                        #warning("TODO: Localize")
+                        Text("Select a Conversation")
+                    }
+                }
+                .navigationDestination(for: ConversationPath.self, destination: ConversationPathView.init)
+                .modifier(NavigationDestinationThreadViewModifier())
+            }
+        }
+        .toolbar(.hidden, for: .navigationBar)
+        .onChange(of: selectedConversation) { _, newVal in
+            print("Selected \(newVal)")
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -16,7 +16,6 @@ public struct MessagesAvailableView: View {
     @EnvironmentObject var navController: NavigationController
     @StateObject private var viewModel: MessagesAvailableViewModel
 
-    @State var selectedConversation: ConversationPath?
     @State var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
 
     @Binding private var searchText: String
@@ -32,6 +31,10 @@ public struct MessagesAvailableView: View {
         }
     }
 
+    private var selectedConversation: Binding<ConversationPath?> {
+        navController.selectedPathBinding($navController.selectedPath)
+    }
+
     public init(course: Course, searchText: Binding<String>) {
         self._viewModel = StateObject(wrappedValue: MessagesAvailableViewModel(course: course))
         self._searchText = searchText
@@ -39,7 +42,7 @@ public struct MessagesAvailableView: View {
 
     public var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibilty) {
-            List(selection: $selectedConversation) {
+            List(selection: selectedConversation) {
                 if !searchText.isEmpty {
                     if searchResults.isEmpty {
                         Text(R.string.localizable.noResultForSearch())
@@ -186,9 +189,9 @@ public struct MessagesAvailableView: View {
         } detail: {
             NavigationStack(path: $navController.tabPath) {
                 Group {
-                    if let selectedConversation {
-                        ConversationPathView(path: selectedConversation)
-                            .id(selectedConversation.id)
+                    if let path = navController.selectedPath as? ConversationPath {
+                        ConversationPathView(path: path)
+                            .id(path.id)
                     } else {
                         #warning("TODO: Localize")
                         Text("Select a Conversation")
@@ -199,9 +202,6 @@ public struct MessagesAvailableView: View {
             }
         }
         .toolbar(.hidden, for: .navigationBar)
-        .onChange(of: selectedConversation) { _, newVal in
-            print("Selected \(newVal)")
-        }
     }
 
     @ViewBuilder var filterBar: some View {

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -174,16 +174,7 @@ public struct MessagesAvailableView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        navController.popToRoot()
-                    } label: {
-                        HStack(spacing: .s) {
-                            Image(systemName: "chevron.backward")
-                                .fontWeight(.semibold)
-                            Text("Back")
-                        }
-                        .offset(x: -8)
-                    }
+                    BackToRootButton()
                 }
             }
         } detail: {

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -55,7 +55,7 @@ public extension NavigationController {
     func goToExercise(courseId: Int, exerciseId: Int) {
         courseTab = .exercise
         goToCourse(id: courseId)
-        outerPath.append(ExercisePath(id: exerciseId, coursePath: CoursePath(id: courseId)))
+        selectedPath = ExercisePath(id: exerciseId, coursePath: CoursePath(id: courseId))
         log.debug("ExercisePath was appended to queue")
     }
 

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -4,7 +4,8 @@ import SwiftUI
 @MainActor
 public class NavigationController: ObservableObject {
 
-    @Published public var path: NavigationPath
+    @Published public var outerPath: NavigationPath
+    @Published public var tabPath: NavigationPath
 
     @Published public var courseTab = TabIdentifier.exercise
 
@@ -13,7 +14,8 @@ public class NavigationController: ObservableObject {
     public var notSupportedUrl: URL?
 
     public init() {
-        self.path = NavigationPath()
+        self.outerPath = NavigationPath()
+        self.tabPath = NavigationPath()
 
         DeeplinkHandler.shared.setup(navigationController: self)
     }
@@ -21,27 +23,28 @@ public class NavigationController: ObservableObject {
 
 public extension NavigationController {
     func popToRoot() {
-        path = NavigationPath()
+        outerPath = NavigationPath()
+        tabPath = NavigationPath()
     }
 
     func goToCourse(id: Int) {
         popToRoot()
 
-        path.append(CoursePath(id: id))
+        outerPath.append(CoursePath(id: id))
         log.debug("CoursePath was appended to queue")
     }
 
     func goToExercise(courseId: Int, exerciseId: Int) {
         courseTab = .exercise
         goToCourse(id: courseId)
-        path.append(ExercisePath(id: exerciseId, coursePath: CoursePath(id: courseId)))
+        outerPath.append(ExercisePath(id: exerciseId, coursePath: CoursePath(id: courseId)))
         log.debug("ExercisePath was appended to queue")
     }
 
     func goToLecture(courseId: Int, lectureId: Int) {
         courseTab = .lecture
         goToCourse(id: courseId)
-        path.append(LecturePath(id: lectureId, coursePath: CoursePath(id: courseId)))
+        outerPath.append(LecturePath(id: lectureId, coursePath: CoursePath(id: courseId)))
         log.debug("LecturePath was appended to queue")
     }
 
@@ -56,7 +59,7 @@ public extension NavigationController {
 
     func goToCourseConversation(courseId: Int, conversationId: Int64) {
         goToCourseConversations(courseId: courseId)
-        path.append(ConversationPath(id: conversationId, coursePath: CoursePath(id: courseId)))
+        outerPath.append(ConversationPath(id: conversationId, coursePath: CoursePath(id: courseId)))
     }
 
     func showDeeplinkNotSupported(url: URL) {

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -62,7 +62,7 @@ public extension NavigationController {
     func goToLecture(courseId: Int, lectureId: Int) {
         courseTab = .lecture
         goToCourse(id: courseId)
-        outerPath.append(LecturePath(id: lectureId, coursePath: CoursePath(id: courseId)))
+        selectedPath = LecturePath(id: lectureId, coursePath: CoursePath(id: courseId))
         log.debug("LecturePath was appended to queue")
     }
 

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -6,6 +6,7 @@ public class NavigationController: ObservableObject {
 
     @Published public var outerPath: NavigationPath
     @Published public var tabPath: NavigationPath
+    @Published public var selectedPath: (any Hashable)?
 
     @Published public var courseTab = TabIdentifier.exercise
 
@@ -18,6 +19,23 @@ public class NavigationController: ObservableObject {
         self.tabPath = NavigationPath()
 
         DeeplinkHandler.shared.setup(navigationController: self)
+    }
+
+    /// Converts ``selectedPath`` into a `Binding` for use in a List Selection.
+    /// Usage:
+    /// ```swift
+    /// private var selectedConversation: Binding<ConversationPath?> {
+    ///     navController.selectedPathBinding($navController.selectedPath)
+    /// }
+    /// …
+    /// List(selection: selectedConversation, …)
+    /// ```
+    public func selectedPathBinding<T: Hashable>(_ selectedPath: Binding<(any Hashable)?>) -> Binding<T?> {
+        Binding {
+            selectedPath.wrappedValue as? T
+        } set: { newValue in
+            selectedPath.wrappedValue = newValue
+        }
     }
 }
 
@@ -59,7 +77,7 @@ public extension NavigationController {
 
     func goToCourseConversation(courseId: Int, conversationId: Int64) {
         goToCourseConversations(courseId: courseId)
-        outerPath.append(ConversationPath(id: conversationId, coursePath: CoursePath(id: courseId)))
+        selectedPath = ConversationPath(id: conversationId, coursePath: CoursePath(id: courseId))
     }
 
     func showDeeplinkNotSupported(url: URL) {

--- a/ArtemisKit/Sources/Navigation/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Navigation/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"selectConversation" = "Please Select a Conversation.";
+"selectLecture" = "Please Select a Lecture.";
+"selectExercise" = "Please Select an Exercise.";

--- a/ArtemisKit/Sources/Navigation/SplitViewSupporting/BackToRootButton.swift
+++ b/ArtemisKit/Sources/Navigation/SplitViewSupporting/BackToRootButton.swift
@@ -1,0 +1,27 @@
+//
+//  BackToRootButton.swift
+//
+//
+//  Created by Anian Schleyer on 04.09.24.
+//
+
+import SwiftUI
+
+public struct BackToRootButton: View {
+    @EnvironmentObject var navController: NavigationController
+
+    public init() {}
+
+    public var body: some View {
+        Button {
+            navController.popToRoot()
+        } label: {
+            HStack(spacing: .s) {
+                Image(systemName: "chevron.backward")
+                    .fontWeight(.semibold)
+                Text("Back")
+            }
+            .offset(x: -8)
+        }
+    }
+}

--- a/ArtemisKit/Sources/Navigation/SplitViewSupporting/SelectDetailView.swift
+++ b/ArtemisKit/Sources/Navigation/SplitViewSupporting/SelectDetailView.swift
@@ -1,0 +1,52 @@
+//
+//  SelectDetailView.swift
+//
+//
+//  Created by Anian Schleyer on 04.09.24.
+//
+
+import SwiftUI
+
+public struct SelectDetailView: View {
+    @EnvironmentObject var navController: NavigationController
+
+    @State private var animation = true
+
+    public init() {}
+
+    public var body: some View {
+        VStack {
+            ZStack {
+                Image(systemName: "arrow.backward")
+                    .offset(x: animation ? 0 : -6)
+            }
+            .animation(.spring(.bouncy(extraBounce: 0.4)), value: animation)
+            .padding(10)
+            .font(.title2)
+            .background {
+                Circle()
+                    .strokeBorder(style: .init())
+            }
+            .foregroundStyle(.secondary)
+
+            Text(selectionText)
+        }
+        .onChange(of: animation, initial: true) { _, newValue in
+            let newTime = newValue ? 3 : 0.25
+            DispatchQueue.main.asyncAfter(deadline: .now() + newTime) {
+                animation.toggle()
+            }
+        }
+    }
+
+    var selectionText: String {
+        return switch navController.courseTab {
+        case .exercise:
+            R.string.localizable.selectExercise()
+        case .lecture:
+            R.string.localizable.selectLecture()
+        case .communication:
+            R.string.localizable.selectConversation()
+        }
+    }
+}


### PR DESCRIPTION
### Problem
We currently use a Full-width, stacked navigation, even when the user is on an iPad. This is a huge waste of space and makes switching between exercises for example unnecessarily complicated.
Additionally, there is a bug on the iPhone version where Scroll Content overlaps with the Title Bar instead of going behind it. This is caused by the app using a TabView contained in a NavigationStack, which is discouraged. Instead, a separate Navigation View should be used inside each Tab of a TabView.

### Before vs After
<img src="https://github.com/user-attachments/assets/84bfd54b-8561-463e-b48b-ee4c1dc65cd9" alt="Before" width="500">
<img src="https://github.com/user-attachments/assets/1b9b79eb-95db-4534-85dd-07a4c9c0bbab" alt="After" width="500">