### PR TITLE
`Communication`: Hide Add/Remove user button from course-wide channels

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "dbcfc4d8110dbccaf1fd8c13c422129b9d81069e",
-        "version" : "14.1.0"
+        "revision" : "4c8d22aa11e55e3eba61899bac93763688c5693b",
+        "version" : "14.2.0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.1.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.2.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -54,13 +54,25 @@ extension ConversationInfoSheetViewModel {
         if conversation.baseConversation is OneToOneChat {
             return false
         }
+        // cannot leave course wide channel
+        if (conversation.baseConversation as? Channel)?.isCourseWide ?? false {
+            return false
+        }
         return true
     }
 
     var canAddUsers: Bool {
         switch conversation {
         case .channel(let conversation):
-            return conversation.hasChannelModerationRights ?? false
+            if conversation.isCourseWide ?? false {
+                return false
+            }
+            switch conversation.subType ?? .general {
+            case .general:
+                return conversation.hasChannelModerationRights ?? false
+            case .exercise, .lecture, .exam:
+                return false
+            }
         case .groupChat(let conversation):
             return conversation.isMember ?? false
         case .oneToOneChat:


### PR DESCRIPTION
Since it isn't possible to add or remove users from course-wide channels, we remove the buttons for those actions.