### PR TITLE
`Communication`: Fix network error when opening chats

### DIFF
--- a/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
@@ -26,7 +26,7 @@ final class ConversationPathViewModel {
         self.messagesService = messagesService
     }
 
-    func loadConversation() async {
+    func reloadConversation() async {
         let result = await messagesService.getConversations(for: path.coursePath.id)
         self.conversation = result.flatMap { conversations in
             if let conversation = conversations.first(where: { $0.id == path.id }) {
@@ -35,5 +35,16 @@ final class ConversationPathViewModel {
                 return .failure(UserFacingError(title: R.string.localizable.conversationNotLoaded()))
             }
         }
+    }
+
+    func loadConversation() async {
+        // If conversation is loaded already, skip
+        switch conversation {
+        case .done:
+            return
+        default:
+            break
+        }
+        await reloadConversation()
     }
 }

--- a/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
@@ -17,7 +17,7 @@ public struct ConversationPathView<Content: View>: View {
 
     public var body: some View {
         DataStateView(data: $viewModel.conversation) {
-            await viewModel.loadConversation()
+            await viewModel.reloadConversation()
         } content: { conversation in
             CoursePathView(path: viewModel.path.coursePath) { course in
                 content(course, conversation)

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -29,6 +29,7 @@ class ConversationViewModel: BaseViewModel {
 
     @Published var isConversationInfoSheetPresented = false
     @Published var selectedMessageId: Int64?
+    @Published var isLoadingMessages = true
 
     var isAllowedToPost: Bool {
         guard let channel = conversation.baseConversation as? Channel else {
@@ -75,6 +76,10 @@ class ConversationViewModel: BaseViewModel {
                                                selector: #selector(updateFavorites(notification:)),
                                                name: .favoriteConversationChanged,
                                                object: nil)
+
+        Task {
+            await loadMessages()
+        }
     }
 
     deinit {
@@ -100,6 +105,10 @@ extension ConversationViewModel {
     }
 
     func loadMessages() async {
+        defer {
+            isLoadingMessages = false
+        }
+
         let result = await messagesService.getMessages(for: course.id, and: conversation.id, page: page)
         switch result {
         case .loading:

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -39,6 +39,7 @@ public struct ConversationView: View {
                     R.string.localizable.noMessages(),
                     systemImage: "bubble.right",
                     description: Text(R.string.localizable.noMessagesDescription()))
+                .loadingIndicator(isLoading: $viewModel.isLoadingMessages)
             } else {
                 ScrollViewReader { value in
                     ScrollView {
@@ -130,10 +131,6 @@ public struct ConversationView: View {
         }
         .sheet(isPresented: $viewModel.isConversationInfoSheetPresented) {
             ConversationInfoSheetView(course: viewModel.course, conversation: $viewModel.conversation)
-        }
-        .task {
-            viewModel.shouldScrollToId = "bottom"
-            await viewModel.loadMessages()
         }
         .onDisappear {
             if navigationController.courseTab != .communication && navigationController.tabPath.isEmpty {

--- a/ArtemisKit/Sources/Navigation/PathViewModels.swift
+++ b/ArtemisKit/Sources/Navigation/PathViewModels.swift
@@ -24,7 +24,20 @@ final class CoursePathViewModel {
         self.courseService = courseService
     }
 
+    func reloadCourse() async {
+        let result = await courseService.getCourse(courseId: path.id)
+        self.course = result.map(\.course)
+    }
+
     func loadCourse() async {
+        // If course is already loaded, skip this
+        switch course {
+        case .done:
+            return
+        default:
+            break
+        }
+
         let start = Date().timeIntervalSince1970
 
         let result = await courseService.getCourse(courseId: path.id)

--- a/ArtemisKit/Sources/Navigation/PathViews.swift
+++ b/ArtemisKit/Sources/Navigation/PathViews.swift
@@ -16,7 +16,7 @@ public struct CoursePathView<Content: View>: View {
 
     public var body: some View {
         DataStateView(data: $viewModel.course) {
-            await viewModel.loadCourse()
+            await viewModel.reloadCourse()
         } content: { course in
             content(course)
         }


### PR DESCRIPTION
This PR fixes the "Network error: Cancelled" message that often briefly appears when opening a conversation.

It also adds a loading indicator when opening chats for the first time before the messages are loaded.