### PR TITLE
`Communication`: Show profile pictures in channel list

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "abe60a35389b3a48746220c8c769e40edfe597e7cfc1f2c27bfcbd88959c19bb",
+  "originHash" : "5efde1acc1a55b9d310c6b32ff1dbfb7a10bb2f1d3e9fc50636c2ee486b2a7ab",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "3d5a7856b07222645ef9bc0b472236083bf6c3e3",
-        "version" : "14.7.1"
+        "revision" : "346950fb2d5263c5f4fbecd5f4c4f6579b4d1669",
+        "version" : "15.0.0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "14.7.1")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.0.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -97,8 +97,6 @@ public struct ConversationView: View {
                 } label: {
                     HStack(alignment: .center, spacing: .m) {
                         viewModel.conversation.baseConversation.icon?
-                            .renderingMode(.template)
-                            .resizable()
                             .scaledToFit()
                             .frame(height: 20)
                         VStack(alignment: .leading, spacing: .xxs) {

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/BrowseChannelsView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/BrowseChannelsView.swift
@@ -75,7 +75,6 @@ private struct ChannelRow: View {
                 HStack {
                     if let icon = channel.icon {
                         icon
-                            .resizable()
                             .scaledToFit()
                             .frame(width: .extraSmallImage, height: .extraSmallImage)
                     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -61,7 +61,6 @@ struct MessageDetailView: View {
                         .fontWeight(.semibold)
                     HStack(spacing: .s) {
                         viewModel.conversation.baseConversation.icon?
-                            .resizable()
                             .scaledToFit()
                             .frame(height: .m * 1.5)
                         Text(viewModel.conversation.baseConversation.conversationName)

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -86,7 +86,6 @@ private extension ConversationRow {
     @ViewBuilder var conversationIcon: some View {
         if let icon = conversation.icon {
             icon
-                .resizable()
                 .scaledToFit()
                 .frame(height: .extraSmallImage)
                 .frame(maxWidth: .infinity, alignment: .trailing)

--- a/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Notifications/Services/NotificationWebsocketServiceImpl.swift
@@ -160,7 +160,7 @@ class NotificationWebsocketServiceImpl: NotificationWebsocketService {
                     for await message in stream {
                         guard let quizExercise = JSONDecoder.getTypeFromSocketMessage(type: QuizExercise.self, message: message) else { continue }
                         if quizExercise.visibleToStudents ?? false,
-                           quizExercise.quizMode == .SYNCHRONIZED,
+                           quizExercise.quizMode == .synchronized,
                            quizExercise.quizBatches?.first?.started ?? false,
                            !(quizExercise.isOpenForPractice ?? false) {
                             guard let notification = Notification.createNotificationFromStartedQuizExercise(quizExercise: quizExercise) else { continue }


### PR DESCRIPTION
This PR adds support for showing profile pictures for DMs in the list of conversations in the messages tab as well as the title bar inside a conversation.

If no picture is available, we fall back to the old lock icon.