### PR TITLE
`Communication`: Fix Upload Image screen stuck on "Done"

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageImagePickerView.swift
@@ -65,18 +65,6 @@ private struct UploadImageView: View {
             .animation(.smooth(duration: 0.2), value: viewModel.uploadState)
         }
         .interactiveDismissDisabled()
-        .onChange(of: viewModel.uploadState) {
-            if viewModel.uploadState == .done {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    dismiss()
-                }
-            }
-            if viewModel.error != nil {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    dismiss()
-                }
-            }
-        }
     }
 
     @ViewBuilder var statusIcon: some View {
@@ -89,10 +77,20 @@ private struct UploadImageView: View {
             if viewModel.uploadState == .done {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.green)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            dismiss()
+                        }
+                    }
             }
             if viewModel.error != nil {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.red)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            dismiss()
+                        }
+                    }
             }
         }
         .font(.largeTitle)


### PR DESCRIPTION
Due to `onChange` not always being called for some reason, the Upload Image screen could get stuck open on "Done".

We fix this by dismissing it after the "Done" checkmark appears as this is the same condition, instead of relying on `onChange`.