### PR TITLE
`Communication`: Highlight favorite conversations in list

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -47,6 +47,7 @@ struct ConversationListView: View {
                         conversations: viewModel.favoriteConversations,
                         sectionTitle: R.string.localizable.favoritesSection(),
                         sectionIconName: "heart.fill")
+                    .environment(\.showFavoriteIcon, false)
                     MessageSection(
                         viewModel: viewModel,
                         conversations: viewModel.channels,
@@ -282,8 +283,8 @@ private struct MessageSection<T: BaseConversation>: View {
                         id: \.id
                     ) { conversation in
                         ConversationRow(viewModel: viewModel.parentViewModel,
-                                        conversation: conversation,
-                                        namePrefix: namePrefix(of: conversation))
+                                        conversation: conversation)
+                        .environment(\.commonChannelNamePrefix, namePrefix(of: conversation))
                     }
                 } label: {
                     SectionDisclosureLabel(
@@ -300,9 +301,9 @@ private struct MessageSection<T: BaseConversation>: View {
     }
 
     /// Returns prefix used for channels of certain SubType if applicable
-    func namePrefix(of conversation: T) -> String? {
-        guard let channel = conversation as? Channel else { return nil }
-        guard let subType = channel.subType?.rawValue else { return nil }
+    func namePrefix(of conversation: T) -> String {
+        guard let channel = conversation as? Channel else { return "" }
+        guard let subType = channel.subType?.rawValue else { return "" }
         return "\(subType)-"
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -11,17 +11,18 @@ import SwiftUI
 
 struct ConversationRow<T: BaseConversation>: View {
 
+    @Environment(\.commonChannelNamePrefix) var namePrefix
+    @Environment(\.showFavoriteIcon) var showFavoriteIcon
     @Environment(\.horizontalSizeClass) var sizeClass
     @EnvironmentObject var navigationController: NavigationController
 
     @ObservedObject var viewModel: MessagesAvailableViewModel
 
     let conversation: T
-    var namePrefix: String?
 
     var conversationDisplayName: String {
         let conversationName = conversation.conversationName
-        guard let namePrefix, !namePrefix.isEmpty else {
+        guard !namePrefix.isEmpty else {
             return conversationName
         }
         if conversationName.hasPrefix(namePrefix) {
@@ -98,6 +99,16 @@ private extension ConversationRow {
                             .offset(x: .s, y: .xs * -1)
                     }
                 }
+                .overlay(alignment: .bottomTrailing) {
+                    if conversation.isFavorite ?? false && showFavoriteIcon {
+                        Image(systemName: "heart.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundStyle(.orange)
+                            .frame(width: .m, height: .m)
+                            .offset(x: .s, y: .s)
+                    }
+                }
         }
     }
 }
@@ -134,5 +145,34 @@ private extension ConversationRow {
     @ViewBuilder var contextMenuItems: some View {
         favoriteButton
         hideAndMuteButtons
+    }
+}
+
+// MARK: Environment Values
+
+private enum ConversationRowPrefixEnvironmentKey: EnvironmentKey {
+    static let defaultValue = ""
+}
+
+private enum ConversationRowFavoriteIconEnvironmentKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var commonChannelNamePrefix: String {
+        get {
+            self[ConversationRowPrefixEnvironmentKey.self]
+        }
+        set {
+            self[ConversationRowPrefixEnvironmentKey.self] = newValue
+        }
+    }
+    var showFavoriteIcon: Bool {
+        get {
+            self[ConversationRowFavoriteIconEnvironmentKey.self]
+        }
+        set {
+            self[ConversationRowFavoriteIconEnvironmentKey.self] = newValue
+        }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -154,7 +154,7 @@ private enum ConversationRowPrefixEnvironmentKey: EnvironmentKey {
     static let defaultValue = ""
 }
 
-private enum ConversationRowFavoriteIconEnvironmentKey: EnvironmentKey {
+private enum ConversationRowFavoriteIconKey: EnvironmentKey {
     static let defaultValue = true
 }
 
@@ -169,10 +169,10 @@ extension EnvironmentValues {
     }
     var showFavoriteIcon: Bool {
         get {
-            self[ConversationRowFavoriteIconEnvironmentKey.self]
+            self[ConversationRowFavoriteIconKey.self]
         }
         set {
-            self[ConversationRowFavoriteIconEnvironmentKey.self] = newValue
+            self[ConversationRowFavoriteIconKey.self] = newValue
         }
     }
 }


### PR DESCRIPTION
Since we now show favorites in their original sections as well, we highlight them with an icon so the user knows whether it is favorited.
<img src="https://github.com/user-attachments/assets/25800ee3-ffd7-4b89-bab8-f59eb376b5f3" alt="New icon" width="300">