### PR TITLE
`Communication`: Add path to thread by message id

### DIFF
--- a/ArtemisKit/Sources/Messages/Navigation/NavigationDestinationThreadViewModifier.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/NavigationDestinationThreadViewModifier.swift
@@ -18,5 +18,6 @@ public struct NavigationDestinationMessagesModifier: ViewModifier {
                 MessageDetailView(viewModel: messagePath.conversationViewModel, message: messagePath.message, presentKeyboardOnAppear: messagePath.presentKeyboardOnAppear)
             }
             .navigationDestination(for: ConversationPath.self, destination: ConversationPathView.init)
+            .navigationDestination(for: ThreadPath.self, destination: ThreadPathView.init)
     }
 }

--- a/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
@@ -48,3 +48,30 @@ final class ConversationPathViewModel {
         await reloadConversation()
     }
 }
+
+@Observable
+final class ThreadPathViewModel {
+    let path: ThreadPath
+    var message: DataState<BaseMessage>
+
+    private let messagesService: MessagesService
+
+    init(path: ThreadPath, messagesService: MessagesService = MessagesServiceFactory.shared) {
+        self.path = path
+        self.message = .loading
+
+        self.messagesService = messagesService
+    }
+
+    func loadMessage() async {
+        let result = await messagesService.getMessage(with: path.postId, for: path.coursePath.id, and: path.conversation.id)
+        switch result {
+        case .loading:
+            message = .loading
+        case .failure(let error):
+            message = .failure(error: error)
+        case .done(let response):
+            message = .done(response: response)
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViewModels.swift
@@ -5,12 +5,14 @@
 //  Created by Nityananda Zbil on 05.03.24.
 //
 
+import Combine
 import Common
 import Extensions
 import Navigation
 import SharedModels
 import SharedServices
 import SwiftUI
+import UserStore
 
 @Observable
 final class ConversationPathViewModel {
@@ -54,17 +56,20 @@ final class ThreadPathViewModel {
     let path: ThreadPath
     var message: DataState<BaseMessage>
 
-    private let messagesService: MessagesService
+    private var subscription: AnyCancellable?
 
-    init(path: ThreadPath, messagesService: MessagesService = MessagesServiceFactory.shared) {
+    init(path: ThreadPath) {
         self.path = path
         self.message = .loading
 
-        self.messagesService = messagesService
+        subscribeToUpdates()
     }
 
     func loadMessage() async {
-        let result = await messagesService.getMessage(with: path.postId, for: path.coursePath.id, and: path.conversation.id)
+        let result = await MessagesServiceFactory.shared.getMessage(with: path.postId,
+                                                                    for: path.coursePath.id,
+                                                                    and: path.conversation.id)
+        // Assigning directly does not work due to BaseMessage and Message not being the same
         switch result {
         case .loading:
             message = .loading
@@ -72,6 +77,62 @@ final class ThreadPathViewModel {
             message = .failure(error: error)
         case .done(let response):
             message = .done(response: response)
+        }
+    }
+
+    /// Ensure we receive updates to the displayed message
+    private func subscribeToUpdates() {
+        let socketConnection = SocketConnectionHandler.shared
+        subscription = socketConnection
+            .messagePublisher
+            .sink { [weak self] messageWebsocketDTO in
+                guard let self else {
+                    return
+                }
+                onMessageReceived(messageWebsocketDTO: messageWebsocketDTO)
+            }
+
+        if path.conversation.baseConversation.type == .channel,
+           let channel = path.conversation.baseConversation as? Channel,
+           channel.isCourseWide == true {
+            socketConnection.subscribeToChannelNotifications(courseId: path.coursePath.id)
+        } else if let id = UserSessionFactory.shared.user?.id {
+            socketConnection.subscribeToConversationNotifications(userId: id)
+        }
+    }
+
+    private func onMessageReceived(messageWebsocketDTO: MessageWebsocketDTO) {
+        // Guard message corresponds to conversation
+        guard messageWebsocketDTO.post.conversation?.id == path.conversation.id else {
+            return
+        }
+        DispatchQueue.main.async {
+            switch messageWebsocketDTO.action {
+            case .update:
+                self.handle(update: messageWebsocketDTO.post)
+            case .delete:
+                if messageWebsocketDTO.post.id == self.path.postId {
+                    self.message = .loading
+                }
+            default:
+                return
+            }
+        }
+    }
+
+    private func handle(update message: Message) {
+        if message.id == path.postId, let oldMessage = self.message.value {
+            // We do not get `authorRole` via websockets, thus we need to manually keep it
+            var newMessage = message
+            newMessage.authorRole = newMessage.authorRole ?? oldMessage.authorRole
+            // Same for answers
+            newMessage.answers = newMessage.answers?.map { answer in
+                var newAnswer = answer
+                let oldAnswer = (oldMessage as? Message)?.answers?.first { $0.id == answer.id }
+                newAnswer.authorRole = newAnswer.authorRole ?? oldAnswer?.authorRole
+                return newAnswer
+            }
+            self.message = .done(response: newMessage)
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
@@ -43,7 +43,7 @@ struct ThreadPathView: View {
             await viewModel.loadMessage()
         } content: { _ in
             CoursePathView(path: viewModel.path.coursePath) { course in
-                MessageDetailView(viewModel: .init(course: course, conversation: viewModel.path.conversation),
+                MessageDetailView(viewModel: .init(course: course, conversation: viewModel.path.conversation, skipLoadingData: true),
                                   message: $viewModel.message)
             }
         }

--- a/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
+++ b/ArtemisKit/Sources/Messages/Navigation/PathViews.swift
@@ -34,3 +34,27 @@ public extension ConversationPathView where Content == ConversationView {
         self.init(viewModel: ConversationPathViewModel(path: path), content: Content.init)
     }
 }
+
+struct ThreadPathView: View {
+    @State private var viewModel: ThreadPathViewModel
+
+    var body: some View {
+        DataStateView(data: $viewModel.message) {
+            await viewModel.loadMessage()
+        } content: { _ in
+            CoursePathView(path: viewModel.path.coursePath) { course in
+                MessageDetailView(viewModel: .init(course: course, conversation: viewModel.path.conversation),
+                                  message: $viewModel.message)
+            }
+        }
+        .task {
+            await viewModel.loadMessage()
+        }
+    }
+}
+
+extension ThreadPathView {
+    init(path: ThreadPath) {
+        self.init(viewModel: ThreadPathViewModel(path: path))
+    }
+}

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -39,6 +39,11 @@ protocol MessagesService {
     func getMessages(for courseId: Int, and conversationId: Int64, filter: MessageRequestFilter, page: Int) async -> DataState<[Message]>
 
     /**
+     * Perform a get request for a specific Message of a specific conversation in a specific course to the server.
+    */
+    func getMessage(with messageId: Int64, for courseId: Int, and conversationId: Int64) async -> DataState<Message>
+
+    /**
      * Perform a post request for a new message for a specific conversation in a specific course to the server.
      */
     func sendMessage(for courseId: Int, conversation: Conversation, content: String) async -> NetworkResponse

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -169,6 +169,44 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
+    struct GetMessageRequest: APIRequest {
+        typealias Response = [Message]
+
+        let courseId: Int
+        let conversationId: Int64
+        let messageId: Int64
+
+        var method: HTTPMethod {
+            return .get
+        }
+
+        var params: [URLQueryItem] {
+            [
+                .init(name: "conversationId", value: String(describing: conversationId)),
+                .init(name: "searchText", value: "#\(messageId)")
+            ]
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/messages"
+        }
+    }
+
+    func getMessage(with messageId: Int64, for courseId: Int, and conversationId: Int64) async -> DataState<Message> {
+        let result = await client.sendRequest(GetMessageRequest(courseId: courseId, conversationId: conversationId, messageId: messageId))
+
+        switch result {
+        case let .success((messages, _)):
+            if let message = messages.first {
+                return .done(response: message)
+            } else {
+                return .failure(error: .init(title: "Message not found"))
+            }
+        case let .failure(error):
+            return DataState(error: error)
+        }
+    }
+
     struct SendMessageRequest: APIRequest {
         typealias Response = Message
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -113,6 +113,10 @@ extension MessagesServiceStub: MessagesService {
         .done(response: messages)
     }
 
+    func getMessage(with messageId: Int64, for courseId: Int, and conversationId: Int64) async -> DataState<Message> {
+        .loading
+    }
+
     func sendMessage(for courseId: Int, conversation: Conversation, content: String) async -> NetworkResponse {
         .loading
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -70,7 +70,8 @@ class ConversationViewModel: BaseViewModel {
         conversation: Conversation,
         messagesRepository: MessagesRepository? = nil,
         messagesService: MessagesService = MessagesServiceFactory.shared,
-        userSession: UserSession = UserSessionFactory.shared
+        userSession: UserSession = UserSessionFactory.shared,
+        skipLoadingData: Bool = false // Used in case we don't need the Conversation itself (Thread view)
     ) {
         self.course = course
         self.conversation = conversation
@@ -83,6 +84,10 @@ class ConversationViewModel: BaseViewModel {
 
         subscribeToConversationTopic()
         fetchOfflineMessages()
+
+        if skipLoadingData {
+            return
+        }
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(updateFavorites(notification:)),

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -140,14 +140,8 @@ extension ConversationViewModel {
     }
 
     func loadMessage(messageId: Int64) async -> DataState<Message> {
-        // TODO: add API to only load one single message
-        let result = await messagesService.getMessages(for: course.id, and: conversation.id, filter: filter, page: page)
-        return result.flatMap { messages in
-            guard let message = messages.first(where: { $0.id == messageId }) else {
-                return .failure(UserFacingError(title: R.string.localizable.messageCouldNotBeLoadedError()))
-            }
-            return .success(message)
-        }
+        let result = await messagesService.getMessage(with: messageId, for: course.id, and: conversation.id)
+        return result
     }
 
     func loadAnswerMessage(answerMessageId: Int64) async -> DataState<AnswerMessage> {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions.swift
@@ -261,6 +261,12 @@ struct MessageActions: View {
                 let oldRole = message.authorRole
                 if var newMessageResult = result.value as? Message {
                     newMessageResult.authorRole = oldRole
+                    newMessageResult.answers = newMessageResult.answers?.map { answer in
+                        var newAnswer = answer
+                        let oldAnswer = message.answers?.first { $0.id == answer.id }
+                        newAnswer.authorRole = newAnswer.authorRole ?? oldAnswer?.authorRole
+                        return newAnswer
+                    }
                     self.$message.wrappedValue = .done(response: newMessageResult)
                     viewModel.selectedMessageId = nil
                 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -162,6 +162,7 @@ private extension MessageDetailView {
                     let needsRoundedCorners = !(sortedArray[safe: index + 1]?.isContinuation(of: answerMessage) ?? false)
                     MessageCellWrapper(
                         viewModel: viewModel,
+                        message: self.$message,
                         answerMessage: answerMessage,
                         isHeaderVisible: isHeaderVisible,
                         roundBottomCorners: needsRoundedCorners)
@@ -216,6 +217,7 @@ private struct MessageCellWrapper: View {
 
     @ObservedObject var viewModel: ConversationViewModel
 
+    let message: Binding<DataState<BaseMessage>>
     let answerMessage: AnswerMessage
     let isHeaderVisible: Bool
     let roundBottomCorners: Bool
@@ -233,6 +235,8 @@ private struct MessageCellWrapper: View {
             if let message = viewModel.messages.first(where: messageContainsAnswer),
                let answer = message.rawValue.answers?.first(where: isAnswerMessage) {
                 return .done(response: answer)
+            } else if let answer = (message.wrappedValue.value as? Message)?.answers?.first(where: isAnswerMessage) {
+                return .done(response: answer)
             } else {
                 return .loading
             }
@@ -240,8 +244,15 @@ private struct MessageCellWrapper: View {
             if var message = viewModel.messages.first(where: messageContainsAnswer)?.rawValue,
                let answer = value.value as? AnswerMessage,
                let index = message.answers?.firstIndex(where: isAnswerMessage) {
+                // Save changes in View model
                 message.answers?[index] = answer
                 viewModel.messages.update(with: .message(message))
+            } else if let answer = value.value as? AnswerMessage,
+                      let index = (message.wrappedValue.value as? Message)?.answers?.firstIndex(where: isAnswerMessage),
+                      var newMessage = message.wrappedValue.value as? Message {
+                // Save changes in message itself
+                newMessage.answers?[index] = answer
+                message.wrappedValue = .done(response: newMessage)
             }
         }
     }

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -91,6 +91,10 @@ public extension NavigationController {
         tabPath = NavigationPath()
     }
 
+    func goToThread(for messageId: Int64, in conversation: Conversation, of course: Course) {
+        tabPath.append(ThreadPath(postId: messageId, conversation: conversation, coursePath: CoursePath(course: course)))
+    }
+
     func showDeeplinkNotSupported(url: URL) {
         notSupportedUrl = url
         showDeeplinkNotSupported = true

--- a/ArtemisKit/Sources/Navigation/Paths.swift
+++ b/ArtemisKit/Sources/Navigation/Paths.swift
@@ -75,3 +75,15 @@ public struct ConversationPath: Hashable {
         self.coursePath = coursePath
     }
 }
+
+public struct ThreadPath: Hashable {
+    public let postId: Int64
+    public let conversation: Conversation
+    public let coursePath: CoursePath
+
+    public init(postId: Int64, conversation: Conversation, coursePath: CoursePath) {
+        self.postId = postId
+        self.conversation = conversation
+        self.coursePath = coursePath
+    }
+}


### PR DESCRIPTION
We need to be able to navigate into a thread based on its id for the save messages for later and forward messages features to work correctly. We add this functionality in this PR.