### PR TITLE
`Improvment`: Padding Issues in Lecture and Video Content

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -299,6 +299,7 @@ struct TextUnitSheetContent: View {
         ScrollView {
             ArtemisMarkdownView(string: textUnit.content ?? "")
         }
+        .padding(.l)
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureUnitVideo.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureUnitVideo.swift
@@ -47,6 +47,7 @@ struct VideoUnitSheetContent: View {
 
                     Link(R.string.localizable.openVideo(), destination: url)
                         .buttonStyle(ArtemisButton())
+                        .padding(.horizontal)
                 } else {
                     Text(R.string.localizable.videoCouldNotBeLoaded())
                         .foregroundColor(.red)


### PR DESCRIPTION
### Problem Description
Missing Paddings in the lecture detail bottom sheets

### Changes

Added padding to TextUnitSheetContent to enhance spacing and visual alignment.
Ensured buttons not touching to start  when no text is present, preventing layout misalignment in VideoUnitSheetContent

### Steps for testing

Check Lecture Unit with video having a description and only having a link and verify paddings.
Check Text Lecture Unit and verify paddings.

### Screenshots

<img width="300" alt="Screenshot 2025-01-04 at 23 21 08" src="https://github.com/user-attachments/assets/24efe620-43ff-4e25-a142-b9a19a867ab3" />
<img width="300" alt="Screenshot 2025-01-04 at 22 39 22" src="https://github.com/user-attachments/assets/08251ddd-c095-42fd-9148-43abc0fb82ba" />


<img width="300" alt="Screenshot 2025-01-04 at 23 12 13" src="https://github.com/user-attachments/assets/0d027273-6f1f-4e4d-a9f8-cfed8d05bec6" />
<img width="300" alt="Screenshot 2025-01-04 at 23 13 33" src="https://github.com/user-attachments/assets/9d7056e6-6775-4e8e-9cc2-b47d0aa55127" />


