### PR TITLE
`Communication`: Fix message (re)actions menu being offset

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -29,7 +29,6 @@ class ConversationViewModel: BaseViewModel {
 
     @Published var isConversationInfoSheetPresented = false
     @Published var selectedMessageId: Int64?
-    var isPerformingMessageAction = false
 
     var isAllowedToPost: Bool {
         guard let channel = conversation.baseConversation as? Channel else {

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/ReactionsViewModel.swift
@@ -67,6 +67,7 @@ class ReactionsViewModel {
                 self.messageBinding.wrappedValue = .done(response: response)
             }
         }
+        conversationViewModel.selectedMessageId = nil
     }
 
     func isMyReaction(_ emoji: String) -> Bool {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -39,7 +39,6 @@ struct MessageDetailView: View {
                         top(message: message)
                         answers(of: message, proxy: proxy)
                     }
-                    .defaultScrollAnchor(.bottom)
                 }
                 if !((viewModel.conversation.baseConversation as? Channel)?.isArchived ?? false),
                    let message = message as? Message {
@@ -92,6 +91,7 @@ private extension MessageDetailView {
         )
         .environment(\.isEmojiPickerButtonVisible, true)
         .environment(\.messageUseFullWidth, true)
+        .animation(.default, value: viewModel.selectedMessageId)
     }
 
     @ViewBuilder var divider: some View {


### PR DESCRIPTION
### Problem
Due to some issues with how SwiftUI handles targets and anchors in scroll views, the tap targets for the message actions menu could be offset. In some cases, the reactions bar also didn't show up or wasn't properly attached to the message. This PR fixes those issues.