### PR TITLE
`Communication`: Improve image view

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5efde1acc1a55b9d310c6b32ff1dbfb7a10bb2f1d3e9fc50636c2ee486b2a7ab",
+  "originHash" : "5cadd12433353b4144bcc99fd464b53c0aa36084b12784b90706859f84dad8c5",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "346950fb2d5263c5f4fbecd5f4c4f6579b4d1669",
-        "version" : "15.0.0"
+        "revision" : "ffa278884a4c61262a0cdc227084e838a8649c89",
+        "version" : "15.1.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mac-cain13/R.swift.git",
       "state" : {
-        "revision" : "4ac2eb7e6157887c9f59dc5ccc5978d51546be6d",
-        "version" : "7.7.0"
+        "revision" : "a9abc6b0afe0fc4a5a71e1d7d2872143dff2d2f1",
+        "version" : "7.8.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tomlokhorst/XcodeEdit",
       "state" : {
-        "revision" : "017d23f71fa8d025989610db26d548c44cacefae",
-        "version" : "2.10.2"
+        "revision" : "1e761a55dd8d73b4e9cc227a297f438413953571",
+        "version" : "2.11.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.1.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -28,18 +28,16 @@ struct MessageCell: View {
         VStack(alignment: .leading, spacing: .s) {
             reactionMenuIfAvailable
 
-            HStack {
-                VStack(alignment: .leading, spacing: .s) {
-                    pinnedIndicator
-                    resolvesPostIndicator
-                    headerIfVisible
-                    ArtemisMarkdownView(string: content)
-                        .opacity(isMessageOffline ? 0.5 : 1)
-                        .environment(\.openURL, OpenURLAction(handler: handle))
-                    editedLabel
-                    resolvedIndicator
-                }
-                Spacer()
+            VStack(alignment: .leading, spacing: .s) {
+                pinnedIndicator
+                resolvesPostIndicator
+                headerIfVisible
+                ArtemisMarkdownView(string: content.surroundingMarkdownImagesWithNewlines())
+                    .opacity(isMessageOffline ? 0.5 : 1)
+                    .environment(\.openURL, OpenURLAction(handler: handle))
+                    .environment(\.imagePreviewsEnabled, viewModel.conversationPath == nil)
+                editedLabel
+                resolvedIndicator
             }
             .contentShape(.rect)
             .onTapGesture(perform: onTapPresentMessage)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -39,6 +39,7 @@ struct MessageCell: View {
                 editedLabel
                 resolvedIndicator
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(.rect)
             .onTapGesture(perform: onTapPresentMessage)
             .onLongPressGesture(perform: onLongPressPresentActionSheet) { changed in


### PR DESCRIPTION
- Allow users to tap on images to view them full screen
- Allow zooming in full screen mode
- Center image

Note: You can only tap on images in the thread view, otherwise users may be unable to enter this view.

Closes #211 and #217

<video src="https://github.com/user-attachments/assets/93fe41ba-d871-4d2a-a7ff-da16cbb81e93">