### PR TITLE
`Notifications`: Fix notifications not navigating to target

### DIFF
--- a/Artemis/ArtemisApp.swift
+++ b/Artemis/ArtemisApp.swift
@@ -1,4 +1,5 @@
 import ArtemisKit
+import Navigation
 import SwiftUI
 
 @main
@@ -8,10 +9,11 @@ struct ArtemisApp: App {
     private var delegate: AppDelegate
 
     @Environment(\.scenePhase) private var scenePhase
+    @StateObject private var navigationController = NavigationController()
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            RootView(navigationController: navigationController)
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .background {
                         delegate.applicationDidEnterBackground(UIApplication.shared)

--- a/ArtemisKit/Sources/ArtemisKit/RootView.swift
+++ b/ArtemisKit/Sources/ArtemisKit/RootView.swift
@@ -12,9 +12,11 @@ public struct RootView: View {
 
     @StateObject private var viewModel = RootViewModel()
 
-    @StateObject private var navigationController = NavigationController()
+    @ObservedObject private var navigationController: NavigationController
 
-    public init() {}
+    public init(navigationController: NavigationController) {
+        self.navigationController = navigationController
+    }
 
     public var body: some View {
         Group {

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -67,12 +67,6 @@ public struct CourseView: View {
         .onChange(of: navigationController.courseTab) {
             searchText = ""
         }
-        .onDisappear {
-            if navigationController.outerPath.count < 2 {
-                // Reset selection if navigating back
-                navigationController.selectedPath = nil
-            }
-        }
     }
 }
 

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -46,6 +46,7 @@ public extension NavigationController {
         outerPath = NavigationPath()
         tabPath = NavigationPath()
         selectedCourse = nil
+        selectedPath = nil
     }
 
     func goToCourse(id: Int) {


### PR DESCRIPTION
When tapping on notifications, sometimes the corresponding target is not opened. This happens if the app is not running, as the NavigationController is not set yet.