### PR TITLE
`Dashboard`: Add recent courses section

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -7,6 +7,7 @@
 
 import CourseRegistration
 import DesignLibrary
+import SharedModels
 import SwiftUI
 
 struct CourseGrid: View {
@@ -15,15 +16,37 @@ struct CourseGrid: View {
     @ObservedObject var viewModel: DashboardViewModel
     @State private var isCourseRegistrationPresented = false
 
+    private var recentCourses: [CourseForDashboardDTO] {
+        guard let courses = viewModel.coursesForDashboard.value?.courses else { return [] }
+        return courses.filter { viewModel.recentCourseIds.contains($0.id) }
+    }
+
     var body: some View {
         DataStateView(data: $viewModel.coursesForDashboard) {
             await viewModel.loadCourses()
         } content: { coursesForDashboard in
             ScrollView {
-                LazyVGrid(columns: Self.layout, spacing: .l) {
-                    ForEach(coursesForDashboard.courses ?? [], content: CourseGridCell.init)
+                if !recentCourses.isEmpty {
+                    Text(R.string.localizable.recentlyAccessed())
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.title.bold())
+
+                    LazyVGrid(columns: Self.layout, spacing: .l) {
+                        ForEach(recentCourses) { course in
+                            CourseGridCell(courseForDashboard: course, viewModel: viewModel)
+                        }
+                    }
+
+                    Text(R.string.localizable.allCourses())
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.title.bold())
+                        .padding(.top, .l)
                 }
-                .padding(.horizontal, .l)
+                LazyVGrid(columns: Self.layout, spacing: .l) {
+                    ForEach(coursesForDashboard.courses ?? []) { course in
+                        CourseGridCell(courseForDashboard: course, viewModel: viewModel)
+                    }
+                }
 
                 HStack {
                     Spacer()
@@ -34,6 +57,7 @@ struct CourseGrid: View {
                     Spacer()
                 }
             }
+            .contentMargins(.horizontal, .l, for: .scrollContent)
             .refreshable {
                 await viewModel.loadCourses()
             }

--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -17,7 +17,9 @@ struct CourseGrid: View {
     @State private var isCourseRegistrationPresented = false
 
     private var recentCourses: [CourseForDashboardDTO] {
-        guard let courses = viewModel.coursesForDashboard.value?.courses else { return [] }
+        guard let courses = viewModel.coursesForDashboard.value?.courses, courses.count > 3 else {
+            return []
+        }
         return courses.filter { viewModel.recentCourseIds.contains($0.id) }
     }
 

--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -14,6 +14,7 @@ struct CourseGridCell: View {
     @EnvironmentObject private var navigationController: NavigationController
 
     let courseForDashboard: CourseForDashboardDTO
+    let viewModel: DashboardViewModel
 
     var nextExercise: Exercise? {
         // filters out every already successful (100%) exercise, only exercises left that still need work
@@ -32,6 +33,10 @@ struct CourseGridCell: View {
     var body: some View {
         Button {
             navigationController.selectedCourse = CoursePath(id: courseForDashboard.id)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                // Update recents with a delay to not update grid during navigation transition
+                viewModel.addToRecents(courseId: courseForDashboard.id)
+            }
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -150,5 +155,5 @@ private extension CourseGridCell {
 }
 
 #Preview {
-    CourseGridCell(courseForDashboard: CourseServiceStub.course)
+    CourseGridCell(courseForDashboard: CourseServiceStub.course, viewModel: .init())
 }

--- a/ArtemisKit/Sources/Dashboard/DashboardViewModel.swift
+++ b/ArtemisKit/Sources/Dashboard/DashboardViewModel.swift
@@ -2,10 +2,14 @@ import Common
 import Foundation
 import SharedModels
 import SharedServices
+import SwiftUI
 
 class DashboardViewModel: BaseViewModel {
 
     @Published var coursesForDashboard: DataState<CoursesForDashboardDTO> = DataState.loading
+
+    @AppStorage("recentCourseIds")
+    var recentCourseIds = [Int]()
 
     private let courseService: CourseService
 
@@ -17,5 +21,36 @@ class DashboardViewModel: BaseViewModel {
 
     func loadCourses() async {
         coursesForDashboard = await courseService.getCourses()
+    }
+
+    func addToRecents(courseId: Int) {
+        if recentCourseIds.contains(courseId) {
+            // Remove it here and insert it back at the beginning
+            // so that it will be discarded last
+            recentCourseIds.removeAll { $0 == courseId }
+        }
+        if recentCourseIds.count >= 3 {
+            recentCourseIds.removeLast()
+        }
+        recentCourseIds.insert(courseId, at: 0)
+    }
+}
+
+// MARK: Array+RawRepresentable
+// Needed for @AppStorage with a Codable array
+extension Array: @retroactive RawRepresentable where Element: Codable {
+    public init?(rawValue: String) {
+        guard let result = try? JSONDecoder().decode([Element].self, from: Data(rawValue.utf8)) else {
+            return nil
+        }
+        self = result
+    }
+
+    public var rawValue: String {
+        if let data = try? JSONEncoder().encode(self),
+           let result = String(data: data, encoding: .utf8) {
+            return result
+        }
+        return "[]"
     }
 }

--- a/ArtemisKit/Sources/Dashboard/DashboardViewModel.swift
+++ b/ArtemisKit/Sources/Dashboard/DashboardViewModel.swift
@@ -20,7 +20,14 @@ class DashboardViewModel: BaseViewModel {
     }
 
     func loadCourses() async {
-        coursesForDashboard = await courseService.getCourses()
+        coursesForDashboard = await courseService.getCourses().map { coursesDTO in
+            // Sort courses alpabetically
+            var response = coursesDTO
+            response.courses = response.courses?.sorted {
+                $0.course.title ?? "" < $1.course.title ?? ""
+            }
+            return response
+        }
     }
 
     func addToRecents(courseId: Int) {

--- a/ArtemisKit/Sources/Dashboard/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Dashboard/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "dashboardRegisterForCourseButton" = "Course Enrollment";
 "dashboardTitle" = "Courses";
+"allCourses" = "All courses";
+"recentlyAccessed" = "Recently accessed";
 "dashboardNextExerciseLabel" = "Next Exercise";
 "dashboardNoExercisePlannedLabel" = "No exercise planned";
 "dashboardNoStatisticsAvailable" = "No statistics available";


### PR DESCRIPTION
We currently don't show recent courses on the dashboard, unlike the web app. Therefore, we add this feature in this PR. The 3 most recently accessed courses are shown at the top of the dashboard in their own section. Below, we show all courses.
Additionally, we sort courses alphabetically now.

<img src="https://github.com/user-attachments/assets/04894240-1614-4a14-9855-2f3c8163ddc7" alt="Recent courses section" width="300">

We do not show this section if the user is only enrolled in 3 or less courses.
