### PR TITLE
`Communication`: Fix Favorites not being reflected correctly in all places

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -270,6 +270,7 @@ extension ConversationInfoSheetViewModel {
             convo.isFavorite?.toggle()
             conversation = .oneToOneChat(conversation: convo)
         }
+        NotificationCenter.default.post(name: .reloadConversationList, object: nil)
     }
 
     func sendMessageToUser(with login: String, navigationController: NavigationController, completion: @escaping () -> Void) {

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -270,7 +270,11 @@ extension ConversationInfoSheetViewModel {
             convo.isFavorite?.toggle()
             conversation = .oneToOneChat(conversation: convo)
         }
-        NotificationCenter.default.post(name: .reloadConversationList, object: nil)
+        NotificationCenter.default.post(name: .favoriteConversationChanged,
+                                        object: nil,
+                                        userInfo: [
+                                            conversation.id: conversation.baseConversation.isFavorite as Any
+                                        ])
     }
 
     func sendMessageToUser(with login: String, navigationController: NavigationController, completion: @escaping () -> Void) {

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -74,6 +74,11 @@ class ConversationViewModel: BaseViewModel {
 
         subscribeToConversationTopic()
         fetchOfflineMessages()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(updateFavorites(notification:)),
+                                               name: .favoriteConversationChanged,
+                                               object: nil)
     }
 
     deinit {
@@ -412,6 +417,22 @@ private extension ConversationViewModel {
         let equal = messages.remove(.message(message))
         if equal != nil {
             diff -= 1
+        }
+    }
+
+    // Change favorites
+    @objc
+    private func updateFavorites(notification: Foundation.Notification) {
+        let isFavorite = notification.userInfo?[conversation.id] as? Bool ?? conversation.baseConversation.isFavorite
+        if var convo = conversation.baseConversation as? Channel {
+            convo.isFavorite = isFavorite
+            conversation = .channel(conversation: convo)
+        } else if var convo = conversation.baseConversation as? GroupChat {
+            convo.isFavorite = isFavorite
+            conversation = .groupChat(conversation: convo)
+        } else if var convo = conversation.baseConversation as? OneToOneChat {
+            convo.isFavorite = isFavorite
+            conversation = .oneToOneChat(conversation: convo)
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/MessagesAvailableViewModel.swift
@@ -66,6 +66,8 @@ class MessagesAvailableViewModel: BaseViewModel {
         self.userSession = userSession
 
         super.init()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadConversations), name: .reloadConversationList, object: nil)
     }
 
     func subscribeToConversationMembershipTopic() async {
@@ -88,6 +90,13 @@ class MessagesAvailableViewModel: BaseViewModel {
     func loadConversations() async {
         let result = await messagesService.getConversations(for: courseId)
         allConversations = result
+    }
+
+    @objc func reloadConversations() {
+        allConversations = .loading
+        Task {
+            await loadConversations()
+        }
     }
 
     func setIsConversationFavorite(conversationId: Int64, isFavorite: Bool) async {
@@ -351,4 +360,12 @@ enum ConversationFilter: FilterPicker {
             conversation.isFavorite ?? false
         }
     }
+}
+
+// MARK: Reload Notification
+
+extension Foundation.Notification.Name {
+    // Sending a notification of this type causes the Notification List to be reloaded,
+    // for example when favorites are changed from elsewhere.
+    static let reloadConversationList = Foundation.Notification.Name("ReloadConversationList")
 }


### PR DESCRIPTION
There are two cases on iPad where the favorite status of conversations is not reflected correctly:

#### Sidebar
- Open Conversation
- Open Info Sheet
- Add/Remove from favorites
- The sidebar does not update

#### Info Sheet
- Open Conversation
- Add/Remove from favorites in the sidebar
- Open Info Sheet
- The Button is showing the wrong action