### PR TITLE
`Communication`: Fix keyboard toolbar not working when using iPad hardware keyboard

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -144,6 +144,7 @@ extension SendMessageViewModel {
     }
 
     func performOnDisappear() {
+        keyboardVisible = false
         do {
             if let host = userSession.institution?.baseURL?.host() {
                 switch configuration {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -33,7 +33,7 @@ struct SendMessageView: View {
             }
             textField
                 .padding(isFocused ? [.horizontal, .bottom] : .all, .l)
-            if isFocused {
+            if isFocused || viewModel.keyboardVisible {
                 keyboardToolbarContent
                     .padding(.horizontal, .l)
                     .padding(.vertical, .m)
@@ -41,7 +41,11 @@ struct SendMessageView: View {
             }
         }
         .onChange(of: isFocused, initial: true) {
-            viewModel.keyboardVisible = isFocused
+            // Don't set keyboardVisible to false automatically on iPad
+            // Focus with hardware keyboard is messed up, this is a workaround
+            if UIDevice.current.userInterfaceIdiom != .pad || isFocused {
+                viewModel.keyboardVisible = isFocused
+            }
         }
         .onAppear {
             viewModel.performOnAppear()
@@ -58,6 +62,7 @@ struct SendMessageView: View {
                     if value.translation.height > 0 {
                         // down
                         isFocused = false
+                        viewModel.keyboardVisible = false
                         let impactMed = UIImpactFeedbackGenerator(style: .medium)
                         impactMed.impactOccurred()
                     }


### PR DESCRIPTION
When using an iPad with a hardware keyboard, some of the actions on the compose message toolbar were not usable.

This was caused by the textfield losing focus when a menu is opened while a hardware keyboard is connected. We work around this by manually tracking focus and only resetting it on the iPad when the compose area is actually dismissed.

This likely also caused confusion for users as it was not clear some of the buttons are menus, see linked issue