### PR TITLE
`Communication`: Remove edit button for instructors

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -95,7 +95,7 @@ struct MessageActions: View {
         @State private var showDeleteAlert = false
         @State private var showEditSheet = false
 
-        var isAbleToEditDelete: Bool {
+        var canDelete: Bool {
             guard let message = message.value else {
                 return false
             }
@@ -107,7 +107,19 @@ struct MessageActions: View {
             guard let channel = viewModel.conversation.baseConversation as? Channel else {
                 return false
             }
-            if channel.hasChannelModerationRights ?? false && message is Message {
+            if channel.hasChannelModerationRights ?? false {
+                return true
+            }
+
+            return false
+        }
+
+        var canEdit: Bool {
+            guard let message = message.value else {
+                return false
+            }
+
+            if message.isCurrentUserAuthor {
                 return true
             }
 
@@ -116,9 +128,10 @@ struct MessageActions: View {
 
         var body: some View {
             Group {
-                if isAbleToEditDelete {
+                if canEdit || canDelete {
                     Divider()
-
+                }
+                if canEdit {
                     Button(R.string.localizable.editMessage(), systemImage: "pencil") {
                         showEditSheet = true
                     }
@@ -128,7 +141,8 @@ struct MessageActions: View {
                         editMessage
                             .font(nil)
                     }
-
+                }
+                if canDelete {
                     Button(R.string.localizable.deleteMessage(), systemImage: "trash", role: .destructive) {
                         showDeleteAlert = true
                     }


### PR DESCRIPTION
### Problem
Instructors are currently allowed to edit any message, even if it is from someone else.

### Solution
We only show the edit button on a user's own message. The delete button is shown on a user's message and if the user is instructor.