### PR TITLE
`Communication`: Fix scroll gesture conflict

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d98f8b8207dd2f669664cadc42e7d9f386e6aa80a1ad0c3e37c5b13e2081ecc9",
+  "originHash" : "60201ec1c26be7adad9fdf6611cc7c649da23b2d45f1aa466264a869dc6de3a1",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "5e4b1223bf33b542bcef2b844f7c451ac0ed7a9e",
         "version" : "1.0.9"
+      }
+    },
+    {
+      "identity" : "artemis-ios-core-modules",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
+      "state" : {
+        "revision" : "f28438e6960df1c91bbfa59e53f46670430f509e",
+        "version" : "15.1.4"
       }
     },
     {

--- a/Artemis/Supporting/Info.plist
+++ b/Artemis/Supporting/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -120,7 +120,8 @@ let package = Package(
                 .product(name: "SharedModels", package: "artemis-ios-core-modules"),
                 .product(name: "SharedServices", package: "artemis-ios-core-modules"),
                 .product(name: "UserStore", package: "artemis-ios-core-modules"),
-                .product(name: "RswiftLibrary", package: "R.swift")
+                .product(name: "RswiftLibrary", package: "R.swift"),
+                .product(name: "Smile", package: "Smile")
             ],
             plugins: [
                 .plugin(name: "RswiftGeneratePublicResources", package: "R.swift")

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageCellModel.swift
@@ -100,10 +100,10 @@ class SwipeToReplyState {
 
     /// Update all view properies associated with swiping to reply
     func update(with distance: CGFloat) {
-        overlayOffset = 200 * exp((distance - 10) / 30)
-        messageBlur = max((-distance - 25) * 0.2 * blurIntensity, 0)
-        overlayOpacity = max(0, min(-(distance + 40) * 0.05, 1))
-        overlayScale = max(0, min(-(distance + 40) * 0.03, 1))
+        overlayOffset = 200 * exp((distance - 15) / 30)
+        messageBlur = max((-distance - 30) * 0.2 * blurIntensity, 0)
+        overlayOpacity = max(0, min(-(distance + 35) * 0.05, 1))
+        overlayScale = max(0, min(-(distance + 35) * 0.03, 1))
 
         // If user dragged far enough to activate reply, let them know
         if !swiped && distance < -70 {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/SwipeToReply.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/SwipeToReply.swift
@@ -38,7 +38,7 @@ struct SwipeToReply: ViewModifier {
     }
 
     var swipeToReplyGesture: some Gesture {
-        DragGesture(minimumDistance: 20)
+        DragGesture(minimumDistance: 25)
             .onChanged { value in
                 // No swiping in Thread View
                 guard enabled else { return }


### PR DESCRIPTION
This PR attempts to fix scrolling occasionally not working on iOS 18 by increasing the threshold of the swipe to reply gesture.