### PR TITLE
`Navigation`: Fix switching tab not working in thread view

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -83,6 +83,11 @@ struct MessageDetailView: View {
                 await reloadMessage()
             }
         }
+        .onChange(of: navController.courseTab) { _, newValue in
+            if newValue != .communication {
+                navController.tabPath = .init()
+            }
+        }
         .onChange(of: message) {
             switch message {
             case .loading:


### PR DESCRIPTION
When inside a message thread, changing tabs does not work properly because the thread stays open. We fix this by closing any thread when navigating to a different tab.