### PR TITLE
`FAQ`: Add missing localization for selecting FAQ

### DIFF
--- a/ArtemisKit/Sources/Navigation/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Navigation/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,4 @@
 "selectConversation" = "Please Select a Conversation.";
 "selectLecture" = "Please Select a Lecture.";
 "selectExercise" = "Please Select an Exercise.";
+"selectFaq" = "Please Select an FAQ.";

--- a/ArtemisKit/Sources/Navigation/SplitViewSupporting/SelectDetailView.swift
+++ b/ArtemisKit/Sources/Navigation/SplitViewSupporting/SelectDetailView.swift
@@ -48,7 +48,7 @@ public struct SelectDetailView: View {
         case .communication:
             R.string.localizable.selectConversation()
         case .faq:
-            "Select faq" // TODO
+            R.string.localizable.selectFaq()
         }
     }
 }


### PR DESCRIPTION
When no FAQ is selected in Split View, there is a placeholder "Select faq" which I missed. This PR updates it to a proper description.