### PR TITLE
`Communication`: Fix messages disappearing after being sent

### DIFF
--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -169,7 +169,7 @@ struct MessagesServiceImpl: MessagesService {
     }
 
     struct SendMessageRequest: APIRequest {
-        typealias Response = RawResponse
+        typealias Response = Message
 
         let courseId: Int
         let visibleForStudents: Bool
@@ -192,7 +192,10 @@ struct MessagesServiceImpl: MessagesService {
         )
 
         switch result {
-        case .success:
+        case .success(let response):
+            NotificationCenter.default.post(name: .newMessageSent,
+                                            object: nil,
+                                            userInfo: ["message": response.0])
             return .success
         case let .failure(error):
             return .failure(error: error)
@@ -924,4 +927,12 @@ private extension ConversationType {
             return nil
         }
     }
+}
+
+// MARK: Reload Notification
+
+extension Foundation.Notification.Name {
+    // Sending a notification of this type causes the Notification List to be reloaded,
+    // when favorites are changed from elsewhere.
+    static let newMessageSent = Foundation.Notification.Name("NewMessageSent")
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -330,6 +330,12 @@ private extension ConversationViewModel {
         } else {
             return
         }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(onOwnMessageSent(notification:)),
+                                               name: .newMessageSent,
+                                               object: nil)
+
         if stompClient.didSubscribeTopic(topic) {
             /// These web socket topics are the same across multiple channels.
             /// We might need to wait until a previously open conversation has unsubscribed
@@ -389,6 +395,15 @@ private extension ConversationViewModel {
             handle(delete: messageWebsocketDTO.post)
         default:
             return
+        }
+    }
+
+    @objc
+    func onOwnMessageSent(notification: Foundation.Notification) {
+        if let message = notification.userInfo?["message"] as? Message {
+            DispatchQueue.main.async {
+                self.onMessageReceived(messageWebsocketDTO: .init(post: message, action: .create, notification: nil))
+            }
         }
     }
 


### PR DESCRIPTION
Currently, when there is an unstable connection to the server via the web socket, messages might disappear after they were successfully sent. This is confusing. With this PR, we ensure the message is always inserted into the chat after it has been sent successfully.