### PR TITLE
`Communication`: Fix info sheet formatting issues

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -140,8 +140,8 @@
 "editDescriptionLabel" = "Edit Description";
 "newDescriptionLabel" = "New Description";
 "moreInfoLabel" = "More info";
-"createdByLabel" = "Created by: %s";
-"createdOnLabel" = "Created on: %s";
+"createdByLabel" = "Created by";
+"createdOnLabel" = "Created on";
 "addFavorite" = "Add to Favorites";
 "removeFavorite" = "Remove from Favorites";
 "sendMessage" = "Send Message";

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -256,10 +256,12 @@ private struct InfoSection: View {
             if conversation.baseConversation.creator?.name != nil || conversation.baseConversation.creationDate != nil {
                 Section(R.string.localizable.moreInfoLabel()) {
                     if let creator = conversation.baseConversation.creator?.name {
-                        Text(R.string.localizable.createdByLabel(creator))
+                        Text(R.string.localizable.createdByLabel())
+                            .badge(creator)
                     }
                     if let creationDate = conversation.baseConversation.creationDate {
-                        Text(R.string.localizable.createdOnLabel(creationDate.mediumDateShortTime))
+                        Text(R.string.localizable.createdOnLabel())
+                            .badge(creationDate.mediumDateShortTime)
                     }
                 }
             }


### PR DESCRIPTION
Author names on the conversation info sheet could display weird characters if the name contains non-ascii characters. This PR fixes this issue.