### PR TITLE
`Communication`: Streamline socket connection handling

### DIFF
--- a/ArtemisKit/Sources/Messages/Networking/SocketConnectionHandler.swift
+++ b/ArtemisKit/Sources/Messages/Networking/SocketConnectionHandler.swift
@@ -1,0 +1,105 @@
+//
+//  SocketConnectionHandler.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 15.11.24.
+//
+
+import APIClient
+import Combine
+import Foundation
+
+class SocketConnectionHandler {
+    private let stompClient = ArtemisStompClient.shared
+    let messagePublisher = PassthroughSubject<MessageWebsocketDTO, Never>()
+    let conversationPublisher = PassthroughSubject<ConversationWebsocketDTO, Never>()
+
+    private var channelSubscription: Task<(), Never>?
+    private var conversationSubscription: Task<(), Never>?
+    private var membershipSubscription: Task<(), Never>?
+
+    static let shared = SocketConnectionHandler()
+
+    private init() {}
+
+    func cancelSubscriptions() {
+        channelSubscription?.cancel()
+        conversationSubscription?.cancel()
+        membershipSubscription?.cancel()
+
+        channelSubscription = nil
+        conversationSubscription = nil
+        membershipSubscription = nil
+    }
+
+    func subscribeToChannelNotifications(courseId: Int) {
+        guard channelSubscription == nil else {
+            return
+        }
+
+        let topic = WebSocketTopic.makeChannelNotifications(courseId: courseId)
+
+        channelSubscription = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let stream = stompClient.subscribe(to: topic)
+
+            for await message in stream {
+                guard let messageWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: MessageWebsocketDTO.self, message: message) else {
+                    continue
+                }
+                print("Stomp channel")
+
+                messagePublisher.send(messageWebsocketDTO)
+            }
+        }
+    }
+
+    func subscribeToConversationNotifications(userId: Int64) {
+        guard conversationSubscription == nil else {
+            return
+        }
+
+        let topic = WebSocketTopic.makeConversationNotifications(userId: userId)
+
+        conversationSubscription = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let stream = stompClient.subscribe(to: topic)
+
+            for await message in stream {
+                guard let messageWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: MessageWebsocketDTO.self, message: message) else {
+                    continue
+                }
+                print("Stomp convo")
+                messagePublisher.send(messageWebsocketDTO)
+            }
+        }
+    }
+
+    func subscribeToMembershipNotifications(courseId: Int, userId: Int64) {
+        guard membershipSubscription == nil else {
+            return
+        }
+
+        let topic = WebSocketTopic.makeConversationMembershipNotifications(courseId: courseId, userId: userId)
+        membershipSubscription = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let stream = stompClient.subscribe(to: topic)
+
+            for await message in stream {
+                guard let conversationWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: ConversationWebsocketDTO.self, message: message) else {
+                    continue
+                }
+                conversationPublisher.send(conversationWebsocketDTO)
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -8,6 +8,7 @@
 import APIClient
 import Foundation
 import Common
+import Combine
 import Extensions
 import SharedModels
 import SharedServices
@@ -45,11 +46,10 @@ class ConversationViewModel: BaseViewModel {
     }
 
     var shouldScrollToId: String?
-    var subscription: Task<(), Never>?
+    var subscription: AnyCancellable?
 
     fileprivate let messagesRepository: MessagesRepository
     private let messagesService: MessagesService
-    private let stompClient: ArtemisStompClient
     private let userSession: UserSession
 
     init(
@@ -57,7 +57,6 @@ class ConversationViewModel: BaseViewModel {
         conversation: Conversation,
         messagesRepository: MessagesRepository? = nil,
         messagesService: MessagesService = MessagesServiceFactory.shared,
-        stompClient: ArtemisStompClient = .shared,
         userSession: UserSession = UserSessionFactory.shared
     ) {
         self.course = course
@@ -65,7 +64,6 @@ class ConversationViewModel: BaseViewModel {
 
         self.messagesRepository = messagesRepository ?? .shared
         self.messagesService = messagesService
-        self.stompClient = stompClient
         self.userSession = userSession
 
         super.init()
@@ -320,49 +318,28 @@ private extension ConversationViewModel {
     // MARK: Initializer
 
     func subscribeToConversationTopic() {
-        let topic: String
+        let socketConnection = SocketConnectionHandler.shared
+        subscription = socketConnection
+            .messagePublisher
+            .sink { [weak self] messageWebsocketDTO in
+                guard let self else {
+                    return
+                }
+                onMessageReceived(messageWebsocketDTO: messageWebsocketDTO)
+            }
+
         if conversation.baseConversation.type == .channel,
            let channel = conversation.baseConversation as? Channel,
            channel.isCourseWide == true {
-            topic = WebSocketTopic.makeChannelNotifications(courseId: course.id)
+            socketConnection.subscribeToChannelNotifications(courseId: course.id)
         } else if let id = userSession.user?.id {
-            topic = WebSocketTopic.makeConversationNotifications(userId: id)
-        } else {
-            return
+            socketConnection.subscribeToConversationNotifications(userId: id)
         }
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(onOwnMessageSent(notification:)),
                                                name: .newMessageSent,
                                                object: nil)
-
-        if stompClient.didSubscribeTopic(topic) {
-            /// These web socket topics are the same across multiple channels.
-            /// We might need to wait until a previously open conversation has unsubscribed
-            /// before we can subscribe again
-            Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
-                DispatchQueue.main.async { [weak self] in
-                    self?.subscribeToConversationTopic()
-                }
-            }
-            return
-        }
-        subscription = Task { [weak self] in
-            guard let stream = self?.stompClient.subscribe(to: topic) else {
-                return
-            }
-
-            for await message in stream {
-                guard let messageWebsocketDTO = JSONDecoder.getTypeFromSocketMessage(type: MessageWebsocketDTO.self, message: message) else {
-                    continue
-                }
-
-                guard let self else {
-                    return
-                }
-                onMessageReceived(messageWebsocketDTO: messageWebsocketDTO)
-            }
-        }
     }
 
     func fetchOfflineMessages() {
@@ -386,15 +363,17 @@ private extension ConversationViewModel {
         guard messageWebsocketDTO.post.conversation?.id == conversation.id else {
             return
         }
-        switch messageWebsocketDTO.action {
-        case .create:
-            handle(new: messageWebsocketDTO.post)
-        case .update:
-            handle(update: messageWebsocketDTO.post)
-        case .delete:
-            handle(delete: messageWebsocketDTO.post)
-        default:
-            return
+        DispatchQueue.main.async {
+            switch messageWebsocketDTO.action {
+            case .create:
+                self.handle(new: messageWebsocketDTO.post)
+            case .update:
+                self.handle(update: messageWebsocketDTO.post)
+            case .delete:
+                self.handle(delete: messageWebsocketDTO.post)
+            default:
+                return
+            }
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -136,11 +136,9 @@ public struct ConversationView: View {
             await viewModel.loadMessages()
         }
         .onDisappear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                if navigationController.selectedCourse == nil {
-                    // only cancel task if we navigate back
-                    viewModel.subscription?.cancel()
-                }
+            if navigationController.courseTab != .communication && navigationController.tabPath.isEmpty {
+                // only cancel task if we leave communication
+                SocketConnectionHandler.shared.cancelSubscriptions()
             }
             viewModel.saveContext()
         }


### PR DESCRIPTION
Handling subscriptions to web socket topics is currently spread across multiple files and locations. This makes it easy to miss something when updating the logic. This PR moves it all into one file and allows for simpler handling of connections.

It also enables us in the future to make use of the same topic in multiple locations simultaneously without workarounds.

The current logic may also have a few bugs related to conversations sharing a topic and thus not being able to subscribe correctly.