### PR TITLE
`Communication`: Improve member picker

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -101,6 +101,8 @@
 "announcementChannelDescription" = "Only instructors and channel moderators can create new messages in an announcement channel. Students can only read the messages and answer to them.";
 "createChannelButtonLabel" = "Create Channel";
 "createChannelNavTitel" = "Create Channel";
+"noMatchingUsers" = "No matching users found";
+"enterAtLeast3Characters" = "Please enter at least three characters to start your search.";
 
 // MARK: BrowseChannelsView
 "joinedLabel" = "Joined";

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
@@ -95,11 +95,17 @@ private extension CreateOrAddToChatView {
             HStack {
                 ForEach(viewModel.selectedUsers.reversed(), id: \.id) { user in
                     if let name = user.name {
-                        Button(role: .destructive) {
+                        Button {
                             viewModel.unstage(user: user)
                         } label: {
-                            Chip(text: name, backgroundColor: .Artemis.artemisBlue)
-                        }
+                            HStack {
+                                ProfilePictureView(user: user, role: nil, course: .mock, size: 25)
+                                    .allowsHitTesting(false)
+                                Text(name)
+                            }
+                            .padding(.m)
+                            .background(Color.Artemis.artemisBlue, in: .rect(cornerRadius: .m))
+                        }.buttonStyle(.plain)
                     }
                 }
             }
@@ -126,7 +132,11 @@ private extension CreateOrAddToChatView {
                             Button {
                                 viewModel.stage(user: user)
                             } label: {
-                                Text(name)
+                                HStack {
+                                    ProfilePictureView(user: user, role: nil, course: .mock, size: 25)
+                                        .allowsHitTesting(false)
+                                    Text(name)
+                                }
                             }
                         }
                     }

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
@@ -115,20 +115,28 @@ private extension CreateOrAddToChatView {
         DataStateView(data: $viewModel.searchResults) {
             await viewModel.loadUsers()
         } content: { users in
-            List {
-                ForEach(
-                    users.filter({ user in !viewModel.selectedUsers.contains(where: { $0.id == user.id }) }), id: \.id
-                ) { user in
-                    if let name = user.name {
-                        Button {
-                            viewModel.stage(user: user)
-                        } label: {
-                            Text(name)
+            if viewModel.searchText.count < 3 {
+                ContentUnavailableView(R.string.localizable.enterAtLeast3Characters(),
+                                       systemImage: "magnifyingglass")
+            } else {
+                List {
+                    let displayedUsers = users.filter({ user in !viewModel.selectedUsers.contains(where: { $0.id == user.id }) })
+                    ForEach(displayedUsers, id: \.id) { user in
+                        if let name = user.name {
+                            Button {
+                                viewModel.stage(user: user)
+                            } label: {
+                                Text(name)
+                            }
                         }
                     }
+                    if displayedUsers.isEmpty {
+                        ContentUnavailableView(R.string.localizable.noMatchingUsers(),
+                                               systemImage: "person.slash.fill")
+                    }
                 }
+                .listStyle(.plain)
             }
-            .listStyle(.plain)
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateOrAddToChatView.swift
@@ -17,6 +17,7 @@ struct CreateOrAddToChatView: View {
         case addToChat(Conversation)
     }
 
+    @FocusState private var focused
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var navigationController: NavigationController
 
@@ -30,6 +31,7 @@ struct CreateOrAddToChatView: View {
                 selectedUsers
                 TextField(R.string.localizable.searchUsersLabel(), text: $viewModel.searchText)
                     .textFieldStyle(.roundedBorder)
+                    .focused($focused)
                     .padding(.horizontal, .l)
                 searchResults
             }
@@ -64,6 +66,9 @@ struct CreateOrAddToChatView: View {
                         }
                     }.disabled(viewModel.selectedUsers.isEmpty)
                 }
+            }
+            .onAppear {
+                focused = true
             }
             .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
         }


### PR DESCRIPTION
The user picker when adding members to a conversation can be improved:
- Show profile pictures
- Show a hint when no matches are found
- Show a hint when not enough characters were typed

<img src="https://github.com/user-attachments/assets/871afea9-47f2-452f-8f53-8e5b1fdd7d05" width="300">
<img src="https://github.com/user-attachments/assets/fe39ac77-c4ed-49fa-9d25-1b52c0068023" width="300">
