### PR TITLE
`Navigation`: Fix blank screen when opening CourseView

### DIFF
--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -18,17 +18,21 @@ public struct CourseView: View {
 
     public var body: some View {
         TabView(selection: $navigationController.courseTab) {
-            ExerciseListView(viewModel: viewModel, searchText: $searchText)
-                .tabItem {
-                    Label(R.string.localizable.exercisesTabLabel(), systemImage: "list.bullet.clipboard.fill")
-                }
-                .tag(TabIdentifier.exercise)
+            FixBlankScreenView {
+                ExerciseListView(viewModel: viewModel, searchText: $searchText)
+            }
+            .tabItem {
+                Label(R.string.localizable.exercisesTabLabel(), systemImage: "list.bullet.clipboard.fill")
+            }
+            .tag(TabIdentifier.exercise)
 
-            LectureListView(viewModel: viewModel, searchText: $searchText)
-                .tabItem {
-                    Label(R.string.localizable.lectureTabLabel(), systemImage: "character.book.closed.fill")
-                }
-                .tag(TabIdentifier.lecture)
+            FixBlankScreenView {
+                LectureListView(viewModel: viewModel, searchText: $searchText)
+            }
+            .tabItem {
+                Label(R.string.localizable.lectureTabLabel(), systemImage: "character.book.closed.fill")
+            }
+            .tag(TabIdentifier.lecture)
 
             if viewModel.isMessagesVisible {
                 MessagesTabView(course: viewModel.course, searchText: $searchText)

--- a/ArtemisKit/Sources/CourseView/FixBlankScreenView.swift
+++ b/ArtemisKit/Sources/CourseView/FixBlankScreenView.swift
@@ -1,0 +1,32 @@
+//
+//  FixBlankScreenView.swift
+//
+//
+//  Created by Anian Schleyer on 08.09.24.
+//
+
+import SwiftUI
+
+/// **Workaround for a SwiftUI Bug.**
+/// SwiftUI renders a blank screen in some cases when opening the
+/// Course TabView on Exercises or Lectures. Introducing a small
+/// delay before showing the view fixes the issue for some reason.
+struct FixBlankScreenView<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+    @State private var displayContent = false
+
+    var body: some View {
+        Group {
+            if displayContent {
+                content()
+            } else {
+                Spacer()
+                    .task {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                            displayContent = true
+                        }
+                    }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem
In some cases, SwiftUI renders a gray blank screen instead of the Exercise/Lecture List when navigating to a course. This behavior is undocumented in SwiftUI and only happens in the Exercise and Lecture Tabs, but not the Communication tab.

This issue is fixed by introducing a tiny delay before showing the view after navigation.