### PR TITLE
`Communication`: Hide empty category sections

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -347,7 +347,7 @@ private struct MessageSection<T: BaseConversation>: View {
         DataStateView(data: $conversations) {
             await viewModel.loadConversations()
         } content: { conversations in
-            if !(isFiltering && conversations.isEmpty) {
+            if !conversations.isEmpty {
                 Section {
                     DisclosureGroup(isExpanded: Binding(get: {
                         isExpanded || isFiltering


### PR DESCRIPTION
We currently display every category in the Conversation List, regardless of whether there are any channels available in that category or not.
With this PR, we change this so that we do not show empty categories anymore, for example when there are no exam channels, we also don't show the "Exams" section.