### PR TITLE
`Communication`: Fix disappearing messages and toolbar

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -323,7 +323,9 @@ private extension ConversationViewModel {
 
     func subscribeToConversationTopic() {
         let topic: String
-        if conversation.baseConversation.type == .channel {
+        if conversation.baseConversation.type == .channel,
+           let channel = conversation.baseConversation as? Channel,
+           channel.isCourseWide == true {
             topic = WebSocketTopic.makeChannelNotifications(courseId: course.id)
         } else if let id = userSession.user?.id {
             topic = WebSocketTopic.makeConversationNotifications(userId: id)

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -322,27 +322,23 @@ private extension ConversationViewModel {
     // MARK: Initializer
 
     func subscribeToConversationTopic() {
-        var isNonCourseWide = false
         let topic: String
         if conversation.baseConversation.type == .channel,
            let channel = conversation.baseConversation as? Channel,
            channel.isCourseWide == true {
             topic = WebSocketTopic.makeChannelNotifications(courseId: course.id)
         } else if let id = userSession.user?.id {
-            isNonCourseWide = true
             topic = WebSocketTopic.makeConversationNotifications(userId: id)
         } else {
             return
         }
         if stompClient.didSubscribeTopic(topic) {
-            if isNonCourseWide {
-                /// This web socket topic is the same across all channels.
-                /// We might need to wait until a previously open conversation has unsubscribed
-                /// before we can subscribe again
-                Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
-                    DispatchQueue.main.async { [weak self] in
-                        self?.subscribeToConversationTopic()
-                    }
+            /// These web socket topics are the same across multiple channels.
+            /// We might need to wait until a previously open conversation has unsubscribed
+            /// before we can subscribe again
+            Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+                DispatchQueue.main.async { [weak self] in
+                    self?.subscribeToConversationTopic()
                 }
             }
             return

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -322,17 +322,29 @@ private extension ConversationViewModel {
     // MARK: Initializer
 
     func subscribeToConversationTopic() {
+        var isNonCourseWide = false
         let topic: String
         if conversation.baseConversation.type == .channel,
            let channel = conversation.baseConversation as? Channel,
            channel.isCourseWide == true {
             topic = WebSocketTopic.makeChannelNotifications(courseId: course.id)
         } else if let id = userSession.user?.id {
+            isNonCourseWide = true
             topic = WebSocketTopic.makeConversationNotifications(userId: id)
         } else {
             return
         }
         if stompClient.didSubscribeTopic(topic) {
+            if isNonCourseWide {
+                /// This web socket topic is the same across all channels.
+                /// We might need to wait until a previously open conversation has unsubscribed
+                /// before we can subscribe again
+                Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+                    DispatchQueue.main.async { [weak self] in
+                        self?.subscribeToConversationTopic()
+                    }
+                }
+            }
             return
         }
         subscription = Task { [weak self] in

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -33,7 +33,7 @@ struct SendMessageView: View {
             }
             textField
                 .padding(isFocused ? [.horizontal, .bottom] : .all, .l)
-            if viewModel.isEditing && isFocused {
+            if isFocused {
                 keyboardToolbarContent
                     .padding(.horizontal, .l)
                     .padding(.vertical, .m)
@@ -101,13 +101,6 @@ private extension SendMessageView {
             .textFieldStyle(.roundedBorder)
             .lineLimit(10)
             .focused($isFocused)
-            .toolbar {
-                if isFocused && !viewModel.isEditing {
-                    ToolbarItem(placement: .keyboard) {
-                        keyboardToolbarContent
-                    }
-                }
-            }
             if !isFocused {
                 sendButton
             }

--- a/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -64,10 +64,11 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
             await subscribeToTutorialGroupNotificationUpdates()
         }
         addTask(subscribeToTutorialGroupNotificationUpdatesTask)
-        let subscribeToConversationNotificationUpdatesTask = Task {
-            await subscribeToConversationNotificationUpdates()
-        }
-        addTask(subscribeToConversationNotificationUpdatesTask)
+#warning("We can't subscribe to this here and in the conversation simultaneously")
+//        let subscribeToConversationNotificationUpdatesTask = Task {
+//            await subscribeToConversationNotificationUpdates()
+//        }
+//        addTask(subscribeToConversationNotificationUpdatesTask)
 
         return stream
     }


### PR DESCRIPTION
- Due to a conflict with the same conversation notification topic being used in multiple places, the web socket did not subscribe correctly to sending messages in non course wide conversations. This lead to messages disappearing after being sent.
- The message toolbar does sometimes not show up on iOS 18