### PR TITLE
`Communication`: Fix cut off channel names

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -69,7 +69,8 @@ struct MessageDetailView: View {
                                 .frame(height: .m * 1.5)
                         }
                         .frame(maxWidth: 25)
-                        Text(viewModel.conversation.baseConversation.conversationName)
+                        Text(viewModel.conversation.baseConversation.conversationName + "    ")
+                            .frame(maxWidth: 220)
                     }
                     .font(.footnote)
                 }.padding(.leading, .m)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -69,6 +69,7 @@ struct MessageDetailView: View {
                                 .frame(height: .m * 1.5)
                         }
                         .frame(maxWidth: 25)
+                        // Workaround: Trailing spaces, otherwise SwiftUI shortens this prematurely
                         Text(viewModel.conversation.baseConversation.conversationName + "    ")
                             .frame(maxWidth: 220)
                     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -60,9 +60,15 @@ struct MessageDetailView: View {
                     Text(R.string.localizable.thread())
                         .fontWeight(.semibold)
                     HStack(spacing: .s) {
-                        viewModel.conversation.baseConversation.icon?
-                            .scaledToFit()
-                            .frame(height: .m * 1.5)
+                        ViewThatFits(in: .horizontal) {
+                            viewModel.conversation.baseConversation.icon?
+                                .scaledToFit()
+                                .frame(height: .m * 1.5)
+                            viewModel.conversation.baseConversation.icon?
+                                .scaleEffect(0.5)
+                                .frame(height: .m * 1.5)
+                        }
+                        .frame(maxWidth: 25)
                         Text(viewModel.conversation.baseConversation.conversationName)
                     }
                     .font(.footnote)


### PR DESCRIPTION
In the thread view, channel names are often abbreviated with "…" despite there being enough room to display the entire title.