### PR TITLE
`Communication`: Add message filter options

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
@@ -1,0 +1,71 @@
+//
+//  MessageRequestFilter.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 16.11.24.
+//
+
+import Foundation
+import SwiftUI
+
+class MessageRequestFilter: Codable {
+    var filters: [FilterOption]
+
+    init(filterToUnresolved: Bool = false,
+         filterToOwn: Bool = false,
+         filterToAnsweredOrReacted: Bool = false) {
+        self.filters = [
+            .init(name: "filterToUnresolved", enabled: filterToUnresolved),
+            .init(name: "filterToOwn", enabled: filterToOwn),
+            .init(name: "filterToAnsweredOrReacted", enabled: filterToAnsweredOrReacted)
+        ]
+    }
+
+    var selectedFilter: String {
+        get {
+            self.filters.first { $0.enabled }?.name ?? "all"
+        }
+        set {
+            if newValue == "all" {
+                self.filters = self.filters.map {
+                    FilterOption(name: $0.name, enabled: false)
+                }
+            } else {
+                self.filters = self.filters.map {
+                    FilterOption(name: $0.name, enabled: $0.name == newValue)
+                }
+            }
+        }
+
+    }
+
+    var queryItems: [URLQueryItem] {
+        var items: [URLQueryItem] = filters.compactMap { filter in
+            if filter.enabled {
+                return .init(name: filter.name, value: "true")
+            } else {
+                return nil
+            }
+        }
+        return items
+    }
+}
+
+struct FilterOption: Codable, Hashable {
+    let name: String
+    let enabled: Bool
+
+    var displayName: String {
+        // TODO: Localize
+        switch name {
+        case "filterToAnsweredOrReacted":
+            return "Reacted"
+        case "filterToUnresolved":
+            return "Unresolved"
+        case "filterToOwn":
+            return "Own"
+        default:
+            return ""
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
@@ -56,14 +56,13 @@ struct FilterOption: Codable, Hashable {
     let enabled: Bool
 
     var displayName: String {
-        // TODO: Localize
         switch name {
         case "filterToAnsweredOrReacted":
-            return "Reacted"
+            return R.string.localizable.messageFilterReacted()
         case "filterToUnresolved":
-            return "Unresolved"
+            return R.string.localizable.messageFilterUnresolved()
         case "filterToOwn":
-            return "Own"
+            return R.string.localizable.messageFilterOwn()
         default:
             return ""
         }

--- a/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
@@ -51,7 +51,9 @@ class MessageRequestFilter: Codable {
             let reacted = message.reactions?.contains(where: { $0.user?.id == UserSessionFactory.shared.user?.id }) ?? false
             return answered || reacted
         case .filterToOwn:
-            return message.isCurrentUserAuthor
+            let isOwn = message.isCurrentUserAuthor
+            let didReply = message.answers?.contains { $0.isCurrentUserAuthor } ?? false
+            return isOwn || didReply
         case .filterToUnresolved:
             return !(message.resolved ?? false)
         default:

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 // MARK: ConversationView
 "noMessages" = "No Messages";
 "noMessagesDescription" = "Write the first message to kickstart this conversation.";
+"noMatchingMessages" = "No messages match the selected filter.";
 "reply" = "reply";
 "new" = "New";
 "pinned" = "Pinned";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "resolvesPost" = "Resolves Post";
 "filterMessages" = "Filter Messages";
 "details" = "Details";
+"messageFilterReacted" = "Reacted";
+"messageFilterUnresolved" = "Unresolved";
+"messageFilterOwn" = "Own";
 
 // MARK: CreateChannelView
 "channelNameLabel" = "Name";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -89,6 +89,8 @@
 "pinned" = "Pinned";
 "resolved" = "Resolved";
 "resolvesPost" = "Resolves Post";
+"filterMessages" = "Filter Messages";
+"details" = "Details";
 
 // MARK: CreateChannelView
 "channelNameLabel" = "Name";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -36,7 +36,7 @@ protocol MessagesService {
     /**
      * Perform a get request for Messages of a specific conversation in a specific course to the server.
      */
-    func getMessages(for courseId: Int, and conversationId: Int64, page: Int) async -> DataState<[Message]>
+    func getMessages(for courseId: Int, and conversationId: Int64, filter: MessageRequestFilter, page: Int) async -> DataState<[Message]>
 
     /**
      * Perform a post request for a new message for a specific conversation in a specific course to the server.

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -136,6 +136,7 @@ struct MessagesServiceImpl: MessagesService {
         let courseId: Int
         let conversationId: Int64
         let page: Int
+        let filter: MessageRequestFilter
 
         var method: HTTPMethod {
             return .get
@@ -149,7 +150,7 @@ struct MessagesServiceImpl: MessagesService {
                 .init(name: "pagingEnabled", value: "true"),
                 .init(name: "page", value: String(describing: page)),
                 .init(name: "size", value: String(describing: Self.size))
-            ]
+            ] + filter.queryItems
         }
 
         var resourceName: String {
@@ -157,8 +158,8 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
-    func getMessages(for courseId: Int, and conversationId: Int64, page: Int) async -> DataState<[Message]> {
-        let result = await client.sendRequest(GetMessagesRequest(courseId: courseId, conversationId: conversationId, page: page))
+    func getMessages(for courseId: Int, and conversationId: Int64, filter: MessageRequestFilter = .init(), page: Int) async -> DataState<[Message]> {
+        let result = await client.sendRequest(GetMessagesRequest(courseId: courseId, conversationId: conversationId, page: page, filter: filter))
 
         switch result {
         case let .success((messages, _)):

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -109,7 +109,7 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
-    func getMessages(for courseId: Int, and conversationId: Int64, page: Int) async -> DataState<[Message]> {
+    func getMessages(for courseId: Int, and conversationId: Int64, filter: MessageRequestFilter, page: Int) async -> DataState<[Message]> {
         .done(response: messages)
     }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -407,6 +407,10 @@ private extension ConversationViewModel {
     }
 
     func handle(new message: Message) {
+        // Only insert message if it matches current filter
+        guard filter.messageMatchesSelectedFilter(message) else {
+            return
+        }
         shouldScrollToId = message.id.description
         let (inserted, _) = messages.insert(.message(message))
         if inserted {
@@ -428,6 +432,12 @@ private extension ConversationViewModel {
                 let oldAnswer = oldMessage?.rawValue.answers?.first { $0.id == answer.id }
                 newAnswer.authorRole = newAnswer.authorRole ?? oldAnswer?.authorRole
                 return newAnswer
+            }
+
+            // If message no longer matches filter, remove it
+            if !filter.messageMatchesSelectedFilter(newMessage) {
+                handle(delete: message)
+                return
             }
 
             messages.update(with: .message(newMessage))

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -129,12 +129,12 @@ public struct ConversationView: View {
                         Label(R.string.localizable.details(), systemImage: "info")
                     }
                     Picker(selection: $viewModel.filter.selectedFilter) {
+                        Text(R.string.localizable.allFilter())
+                            .tag("all")
                         ForEach(viewModel.filter.filters, id: \.self) { filter in
                             Text(filter.displayName)
                                 .tag(filter.name)
                         }
-                        Text(R.string.localizable.allFilter())
-                            .tag("all")
                     } label: {
                         Label(R.string.localizable.filterMessages(),
                               systemImage: "line.3.horizontal.decrease")

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -38,7 +38,11 @@ public struct ConversationView: View {
                 ContentUnavailableView(
                     R.string.localizable.noMessages(),
                     systemImage: "bubble.right",
-                    description: Text(R.string.localizable.noMessagesDescription()))
+                    description:
+                        viewModel.filter.selectedFilter == "all" ?
+                            Text(R.string.localizable.noMessagesDescription()) :
+                            Text(R.string.localizable.noMatchingMessages())
+                )
             } else {
                 ScrollViewReader { value in
                     ScrollView {

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -39,7 +39,6 @@ public struct ConversationView: View {
                     R.string.localizable.noMessages(),
                     systemImage: "bubble.right",
                     description: Text(R.string.localizable.noMessagesDescription()))
-                .loadingIndicator(isLoading: $viewModel.isLoadingMessages)
             } else {
                 ScrollViewReader { value in
                     ScrollView {
@@ -91,6 +90,7 @@ public struct ConversationView: View {
                 )
             }
         }
+        .loadingIndicator(isLoading: $viewModel.isLoadingMessages)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
@@ -122,10 +122,26 @@ public struct ConversationView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    viewModel.isConversationInfoSheetPresented = true
+                Menu {
+                    Button {
+                        viewModel.isConversationInfoSheetPresented = true
+                    } label: {
+                        Label(R.string.localizable.details(), systemImage: "info")
+                    }
+                    Picker(selection: $viewModel.filter.selectedFilter) {
+                        ForEach(viewModel.filter.filters, id: \.self) { filter in
+                            Text(filter.displayName)
+                                .tag(filter.name)
+                        }
+                        Text(R.string.localizable.allFilter())
+                            .tag("all")
+                    } label: {
+                        Label(R.string.localizable.filterMessages(),
+                              systemImage: "line.3.horizontal.decrease")
+                    }
+                    .pickerStyle(.menu)
                 } label: {
-                    Image(systemName: "info.circle")
+                    Image(systemName: "ellipsis.circle")
                 }
             }
         }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 
 struct MessageDetailView: View {
 
+    @EnvironmentObject var navController: NavigationController
     @ObservedObject var viewModel: ConversationViewModel
     @Binding private var message: DataState<BaseMessage>
 
@@ -80,6 +81,17 @@ struct MessageDetailView: View {
         .task {
             if message.value == nil {
                 await reloadMessage()
+            }
+        }
+        .onChange(of: message) {
+            switch message {
+            case .loading:
+                // Message was deleted
+                if !navController.tabPath.isEmpty {
+                    navController.tabPath.removeLast()
+                }
+            default:
+                break
             }
         }
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})


### PR DESCRIPTION
This PR adds options for filtering messages inside a conversation.

<img src="https://github.com/user-attachments/assets/b1a75426-5ae4-4745-a1a4-9422bb241cac" width="300" alt="New menu">
<img src="https://github.com/user-attachments/assets/9c03ff3c-a828-4992-a89a-0476d18d0fca" width="300" alt="Filter options">
