### PR TITLE
`Lectures`: Group Lectures by Past/Current/Future

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -166,8 +166,8 @@ private struct LectureListSectionView: View {
         self.course = course
         self.lectureGroup = lectureGroup
 
-        let isCurrentOrDue = lectureGroup.type == .current || lectureGroup.type == .dueSoon
-        _isExpanded = State(wrappedValue: isCurrentOrDue)
+        let isCurrent = lectureGroup.type == .current
+        _isExpanded = State(wrappedValue: isCurrent)
     }
 
     var body: some View {


### PR DESCRIPTION
See https://github.com/ls1intum/artemis-ios/pull/162, this PR adds the same for Lectures.

However, since a lecture is not "due", we omit this group and only have Past, Current, Future as well as No Date.