### PR TITLE
`Dashboard`: Fix card background changing when notifications are open

### DIFF
--- a/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
+++ b/ArtemisKit/Sources/Notifications/Views/View+NotificationToolbar.swift
@@ -22,8 +22,6 @@ private struct NotificationBell: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            // Prevent user from accidentally tapping buttons outside the popover while open
-            .disabled(isNotificationSheetPresented)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {


### PR DESCRIPTION
When opening the notifications, the background color of course cards changes slightly. This PR fixes this.