### PR TITLE
`Communication`: Add support for uploading images

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -156,6 +156,7 @@
 "ok" = "OK";
 "loading" = "Loading...";
 "cancel" = "Cancel";
+"uploading" = "Uploading";
 "previous" = "Previous";
 "next" = "Next";
 "confirm" = "Confirm";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "codeBlock" = "Code block";
 "code" = "Code";
 "link" = "Link";
+"uploadImage" = "Upload Image";
 
 // MARK: SendMessageMentionContentView
 "members" = "Members";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -49,6 +49,11 @@ protocol MessagesService {
     func sendAnswerMessage(for courseId: Int, message: Message, content: String) async -> NetworkResponse
 
     /**
+     * Perform a post request for uploading a jpeg image in a specific conversation to the server.
+     */
+    func uploadImage(for courseId: Int, and conversationId: Int64, image: Data) async -> DataState<String>
+
+    /**
      * Perform a delete request for a message in a specific course to the server.
      */
     func deleteMessage(for courseId: Int, messageId: Int64) async -> NetworkResponse

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -229,6 +229,31 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
+    struct UploadImageResult: Codable {
+        let path: String
+    }
+
+    func uploadImage(for courseId: Int, and conversationId: Int64, image: Data) async -> DataState<String> {
+        if image.count > 5 * 1024 * 1024 {
+            return .failure(error: .init(title: "File too big to upload"))
+        }
+
+        let request = MultipartFormDataRequest(path: "api/files/courses/\(courseId)/conversations/\(conversationId)")
+        request.addDataField(named: "file",
+                             filename: UUID().uuidString,
+                             data: image,
+                             mimeType: "image/jpeg")
+
+        let result: Swift.Result<(UploadImageResult, Int), APIClientError> = await client.sendRequest(request)
+
+        switch result {
+        case .success(let response):
+            return .done(response: response.0.path)
+        case .failure(let failure):
+            return .failure(error: .init(error: failure))
+        }
+    }
+
     struct DeleteMessageRequest: APIRequest {
         typealias Response = RawResponse
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -240,7 +240,7 @@ struct MessagesServiceImpl: MessagesService {
 
         let request = MultipartFormDataRequest(path: "api/files/courses/\(courseId)/conversations/\(conversationId)")
         request.addDataField(named: "file",
-                             filename: UUID().uuidString,
+                             filename: "\(UUID().uuidString).jpg",
                              data: image,
                              mimeType: "image/jpeg")
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -204,4 +204,8 @@ extension MessagesServiceStub: MessagesService {
     func unarchiveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
         .loading
     }
+
+    func uploadImage(for courseId: Int, and conversationId: Int64, image: Data) async -> DataState<String> {
+        .loading
+    }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageUploadImageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageUploadImageViewModel.swift
@@ -77,9 +77,9 @@ final class SendMessageUploadImageViewModel {
         uploadState = .compressing
         imagePath = nil
 
-        Task { [weak self] in
+        Task {
             if let transferable = try? await item.loadTransferable(type: Data.self) {
-                self?.upload(image: UIImage(data: transferable))
+                upload(image: UIImage(data: transferable))
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageUploadImageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageUploadImageViewModel.swift
@@ -1,0 +1,129 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 09.11.24.
+//
+
+import Common
+import Foundation
+import PhotosUI
+import SwiftUI
+
+enum UploadState: Equatable {
+    case selectImage
+    case compressing
+    case uploading
+    case done
+    case failed(error: UserFacingError)
+}
+
+@Observable
+final class SendMessageUploadImageViewModel {
+
+    let courseId: Int
+    let conversationId: Int64
+
+    var selection: PhotosPickerItem?
+    var uploadState = UploadState.selectImage
+    var imagePath: String?
+
+    var showUploadScreen: Binding<Bool> {
+        .init {
+            self.uploadState != .selectImage
+        } set: { newValue in
+            if !newValue {
+                self.uploadState = .selectImage
+            }
+        }
+    }
+    var showError: Binding<Bool> {
+        .init {
+            switch self.uploadState {
+            case .failed:
+                return true
+            default:
+                return false
+            }
+        } set: { newValue in
+            if !newValue {
+                self.uploadState = .selectImage
+            }
+        }
+    }
+
+    private let messagesService: MessagesService
+
+    init(
+        courseId: Int,
+        conversationId: Int64,
+        messagesService: MessagesService = MessagesServiceFactory.shared
+    ) {
+        self.courseId = courseId
+        self.conversationId = conversationId
+        self.messagesService = messagesService
+    }
+
+    /// Register as change handler for selection on View
+    func onChange() {
+        loadTransferable(from: selection)
+    }
+
+    private func loadTransferable(from item: PhotosPickerItem?) {
+        guard let item else {
+            return
+        }
+
+        uploadState = .compressing
+        imagePath = nil
+
+        Task { [weak self] in
+            if let transferable = try? await item.loadTransferable(type: Data.self) {
+                self?.upload(image: UIImage(data: transferable))
+            }
+        }
+    }
+
+    private func upload(image: UIImage?) {
+        guard let image else { return }
+
+        guard let imageData = compressImageBelow5MB(image) else {
+            uploadState = .failed(error: .init(title: "Image too big to upload. Plese select a smaller image."))
+            return
+        }
+
+        uploadState = .uploading
+
+        Task {
+            let result = await messagesService.uploadImage(for: courseId, and: conversationId, image: imageData)
+
+            switch result {
+            case .loading:
+                break
+            case .failure(let error):
+                uploadState = .failed(error: error)
+            case .done(let response):
+                imagePath = response
+                uploadState = .done
+            }
+            selection = nil
+        }
+    }
+
+    private func compressImageBelow5MB(_ image: UIImage, level: Double = 1) -> Data? {
+        guard let imageData = image.jpegData(compressionQuality: level) else {
+            return nil
+        }
+
+        // Too much compression needed to be useful
+        if level < 0.3 {
+            return nil
+        }
+
+        if imageData.count > 5 * 1024 * 1024 {
+            return compressImageBelow5MB(image, level: level - 0.2)
+        } else {
+            return imageData
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -205,6 +205,10 @@ extension SendMessageViewModel {
         }
     }
 
+    func insertImageMention(path: String) {
+        appendToSelection(before: "![", after: "](\(path))", placeholder: "image")
+    }
+
     /// Prepends/Appends the given snippets to text the user has selected.
     private func appendToSelection(before: String, after: String, placeholder: String) {
         let placeholderText = "\(before)\(placeholder)\(after)"

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
@@ -46,35 +46,10 @@ private struct UploadImageView: View {
 
     var body: some View {
         ZStack {
-            if let image = viewModel.image {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .ignoresSafeArea()
-                    .blur(radius: 10, opaque: true)
-                    .opacity(0.2)
-            }
+            backgroundImage
 
             VStack {
-                Group {
-                    if viewModel.uploadState != .done && viewModel.error == nil {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .scaleEffect(1.5)
-                    }
-                    if viewModel.uploadState == .done {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                    }
-                    if viewModel.error != nil {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.red)
-                    }
-                }
-                .font(.largeTitle)
-                .frame(height: 60)
-                .transition(.blurReplace)
+                statusIcon
 
                 Text(viewModel.statusLabel)
                     .frame(maxWidth: 300)
@@ -101,6 +76,39 @@ private struct UploadImageView: View {
                     dismiss()
                 }
             }
+        }
+    }
+
+    @ViewBuilder var statusIcon: some View {
+        Group {
+            if viewModel.uploadState != .done && viewModel.error == nil {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(1.5)
+            }
+            if viewModel.uploadState == .done {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+            if viewModel.error != nil {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+        .font(.largeTitle)
+        .frame(height: 60)
+        .transition(.blurReplace)
+    }
+
+    @ViewBuilder var backgroundImage: some View {
+        if let image = viewModel.image {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .ignoresSafeArea()
+                .blur(radius: 10, opaque: true)
+                .opacity(0.2)
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
@@ -1,0 +1,40 @@
+//
+//  SendMessageImagePickerView.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 09.11.24.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct SendMessageImagePickerView: View {
+
+    var sendViewModel: SendMessageViewModel
+    @State private var viewModel: SendMessageUploadImageViewModel
+
+    init(sendMessageViewModel: SendMessageViewModel) {
+        self._viewModel = State(initialValue: .init(courseId: sendMessageViewModel.course.id,
+                                                    conversationId: sendMessageViewModel.conversation.id))
+        self.sendViewModel = sendMessageViewModel
+    }
+
+    var body: some View {
+        PhotosPicker(selection: $viewModel.selection,
+                     matching: .images,
+                     preferredItemEncoding: .compatible) {
+            // TODO: Localize
+            Label("Upload Image", systemImage: "photo.fill")
+        }
+                     .onChange(of: viewModel.selection) {
+                         viewModel.onChange()
+                     }
+                     .sheet(isPresented: viewModel.showUploadScreen) {
+                         if let path = viewModel.imagePath {
+                             sendViewModel.insertImageMention(path: path)
+                         }
+                     } content: {
+                         Text("Uploading: \(viewModel.uploadState)")
+                     }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
@@ -25,15 +25,82 @@ struct SendMessageImagePickerView: View {
                      preferredItemEncoding: .compatible) {
             Label(R.string.localizable.uploadImage(), systemImage: "photo.fill")
         }
-         .onChange(of: viewModel.selection) {
-             viewModel.onChange()
-         }
-         .sheet(isPresented: viewModel.showUploadScreen) {
-             if let path = viewModel.imagePath {
-                 sendViewModel.insertImageMention(path: path)
-             }
-         } content: {
-             Text("Uploading: \(viewModel.uploadState)")
-         }
+        .onChange(of: viewModel.selection) {
+            viewModel.onChange()
+        }
+        .sheet(isPresented: viewModel.showUploadScreen) {
+            if let path = viewModel.imagePath {
+                sendViewModel.insertImageMention(path: path)
+            }
+            viewModel.selection = nil
+            viewModel.image = nil
+        } content: {
+            UploadImageView(viewModel: viewModel)
+        }
+    }
+}
+
+private struct UploadImageView: View {
+    var viewModel: SendMessageUploadImageViewModel
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        ZStack {
+            if let image = viewModel.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .ignoresSafeArea()
+                    .blur(radius: 10, opaque: true)
+                    .opacity(0.2)
+            }
+
+            VStack {
+                Group {
+                    if viewModel.uploadState != .done && viewModel.error == nil {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .scaleEffect(1.5)
+                    }
+                    if viewModel.uploadState == .done {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                    if viewModel.error != nil {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+                .font(.largeTitle)
+                .frame(height: 60)
+                .transition(.blurReplace)
+
+                Text(viewModel.statusLabel)
+                    .frame(maxWidth: 300)
+                    .font(.title)
+
+                if viewModel.uploadState == .uploading {
+                    Button(R.string.localizable.cancel()) {
+                        viewModel.cancel()
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .animation(.smooth(duration: 0.2), value: viewModel.uploadState)
+        }
+        .interactiveDismissDisabled()
+        .onChange(of: viewModel.uploadState) {
+            if viewModel.uploadState == .done {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    dismiss()
+                }
+            }
+            if viewModel.error != nil {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    dismiss()
+                }
+            }
+        }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
@@ -23,18 +23,17 @@ struct SendMessageImagePickerView: View {
         PhotosPicker(selection: $viewModel.selection,
                      matching: .images,
                      preferredItemEncoding: .compatible) {
-            // TODO: Localize
-            Label("Upload Image", systemImage: "photo.fill")
+            Label(R.string.localizable.uploadImage(), systemImage: "photo.fill")
         }
-                     .onChange(of: viewModel.selection) {
-                         viewModel.onChange()
-                     }
-                     .sheet(isPresented: viewModel.showUploadScreen) {
-                         if let path = viewModel.imagePath {
-                             sendViewModel.insertImageMention(path: path)
-                         }
-                     } content: {
-                         Text("Uploading: \(viewModel.uploadState)")
-                     }
+         .onChange(of: viewModel.selection) {
+             viewModel.onChange()
+         }
+         .sheet(isPresented: viewModel.showUploadScreen) {
+             if let path = viewModel.imagePath {
+                 sendViewModel.insertImageMention(path: path)
+             }
+         } content: {
+             Text("Uploading: \(viewModel.uploadState)")
+         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -184,6 +184,7 @@ private extension SendMessageView {
                         Label(R.string.localizable.link(), systemImage: "link")
                             .labelStyle(.iconOnly)
                     }
+                    SendMessageImagePickerView(sendMessageViewModel: viewModel)
                 }
                 .font(.title3)
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -135,7 +135,6 @@ private extension SendMessageView {
                         }
                     } label: {
                         Label(R.string.localizable.mention(), systemImage: "plus.circle.fill")
-                            .labelStyle(.iconOnly)
                     }
                     Menu {
                         Button {
@@ -155,13 +154,11 @@ private extension SendMessageView {
                         }
                     } label: {
                         Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
-                            .labelStyle(.iconOnly)
                     }
                     Button {
                         viewModel.didTapBlockquoteButton()
                     } label: {
                         Label(R.string.localizable.quote(), systemImage: "quote.opening")
-                            .labelStyle(.iconOnly)
                     }
                     Menu {
                         Button {
@@ -176,16 +173,15 @@ private extension SendMessageView {
                         }
                     } label: {
                         Label(R.string.localizable.code(), systemImage: "curlybraces")
-                            .labelStyle(.iconOnly)
                     }
                     Button {
                         viewModel.didTapLinkButton()
                     } label: {
                         Label(R.string.localizable.link(), systemImage: "link")
-                            .labelStyle(.iconOnly)
                     }
                     SendMessageImagePickerView(sendMessageViewModel: viewModel)
                 }
+                .labelStyle(.iconOnly)
                 .font(.title3)
             }
             Spacer()


### PR DESCRIPTION
We want users to be able to upload images into chats.

- [x] Add image picker
- [x] Add upload functions
- [x] Insert uploaded image into message
- [x] Add upload screen

<img src="https://github.com/user-attachments/assets/bd79f7bf-4657-4979-a7eb-d34f902ecf0a" alt="Keyboard toolbar" width="300">
<img src="https://github.com/user-attachments/assets/4d4b55fe-0c9b-4f25-a7bd-a9eeb5c013f2" alt="Upload screen" width="300">