### PR TITLE
`Comunication`: Use TextSelection for message formatting buttons

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "8eb0e3c715c0eaa17ff6603b1eae1965a5a0666609384d9087b9c335356d3826",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -68,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mac-cain13/R.swift.git",
       "state" : {
-        "revision" : "384eab88d1a0b98ac96f4819e50a4308ecd5359f",
-        "version" : "7.5.0"
+        "revision" : "4ac2eb7e6157887c9f59dc5ccc5978d51546be6d",
+        "version" : "7.7.0"
       }
     },
     {
@@ -176,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tomlokhorst/XcodeEdit",
       "state" : {
-        "revision" : "b6b67389a0f1a6fdd9c6457a8ab5b02eaab13c5c",
-        "version" : "2.9.2"
+        "revision" : "017d23f71fa8d025989610db26d548c44cacefae",
+        "version" : "2.10.2"
       }
     },
     {
@@ -190,5 +191,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -137,5 +137,7 @@ let package = Package(
             dependencies: [
                 "Messages"
             ])
-    ]
+    ],
+    // TODO: Eventually upgrade
+    swiftLanguageModes: [.v5]
 )

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "ArtemisKit",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v18)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
         .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.5.2")),
-        .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.0.0")
+        .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -192,7 +192,7 @@ extension SendMessageViewModel {
             isMemberPickerSuppressed = true
         } else {
             isMemberPickerSuppressed = false
-            text += "@"
+            appendToSelection(before: "@", after: " ", placeholder: " ")
         }
     }
 
@@ -201,7 +201,7 @@ extension SendMessageViewModel {
             isChannelPickerSuppressed = true
         } else {
             isChannelPickerSuppressed = false
-            text += "#"
+            appendToSelection(before: "#", after: " ", placeholder: " ")
         }
     }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -9,6 +9,7 @@ import APIClient
 import Common
 import Foundation
 import SharedModels
+import SwiftUI
 import UserStore
 
 extension SendMessageViewModel {
@@ -44,6 +45,7 @@ final class SendMessageViewModel {
     // MARK: Text
 
     var text = ""
+    var selection: TextSelection?
 
     var isEditing: Bool {
         switch configuration {
@@ -158,35 +160,31 @@ extension SendMessageViewModel {
     // MARK: Toolbar
 
     func didTapBoldButton() {
-        text.append("****")
+        appendToSelection(before: "**", after: "**", placeholder: "bold")
     }
 
     func didTapItalicButton() {
-        text.append("**")
+        appendToSelection(before: "*", after: "*", placeholder: "italic")
     }
 
     func didTapUnderlineButton() {
-        text.append("<ins></ins>")
+        appendToSelection(before: "<ins>", after: "</ins>", placeholder: "underlined")
     }
 
     func didTapBlockquoteButton() {
-        text.append("> Reference")
+        appendToSelection(before: "> ", after: "", placeholder: "Reference")
     }
 
     func didTapCodeButton() {
-        text.append("``")
+        appendToSelection(before: "`", after: "`", placeholder: "Code")
     }
 
     func didTapCodeBlockButton() {
-        text.append("""
-                    ```java
-                    Source Code
-                    ```
-                    """)
+        appendToSelection(before: "```java\n", after: "\n```", placeholder: "Source Code")
     }
 
     func didTapLinkButton() {
-        text.append("[](http://)")
+        appendToSelection(before: "[", after: "](https://)", placeholder: "Display Text")
     }
 
     func didTapAtButton() {
@@ -204,6 +202,42 @@ extension SendMessageViewModel {
         } else {
             isChannelPickerSuppressed = false
             text += "#"
+        }
+    }
+
+    /// Prepends/Appends the given snippets to text the user has selected.
+    private func appendToSelection(before: String, after: String, placeholder: String) {
+        let placeholderText = "\(before)\(placeholder)\(after)"
+        var shouldSelectPlaceholder = false
+
+        if let selection {
+            switch selection.indices {
+            case .selection(let range):
+                let newText: String
+                if text[range].isEmpty {
+                    newText = placeholderText
+                    shouldSelectPlaceholder = true
+                } else {
+                    newText = "\(before)\(text[range])\(after)"
+                }
+                text.replaceSubrange(range, with: newText)
+                if !shouldSelectPlaceholder, let endIndex = text.range(of: newText)?.upperBound {
+                    self.selection = TextSelection(insertionPoint: endIndex)
+                }
+            default:
+                break
+            }
+        } else {
+            text.append(placeholderText)
+            shouldSelectPlaceholder = true
+        }
+
+        if shouldSelectPlaceholder {
+            for range in text.ranges(of: placeholderText) {
+                if let placeholderRange = text[range].range(of: placeholder) {
+                    selection = TextSelection(range: range.clamped(to: placeholderRange))
+                }
+            }
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
@@ -15,7 +15,16 @@ struct SendMessageMentionContentView: View {
     var body: some View {
         NavigationStack {
             let delegate = SendMessageMentionContentDelegate { [weak viewModel] mention in
-                viewModel?.text.append(mention)
+                if let selection = viewModel?.selection {
+                    switch selection.indices {
+                    case .selection(let range):
+                        viewModel?.text.insert(contentsOf: mention, at: range.upperBound)
+                    default:
+                        viewModel?.text.append(mention)
+                    }
+                } else {
+                    viewModel?.text.append(mention)
+                }
                 viewModel?.wantsToAddMessageMentionContentType = nil
             }
             Group {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -96,6 +96,7 @@ private extension SendMessageView {
             TextField(
                 R.string.localizable.messageAction(viewModel.conversation.baseConversation.conversationName),
                 text: $viewModel.text,
+                selection: $viewModel.selection,
                 axis: .vertical
             )
             .textFieldStyle(.roundedBorder)

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -185,6 +185,7 @@ private extension SendMessageView {
                             .labelStyle(.iconOnly)
                     }
                 }
+                .font(.title3)
             }
             Spacer()
             sendButton


### PR DESCRIPTION
When composing a message, we want to improve the experience:

If you select a portion of text and then press "bold" for example, it should make the selected text bold instead of adding a bold placeholder at the end.

If you haven't selected any text, we add the "bold" placeholder and automatically mark it as selected so that the user can immediately type what should be in bold.