### PR TITLE
`Communication`: Add strikethrough text formatting option

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 "bold" = "Bold";
 "italic" = "Italic";
 "underline" = "Underline";
+"strikethrough" = "Strikethrough";
 "quote" = "Quote";
 "inlineCode" = "Inline code";
 "codeBlock" = "Code block";

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -184,6 +184,10 @@ extension SendMessageViewModel {
         appendToSelection(before: "<ins>", after: "</ins>", placeholder: "underlined")
     }
 
+    func didTapStrikethroughButton() {
+        appendToSelection(before: "~~", after: "~~", placeholder: "strikethough")
+    }
+
     func didTapBlockquoteButton() {
         appendToSelection(before: "> ", after: "", placeholder: "Reference")
     }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -175,6 +175,11 @@ private extension SendMessageView {
                         } label: {
                             Label(R.string.localizable.underline(), systemImage: "underline")
                         }
+                        Button {
+                            viewModel.didTapStrikethroughButton()
+                        } label: {
+                            Label(R.string.localizable.strikethrough(), systemImage: "strikethrough")
+                        }
                     } label: {
                         Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
                     }


### PR DESCRIPTION
In addition to Bold, italic, and theoretically underlined, we add support for strikethrough text

<img src="https://github.com/user-attachments/assets/80588608-44d6-43d7-814b-0efdbed4ea45" alt="New option" width="300">
