### PR TITLE
`Notifications`: Support focus communication notifications

### DIFF
--- a/Artemis.entitlements
+++ b/Artemis.entitlements
@@ -25,6 +25,8 @@
 		<string>webcredentials:artemis-test6.artemis.cit.tum.de</string>
 		<string>webcredentials:artemis-test9.artemis.cit.tum.de</string>
 	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)de.tum.cit.ase.artemis</string>

--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		51B0EFCA2CE6468700927F30 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_VERSION_NUMBER = "$(APP_VERSION_NUMBER)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = ArtemisNotificationExtension/ArtemisNotificationExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -428,6 +429,7 @@
 		51B0EFCB2CE6468700927F30 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_VERSION_NUMBER = "$(APP_VERSION_NUMBER)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = ArtemisNotificationExtension/ArtemisNotificationExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -504,6 +506,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_VERSION_NUMBER = 1.6.0;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -567,6 +570,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_VERSION_NUMBER = 1.6.0;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -624,6 +628,7 @@
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_VERSION_NUMBER = "$(APP_VERSION_NUMBER)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Artemis.entitlements;
@@ -653,6 +658,7 @@
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_VERSION_NUMBER = "$(APP_VERSION_NUMBER)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Artemis.entitlements;

--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(APP_VERSION_NUMBER)";
 				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.ase.artemis.ArtemisNotificationExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -448,7 +448,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "$(APP_VERSION_NUMBER)";
 				PRODUCT_BUNDLE_IDENTIFIER = de.tum.cit.ase.artemis.ArtemisNotificationExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "60201ec1c26be7adad9fdf6611cc7c649da23b2d45f1aa466264a869dc6de3a1",
+  "originHash" : "65d5feea92024c72bff54ba2bd921950d359ec88bac673e3ac6317c7f9dc434c",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "f28438e6960df1c91bbfa59e53f46670430f509e",
-        "version" : "15.1.4"
+        "revision" : "787cc65dec2df54ca98ff917b30b55b66bb2d9d2",
+        "version" : "15.2.0"
       }
     },
     {

--- a/Artemis/Supporting/Info.plist
+++ b/Artemis/Supporting/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/Artemis/Supporting/Info.plist
+++ b/Artemis/Supporting/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>$(APP_VERSION_NUMBER)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/Kelvas09/EmojiPicker.git", from: "1.0.0"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.1.2")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.2.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -114,6 +114,7 @@ let package = Package(
                 "Faq",
                 "Navigation",
                 .product(name: "EmojiPicker", package: "EmojiPicker"),
+                .product(name: "Smile", package: "Smile"),
                 .product(name: "APIClient", package: "artemis-ios-core-modules"),
                 .product(name: "ArtemisMarkdown", package: "artemis-ios-core-modules"),
                 .product(name: "DesignLibrary", package: "artemis-ios-core-modules"),

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/UploadFileView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/UploadFileView.swift
@@ -78,4 +78,3 @@ struct UploadFileProgressView: View {
         }
     }
 }
-

--- a/ArtemisNotificationExtension/Info.plist
+++ b/ArtemisNotificationExtension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleShortVersionString</key>
+	<string>$(APP_VERSION_NUMBER)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ArtemisNotificationExtension/NotificationService.swift
+++ b/ArtemisNotificationExtension/NotificationService.swift
@@ -35,6 +35,17 @@ class NotificationService: UNNotificationServiceExtension {
             bestAttemptContent = await PushNotificationHandler
                 .extractNotification(from: payloadString, iv: initVector) ?? bestAttemptContent
 
+            // Add communication notification info
+            if let intent = await PushNotificationHandler.getCommunicationIntent(for: bestAttemptContent) {
+                do {
+                    let content = try bestAttemptContent.updating(from: intent)
+                    contentHandler(content)
+                    return
+                } catch {
+                    // Ignore error in case of failure and use previous best attempt content
+                }
+            }
+
             contentHandler(bestAttemptContent)
         }
     }


### PR DESCRIPTION
This PR adds support for iOS Communication Notifications.

- Profile Pictures
- More streamlined content (no more "Sent a message regarding exercise x in course y")
- Grouping notifications per thread

- [x] Update core modules

### New vs old
<img src="https://github.com/user-attachments/assets/56b6c8ac-c448-4bc1-93ee-d8b59f30b244" width="300" alt="New vs old">

### Examples (with/without profile pic set, in channel, thread, dm)
<img src="https://github.com/user-attachments/assets/efea723c-4bef-4697-8d67-bf676a00996d" width="330" alt="Examples">

