### PR TITLE
`Chore`/`Communication`: Fix state change during view update console error

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageMentionContentView.swift
@@ -15,7 +15,7 @@ struct SendMessageMentionContentView: View {
     var body: some View {
         NavigationStack {
             let delegate = SendMessageMentionContentDelegate { [weak viewModel] mention in
-                if let selection = viewModel?.selection {
+                if let selection = viewModel?.selection.wrappedValue {
                     switch selection.indices {
                     case .selection(let range):
                         viewModel?.text.insert(contentsOf: mention, at: range.upperBound)

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -40,6 +40,9 @@ struct SendMessageView: View {
                     .background(.bar)
             }
         }
+        .onChange(of: isFocused, initial: true) {
+            viewModel.keyboardVisible = isFocused
+        }
         .onAppear {
             viewModel.performOnAppear()
             if viewModel.presentKeyboardOnAppear {
@@ -96,7 +99,7 @@ private extension SendMessageView {
             TextField(
                 R.string.localizable.messageAction(viewModel.conversation.baseConversation.conversationName),
                 text: $viewModel.text,
-                selection: $viewModel.selection,
+                selection: viewModel.selection,
                 axis: .vertical
             )
             .textFieldStyle(.roundedBorder)


### PR DESCRIPTION
Whenever a conversation/thread is opened, on the console there is an error message:
> Modifying state during view update. This could lead to undefined behavior.

This PR fixes this. It was caused by SwiftUI updating the TextSelection for no reason twice when the text field appears.