### PR TITLE
`Courses`: Add placeholder icon for courses without image

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -48,7 +48,12 @@ private extension CourseGridCell {
         HStack(alignment: .center, spacing: .m) {
             if let imageURL = courseForDashboard.course.courseIconURL {
                 ArtemisAsyncImage(imageURL: imageURL) {
-                    EmptyView()
+                    if let firstChar = courseForDashboard.course.title?.first {
+                        Text(String(firstChar))
+                            .font(.largeTitle)
+                            .frame(width: .largeImage * 1.25, height: .largeImage * 1.25, alignment: .center)
+                            .background(.regularMaterial, in: .circle)
+                    }
                 }
                 .clipShape(.circle)
                 .frame(width: .largeImage * 1.25)


### PR DESCRIPTION
We currently do not show an icon for courses that don't have an image in the course grid. This is inconsistent with the web app. With this PR, we add a placeholder icon for this case, just like on the web app.

<img src="https://github.com/user-attachments/assets/55680e4c-d13d-4c79-8ce4-702ba4caf49e" alt="New icon" width="300">
