### PR TITLE
`Communication`: Add unresolved filter

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "678d442c6f7828def400a70ae15968aef67ef52d",
-        "version" : "1.8.3"
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
       }
     },
     {

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "unreadFilter" = "Unread";
 "allFilter" = "All";
 "recentFilter" = "Recent";
+"unresolvedFilter" = "Unresolved";
 
 // MARK: MessageDetailView
 "edited" = "Edited";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -62,6 +62,8 @@
 "allFilter" = "All";
 "recentFilter" = "Recent";
 "unresolvedFilter" = "Unresolved";
+"allDone" = "All done";
+"allDoneDescription" = "All messages are resolved. Good work!";
 
 // MARK: MessageDetailView
 "edited" = "Edited";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -162,6 +162,11 @@ protocol MessagesService {
      * Perform a put request to edit the name/topic/description of  a specific conversation in a specific course to the server.
      */
     func editConversation(for courseId: Int, conversation: Conversation, newName: String?, newTopic: String?, newDescription: String?) async -> DataState<Conversation>
+
+    /**
+     * Perform a get request to retrieve channels which have unresolved messages
+     */
+    func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]>
 }
 
 extension MessagesService {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -12,6 +12,90 @@ import SharedModels
 
 // Requests for Conversation Management
 extension MessagesServiceImpl {
+    struct CreateChannelRequest: APIRequest {
+        typealias Response = Channel
+
+        let courseId: Int
+        var type: ConversationType = .channel
+        let name: String
+        let description: String?
+        let isPublic: Bool
+        let isAnnouncementChannel: Bool
+
+        var method: HTTPMethod {
+            return .post
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/channels"
+        }
+    }
+
+    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> DataState<Channel> {
+        let result = await client.sendRequest(
+            CreateChannelRequest(courseId: courseId, name: name, description: description, isPublic: !isPrivate, isAnnouncementChannel: isAnnouncement)
+        )
+
+        switch result {
+        case let .success((channel, _)):
+            return .done(response: channel)
+        case let .failure(error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct ArchiveChannelRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let courseId: Int
+        let channelId: Int64
+
+        var method: HTTPMethod {
+            return .post
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/channels/\(channelId)/archive"
+        }
+    }
+
+    func archiveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
+        let result = await client.sendRequest(ArchiveChannelRequest(courseId: courseId, channelId: channelId))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
+    struct UnarchiveChannelRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let courseId: Int
+        let channelId: Int64
+
+        var method: HTTPMethod {
+            return .post
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/channels/\(channelId)/unarchive"
+        }
+    }
+
+    func unarchiveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
+        let result = await client.sendRequest(UnarchiveChannelRequest(courseId: courseId, channelId: channelId))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
     struct GetUnresolvedChannelsRequest: APIRequest {
         typealias Response = [UnresolvedChannelsResponse]
         struct UnresolvedChannelsResponse: Codable {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -1,0 +1,58 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 28.12.24.
+//
+
+import APIClient
+import Common
+import Foundation
+import SharedModels
+
+// Requests for Conversation Management
+extension MessagesServiceImpl {
+    struct GetUnresolvedChannelsRequest: APIRequest {
+        typealias Response = [UnresolvedChannelsResponse]
+        struct UnresolvedChannelsResponse: Codable {
+            let conversation: Conversation
+        }
+
+        let courseId: Int
+        let channelIds: [Int64]
+        var channelIdsString: String {
+            channelIds.map(String.init(describing:)).joined(separator: ",")
+        }
+
+        var method: HTTPMethod {
+            return .get
+        }
+
+        var params: [URLQueryItem] {
+            [
+                .init(name: "courseWideChannelIds", value: channelIdsString),
+                .init(name: "postSortCriterion", value: "CREATION_DATE"),
+                .init(name: "sortingOrder", value: "DESCENDING"),
+                .init(name: "pagingEnabled", value: "true"),
+                .init(name: "page", value: "0"),
+                .init(name: "size", value: "\(50)")
+            ] + MessageRequestFilter(filterToUnresolved: true).queryItems
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/messages"
+        }
+    }
+
+    func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]> {
+        let result = await client.sendRequest(GetUnresolvedChannelsRequest(courseId: courseId, channelIds: channelIds))
+
+        switch result {
+        case let .success((conversations, _)):
+            let ids = conversations.map(\.conversation.id)
+            return .done(response: Array(Set(ids)))
+        case let .failure(error):
+            return DataState(error: error)
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -14,7 +14,7 @@ import UserStore
 // swiftlint:disable file_length type_body_length
 struct MessagesServiceImpl: MessagesService {
 
-    private let client = APIClient()
+    internal let client = APIClient()
 
     struct GetConversationsRequest: APIRequest {
         typealias Response = [Conversation]

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -661,38 +661,6 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
-    struct CreateChannelRequest: APIRequest {
-        typealias Response = Channel
-
-        let courseId: Int
-        var type: ConversationType = .channel
-        let name: String
-        let description: String?
-        let isPublic: Bool
-        let isAnnouncementChannel: Bool
-
-        var method: HTTPMethod {
-            return .post
-        }
-
-        var resourceName: String {
-            return "api/courses/\(courseId)/channels"
-        }
-    }
-
-    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> DataState<Channel> {
-        let result = await client.sendRequest(
-            CreateChannelRequest(courseId: courseId, name: name, description: description, isPublic: !isPrivate, isAnnouncementChannel: isAnnouncement)
-        )
-
-        switch result {
-        case let .success((channel, _)):
-            return .done(response: channel)
-        case let .failure(error):
-            return .failure(error: UserFacingError(error: error))
-        }
-    }
-
     struct SearchForUsersRequest: APIRequest {
         typealias Response = [ConversationUser]
 
@@ -816,58 +784,6 @@ struct MessagesServiceImpl: MessagesService {
             return .done(response: users)
         case let .failure(error):
             return .failure(error: UserFacingError(error: error))
-        }
-    }
-
-    struct ArchiveChannelRequest: APIRequest {
-        typealias Response = RawResponse
-
-        let courseId: Int
-        let channelId: Int64
-
-        var method: HTTPMethod {
-            return .post
-        }
-
-        var resourceName: String {
-            return "api/courses/\(courseId)/channels/\(channelId)/archive"
-        }
-    }
-
-    func archiveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
-        let result = await client.sendRequest(ArchiveChannelRequest(courseId: courseId, channelId: channelId))
-
-        switch result {
-        case .success:
-            return .success
-        case let .failure(error):
-            return .failure(error: error)
-        }
-    }
-
-    struct UnarchiveChannelRequest: APIRequest {
-        typealias Response = RawResponse
-
-        let courseId: Int
-        let channelId: Int64
-
-        var method: HTTPMethod {
-            return .post
-        }
-
-        var resourceName: String {
-            return "api/courses/\(courseId)/channels/\(channelId)/unarchive"
-        }
-    }
-
-    func unarchiveChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
-        let result = await client.sendRequest(UnarchiveChannelRequest(courseId: courseId, channelId: channelId))
-
-        switch result {
-        case .success:
-            return .success
-        case let .failure(error):
-            return .failure(error: error)
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -208,4 +208,8 @@ extension MessagesServiceStub: MessagesService {
     func uploadFile(for courseId: Int, and conversationId: Int64, file: Data, filename: String, mimeType: String) async -> DataState<String> {
         .loading
     }
+
+    func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]> {
+        .loading
+    }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -34,9 +34,9 @@ struct ConversationListView: View {
                 filterBar
 
                 if viewModel.filter == .unresolved && viewModel.allChannelsResolved {
-                    ContentUnavailableView("All done",
+                    ContentUnavailableView(R.string.localizable.allDone(),
                                            image: "checkmark",
-                                           description: Text("All messages are resolved. Good work!"))
+                                           description: Text(R.string.localizable.allDoneDescription()))
                 }
 
                 Group {


### PR DESCRIPTION
Filter for tutors that shows channels with unresolved messages.

Possible Follow-up: Channels should open with "Unresolved" message filter already selected.

<img src="https://github.com/user-attachments/assets/c7634086-9191-4ed6-945d-d0bf14c9a1a5" alt="New filter" width="300">
