### PR TITLE
`General`: Refactor MessageSections

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/ConversationListViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/ConversationListViewModel.swift
@@ -19,7 +19,7 @@ class ConversationListViewModel {
     var searchText = ""
 
     var conversations: [Conversation]
-    var favoriteConversations = [Conversation]()
+    var favoriteConversations = [BaseConversation]()
 
     var channels = [Channel]()
     var exercises = [Channel]()
@@ -28,7 +28,7 @@ class ConversationListViewModel {
     var groupChats = [GroupChat]()
     var oneToOneChats = [OneToOneChat]()
 
-    var hiddenConversations = [Conversation]()
+    var hiddenConversations = [BaseConversation]()
 
     var searchResults: [Conversation] {
         conversations.filter {
@@ -90,6 +90,7 @@ class ConversationListViewModel {
             .filter {
                 $0.baseConversation.isFavorite ?? false && filter.matches($0.baseConversation, course: course)
             }
+            .map { $0.baseConversation }
 
         channels = notHiddenConversations
             .compactMap { $0.baseConversation as? Channel }
@@ -117,6 +118,7 @@ class ConversationListViewModel {
 
         hiddenConversations = conversations
             .filter { $0.baseConversation.isHidden ?? false && filter.matches($0.baseConversation, course: course) }
+            .map { $0.baseConversation }
     }
 
     /// Reset filter to all if there are no more matches

--- a/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/ConversationListViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessagesTabViewModels/ConversationListViewModel.swift
@@ -87,10 +87,10 @@ class ConversationListViewModel {
         }
 
         favoriteConversations = notHiddenConversations
-            .filter {
-                $0.baseConversation.isFavorite ?? false && filter.matches($0.baseConversation, course: course)
-            }
             .map { $0.baseConversation }
+            .filter {
+                $0.isFavorite ?? false && filter.matches($0, course: course)
+            }
 
         channels = notHiddenConversations
             .compactMap { $0.baseConversation as? Channel }
@@ -117,8 +117,8 @@ class ConversationListViewModel {
             .filter { filter.matches($0, course: course) }
 
         hiddenConversations = conversations
-            .filter { $0.baseConversation.isHidden ?? false && filter.matches($0.baseConversation, course: course) }
             .map { $0.baseConversation }
+            .filter { $0.isHidden ?? false && filter.matches($0, course: course) }
     }
 
     /// Reset filter to all if there are no more matches

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -28,15 +28,7 @@ struct ConversationListView: View {
                     ContentUnavailableView.search
                 }
                 ForEach(viewModel.searchResults) { conversation in
-                    if let channel = conversation.baseConversation as? Channel {
-                        ConversationRow(viewModel: viewModel.parentViewModel, conversation: channel)
-                    }
-                    if let groupChat = conversation.baseConversation as? GroupChat {
-                        ConversationRow(viewModel: viewModel.parentViewModel, conversation: groupChat)
-                    }
-                    if let oneToOneChat = conversation.baseConversation as? OneToOneChat {
-                        ConversationRow(viewModel: viewModel.parentViewModel, conversation: oneToOneChat)
-                    }
+                    ConversationRow(viewModel: viewModel.parentViewModel, conversation: conversation.baseConversation)
                 }.listRowBackground(Color.clear)
             } else {
                 filterBar

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -42,11 +42,12 @@ struct ConversationListView: View {
                 filterBar
 
                 Group {
-                    MixedMessageSection(
-                        viewModel: viewModel.parentViewModel,
+                    MessageSection(
+                        viewModel: viewModel,
                         conversations: viewModel.favoriteConversations,
                         sectionTitle: R.string.localizable.favoritesSection(),
-                        sectionIconName: "heart.fill")
+                        sectionIconName: "heart.fill",
+                        hidePrefixes: false)
                     .environment(\.showFavoriteIcon, false)
                     MessageSection(
                         viewModel: viewModel,
@@ -83,12 +84,13 @@ struct ConversationListView: View {
                             sectionTitle: R.string.localizable.directMessages(),
                             sectionIconName: "bubble.left.fill")
                     }
-                    MixedMessageSection(
-                        viewModel: viewModel.parentViewModel,
+                    MessageSection(
+                        viewModel: viewModel,
                         conversations: viewModel.hiddenConversations,
                         sectionTitle: R.string.localizable.hiddenSection(),
                         sectionIconName: "nosign",
-                        isExpanded: false)
+                        isExpanded: false,
+                        hidePrefixes: false)
                 }
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets(top: 0, leading: .s, bottom: 0, trailing: .s))
@@ -132,69 +134,6 @@ struct ConversationListView: View {
     }
 }
 
-private struct MixedMessageSection: View {
-
-    @ObservedObject private var viewModel: MessagesAvailableViewModel
-
-    private var conversations: [Conversation]
-
-    @State private var isExpanded = true
-
-    private let sectionTitle: String
-    private let sectionIconName: String
-
-    init(
-        viewModel: MessagesAvailableViewModel,
-        conversations: [Conversation],
-        sectionTitle: String,
-        sectionIconName: String,
-        isExpanded: Bool = true
-    ) {
-        self.viewModel = viewModel
-        self.conversations = conversations
-        self.sectionTitle = sectionTitle
-        self.sectionIconName = sectionIconName
-        self._isExpanded = State(wrappedValue: isExpanded)
-    }
-
-    var sectionUnreadCount: Int {
-        conversations.reduce(0) {
-            $0 + ($1.baseConversation.unreadMessagesCount ?? 0)
-        }
-    }
-
-    var body: some View {
-        if !conversations.isEmpty {
-            Section {
-                DisclosureGroup(isExpanded: $isExpanded) {
-                    ForEach(
-                        conversations.sorted {
-                            // Show non-muted conversations above muted ones
-                            ($0.baseConversation.isMuted ?? false ? 0 : 1) > ($1.baseConversation.isMuted ?? false ? 0 : 1)
-                        }
-                    ) { conversation in
-                        if let channel = conversation.baseConversation as? Channel {
-                            ConversationRow(viewModel: viewModel, conversation: channel)
-                        }
-                        if let groupChat = conversation.baseConversation as? GroupChat {
-                            ConversationRow(viewModel: viewModel, conversation: groupChat)
-                        }
-                        if let oneToOneChat = conversation.baseConversation as? OneToOneChat {
-                            ConversationRow(viewModel: viewModel, conversation: oneToOneChat)
-                        }
-                    }
-                } label: {
-                    SectionDisclosureLabel(
-                        sectionTitle: sectionTitle,
-                        sectionIconName: sectionIconName,
-                        sectionUnreadCount: sectionUnreadCount,
-                        isUnreadCountVisible: !isExpanded)
-                }
-            }
-        }
-    }
-}
-
 private struct SectionDisclosureLabel: View {
 
     let sectionTitle: String
@@ -232,17 +171,18 @@ private struct SectionDisclosureLabel: View {
     }
 }
 
-private struct MessageSection<T: BaseConversation>: View {
+private struct MessageSection: View {
 
     var viewModel: ConversationListViewModel
 
-    private var conversations: [T]
+    private var conversations: [BaseConversation]
 
     @State private var isExpanded = true
     @State private var isFiltering = false
 
     let sectionTitle: String
     let sectionIconName: String
+    let hidePrefixes: Bool
 
     var sectionUnreadCount: Int {
         conversations.reduce(0) {
@@ -252,16 +192,18 @@ private struct MessageSection<T: BaseConversation>: View {
 
     init(
         viewModel: ConversationListViewModel,
-        conversations: [T],
+        conversations: [BaseConversation],
         sectionTitle: String,
         sectionIconName: String,
-        isExpanded: Bool = true
+        isExpanded: Bool = true,
+        hidePrefixes: Bool = true
     ) {
         self.viewModel = viewModel
         self.conversations = conversations
         self.sectionTitle = sectionTitle
         self.sectionIconName = sectionIconName
         self._isExpanded = State(wrappedValue: isExpanded)
+        self.hidePrefixes = hidePrefixes
     }
 
     var body: some View {
@@ -283,8 +225,8 @@ private struct MessageSection<T: BaseConversation>: View {
                         id: \.id
                     ) { conversation in
                         ConversationRow(viewModel: viewModel.parentViewModel,
-                                        conversation: conversation)
-                        .environment(\.commonChannelNamePrefix, namePrefix(of: conversation))
+                                        conversation: conversation,
+                                        namePrefix: namePrefix(of: conversation))
                     }
                 } label: {
                     SectionDisclosureLabel(
@@ -301,9 +243,12 @@ private struct MessageSection<T: BaseConversation>: View {
     }
 
     /// Returns prefix used for channels of certain SubType if applicable
-    func namePrefix(of conversation: T) -> String {
-        guard let channel = conversation as? Channel else { return "" }
-        guard let subType = channel.subType?.rawValue else { return "" }
+    func namePrefix(of conversation: BaseConversation) -> String? {
+        guard hidePrefixes,
+              let channel = conversation as? Channel,
+              let subType = channel.subType?.rawValue else {
+            return nil
+        }
         return "\(subType)-"
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -9,20 +9,20 @@ import Navigation
 import SharedModels
 import SwiftUI
 
-struct ConversationRow<T: BaseConversation>: View {
+struct ConversationRow: View {
 
-    @Environment(\.commonChannelNamePrefix) var namePrefix
     @Environment(\.showFavoriteIcon) var showFavoriteIcon
     @Environment(\.horizontalSizeClass) var sizeClass
     @EnvironmentObject var navigationController: NavigationController
 
     @ObservedObject var viewModel: MessagesAvailableViewModel
 
-    let conversation: T
+    let conversation: BaseConversation
+    var namePrefix: String?
 
     var conversationDisplayName: String {
         let conversationName = conversation.conversationName
-        guard !namePrefix.isEmpty else {
+        guard let namePrefix, !namePrefix.isEmpty else {
             return conversationName
         }
         if conversationName.hasPrefix(namePrefix) {
@@ -150,23 +150,11 @@ private extension ConversationRow {
 
 // MARK: Environment Values
 
-private enum ConversationRowPrefixEnvironmentKey: EnvironmentKey {
-    static let defaultValue = ""
-}
-
 private enum ConversationRowFavoriteIconKey: EnvironmentKey {
     static let defaultValue = true
 }
 
 extension EnvironmentValues {
-    var commonChannelNamePrefix: String {
-        get {
-            self[ConversationRowPrefixEnvironmentKey.self]
-        }
-        set {
-            self[ConversationRowPrefixEnvironmentKey.self] = newValue
-        }
-    }
     var showFavoriteIcon: Bool {
         get {
             self[ConversationRowFavoriteIconKey.self]


### PR DESCRIPTION
We currently have `MixedMessageSection` and `MessageSection` for grouping channels in the conversation list. They are 90% identical though, thus it makes sense to combine them. They are also generic without needing to be.