### PR TITLE
Improvement : Renmame Hidden to Archive

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -45,13 +45,13 @@
 "createChat" = "Create Chat";
 "noResultForSearch" = "There is no result for your search.";
 "favoritesSection" = "Favorites";
-"hiddenSection" = "Hidden";
+"hiddenSection" = "Archive";
 "favorite" = "Favorite";
 "unfavorite" = "Unfavorite";
 "mute" = "Mute";
 "unmute" = "Unmute";
-"hide" = "Hide";
-"show" = "Show";
+"archive" = "Archive";
+"unarchive" = "Unarchive";
 "channels" = "Channels";
 "generalTopics" = "General Topics";
 "exercises" = "Exercises";

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -86,7 +86,7 @@ struct ConversationListView: View {
                         viewModel: viewModel,
                         conversations: viewModel.hiddenConversations,
                         sectionTitle: R.string.localizable.hiddenSection(),
-                        sectionIconName: "nosign",
+                        sectionIconName: "archivebox.fill",
                         isExpanded: false,
                         hidePrefixes: false)
                 }

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationRow/ConversationRow.swift
@@ -126,8 +126,8 @@ private extension ConversationRow {
 
     @ViewBuilder var hideAndMuteButtons: some View {
         let isHidden = conversation.isHidden ?? false
-        Button(isHidden ? R.string.localizable.show() : R.string.localizable.hide(),
-               systemImage: isHidden ? "eye.fill" : "eye.slash.fill") {
+        Button(isHidden ? R.string.localizable.unarchive() : R.string.localizable.archive(),
+               systemImage: "archivebox.fill") {
             Task(priority: .userInitiated) {
                 await viewModel.setConversationIsHidden(conversationId: conversation.id, isHidden: !(conversation.isHidden ?? false))
             }


### PR DESCRIPTION
Problem Description
The "Hidden" feature was unclear and inconsistent with users' expectations of how archiving should function. Additionally, there were no clear rules governing the interaction between favorite and archive statuses, leading to potential conflicts in the user experience. To ensure consistency with the Web and Android applications, adjustments are needed.

Changes
Renamed the feature:
The "Hidden" section is now renamed to "Archive."
Updated all related icons to reflect the new Archive feature.
In the channel settings, the Hide and Unhide options have been renamed to Archive and Unarchive respectively.

Steps for testing
1 - Test case: Rename and icon update
- Verify that the "Hidden" section is now named "Archive" across the app.
- Check that all icons related to this feature are updated appropriately.
- In the channel settings, confirm that the Hide and Unhide options are now labeled as Archive and Unarchive.
