### PR TITLE
`Communication`: Remove delivered notifications when entering/leaving channel

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -138,6 +138,9 @@ public struct ConversationView: View {
                 SocketConnectionHandler.shared.cancelSubscriptions()
             }
             viewModel.saveContext()
+            Task {
+                await viewModel.removeAssociatedNotifications()
+            }
         }
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
Currently, notifications are only removed if the user taps on them to open them, or manually deletes them.
With this PR, we want to remove notifications for a conversation as soon as the user enters or leaves that conversation, indicating that they have already seen these messages.