### PR TITLE
`Communication`: Add Profile Pictures

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "d32c9d0",
-        "revision" : "d32c9d08fcde943db5976f75af5e54c30fc1d265"
+        "revision" : "1ce04cfa8bd86f121632c3309e2bb44c70d6f311",
+        "version" : "14.3.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ashleymills/Reachability.swift",
       "state" : {
-        "revision" : "98e968e7b6c1318fb61df23e347bc319761e8acb",
-        "version" : "5.0.0"
+        "revision" : "7cbd73f46a7dfaeca079e18df7324c6de6d1834a",
+        "version" : "5.2.3"
       }
     },
     {
@@ -97,15 +97,6 @@
       "state" : {
         "revision" : "fd4df99170f5e9d7cf9aa8312aa8506e0e7a44e7",
         "version" : "0.35.0"
-      }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream.git",
-      "state" : {
-        "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-        "version" : "4.0.4"
       }
     },
     {
@@ -149,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Romixery/SwiftStomp.git",
       "state" : {
-        "revision" : "99dcfa7f428485b92de2359c9df9c778fd2d5599",
-        "version" : "1.1.1"
+        "revision" : "f25926d2ab67ec0391de9a706cf71dfb08d36bbc",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "4c8d22aa11e55e3eba61899bac93763688c5693b",
-        "version" : "14.2.0"
+        "branch" : "3407ff7",
+        "revision" : "3407ff7c193eb0180047db15ac8db3af6cc6bd1c"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "3407ff7",
-        "revision" : "3407ff7c193eb0180047db15ac8db3af6cc6bd1c"
+        "branch" : "d32c9d0",
+        "revision" : "d32c9d08fcde943db5976f75af5e54c30fc1d265"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -18,11 +18,9 @@ let package = Package(
             ])
     ],
     dependencies: [
-        // Starscream 4.0.6 does not build
-        .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "d32c9d0"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.3.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "3407ff7"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "d32c9d0"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", exact: "4.0.4"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.2.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "3407ff7"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Models/Schema/SchemaV1.swift
+++ b/ArtemisKit/Sources/Messages/Models/Schema/SchemaV1.swift
@@ -29,7 +29,7 @@ enum SchemaV1: VersionedSchema {
 
         var lastAccessDate: Date
 
-        @Relationship(deleteRule: .cascade, inverse: \Course.server)
+        @Relationship(deleteRule: .cascade)
         var courses: [Course]
 
         init(host: String, lastAccessDate: Date, courses: [Course] = []) {

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -128,9 +128,11 @@ public struct ConversationView: View {
             await viewModel.loadMessages()
         }
         .onDisappear {
-            if navigationController.outerPath.count < 2 {
-                // only cancel task if we navigate back
-                viewModel.subscription?.cancel()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if navigationController.selectedCourse == nil {
+                    // only cancel task if we navigate back
+                    viewModel.subscription?.cancel()
+                }
             }
             viewModel.saveContext()
         }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -94,11 +94,15 @@ extension MessageCell {
 
 private extension MessageCell {
     var author: String {
-        message.value?.author?.name ?? ""
+        authorUser?.name ?? ""
     }
 
     private var authorRole: UserRole? {
         message.value?.authorRole
+    }
+
+    private var authorUser: ConversationUser? {
+        return message.value?.author
     }
 
     var creationDate: Date? {
@@ -180,23 +184,31 @@ private extension MessageCell {
 
     @ViewBuilder var headerIfVisible: some View {
         if viewModel.isHeaderVisible {
-            HStack(alignment: .firstTextBaseline, spacing: .m) {
-                roleBadge
-                Text(isMessageOffline ? "Redacted" : author)
-                    .bold()
-                    .redacted(reason: isMessageOffline ? .placeholder : [])
-                if let creationDate {
-                    let formatter: DateFormatter = viewModel.conversationPath == nil ? .superShortDateAndTime : .timeOnly
-                    Text(creationDate, formatter: formatter)
-                        .font(.caption)
-                    if viewModel.isChipVisible(creationDate: creationDate, authorId: message.value?.author?.id) {
-                        Chip(
-                            text: R.string.localizable.new(),
-                            backgroundColor: .Artemis.artemisBlue,
-                            padding: .s
-                        )
-                        .font(.footnote)
+            HStack(alignment: .center, spacing: .m) {
+                if let authorUser {
+                    ProfilePictureView(user: authorUser)
+                }
+                VStack(alignment: .leading, spacing: .xs) {
+                    HStack(alignment: .firstTextBaseline, spacing: .m) {
+                        roleBadge
+                        Spacer()
+                        if let creationDate {
+                            let formatter: DateFormatter = viewModel.conversationPath == nil ? .superShortDateAndTime : .timeOnly
+                            Text(creationDate, formatter: formatter)
+                                .font(.caption)
+                            if viewModel.isChipVisible(creationDate: creationDate, authorId: message.value?.author?.id) {
+                                Chip(
+                                    text: R.string.localizable.new(),
+                                    backgroundColor: .Artemis.artemisBlue,
+                                    padding: .s
+                                )
+                                .font(.footnote)
+                            }
+                        }
                     }
+                    Text(isMessageOffline ? "Redacted" : author)
+                        .bold()
+                        .redacted(reason: isMessageOffline ? .placeholder : [])
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -184,7 +184,7 @@ private extension MessageCell {
 
     @ViewBuilder var headerIfVisible: some View {
         if viewModel.isHeaderVisible {
-            HStack(alignment: .center, spacing: .m) {
+            HStack(alignment: .top, spacing: .m) {
                 if let authorUser {
                     ProfilePictureView(user: authorUser)
                 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -23,12 +23,12 @@ struct ProfilePictureView: View {
             }
         }
         .frame(width: 42, height: 42)
-        .clipShape(.circle)
+        .clipShape(.rect(cornerRadius: .m))
     }
 
     @ViewBuilder var defaultProfilePicture: some View {
         ZStack {
-            Circle()
+            Rectangle()
                 .fill(backgroundColor)
             Text(initials)
                 .font(.headline.bold())

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -1,0 +1,56 @@
+//
+//  ProfilePictureView.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 11.09.24.
+//
+
+import DesignLibrary
+import SharedModels
+import SwiftUI
+
+struct ProfilePictureView: View {
+    let user: ConversationUser
+
+    var body: some View {
+        Group {
+            if let url = user.imagePath {
+                ArtemisAsyncImage(imageURL: url) {
+                    defaultProfilePicture
+                }
+            } else {
+                defaultProfilePicture
+            }
+        }
+        .frame(width: 42, height: 42)
+        .clipShape(.circle)
+    }
+
+    @ViewBuilder var defaultProfilePicture: some View {
+        ZStack {
+            Circle()
+                .fill(backgroundColor)
+            Text(initials)
+                .font(.title2)
+                .fontDesign(.rounded)
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var initials: String {
+        let nameComponents = user.name?.split(separator: " ")
+        let initialFirstName = nameComponents?.first?.prefix(1) ?? ""
+        let initialLastName = nameComponents?.last?.prefix(1) ?? ""
+        let initials = initialFirstName + initialLastName
+        if initials.isEmpty {
+            return "NA"
+        } else {
+            return String(initials)
+        }
+    }
+
+    private var backgroundColor: Color {
+        let hash = abs(String(user.id).hashValue) % 255
+        return Color(hue: Double(hash) / 255, saturation: 0.5, brightness: 0.5)
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -22,7 +22,7 @@ struct ProfilePictureView: View {
                 defaultProfilePicture
             }
         }
-        .frame(width: 42, height: 42)
+        .frame(width: 44, height: 44)
         .clipShape(.rect(cornerRadius: .m))
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -31,10 +31,11 @@ struct ProfilePictureView: View {
             Circle()
                 .fill(backgroundColor)
             Text(initials)
-                .font(.title3.bold())
+                .font(.headline.bold())
                 .fontDesign(.rounded)
                 .foregroundStyle(.white)
         }
+        .accessibilityHidden(true)
     }
 
     private var initials: String {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -31,7 +31,7 @@ struct ProfilePictureView: View {
             Circle()
                 .fill(backgroundColor)
             Text(initials)
-                .font(.title2)
+                .font(.title3.bold())
                 .fontDesign(.rounded)
                 .foregroundStyle(.white)
         }


### PR DESCRIPTION
### Problem
Users cannot see profile pictures in the iOS app.

### Solution
We display profile pictures when available in the Profile Settings as well as conversations. If no profile picture is available in a conversation, we instead show a placeholder with the user's initials.

<img src="https://github.com/user-attachments/assets/3f24b8c3-608b-4085-9ca3-cd8772b0fac6" alt="Demo" width="250">

- [x] Merge https://github.com/ls1intum/artemis-ios-core-modules/pull/78 & Create Release
- [x] Update Core Modules Version
