### PR TITLE
`Communication`: Add  Delete Channel button

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -164,6 +164,10 @@
 "removeFavorite" = "Remove from Favorites";
 "sendMessage" = "Send Message";
 "deleteChannel" = "Delete Channel";
+"confirmDeleteTitle" = "Delete Channel";
+"confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
+"delete" = "Delete";
+"cancel" = "Cancel";
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 "addFavorite" = "Add to Favorites";
 "removeFavorite" = "Remove from Favorites";
 "sendMessage" = "Send Message";
+"deleteChannel" = "Delete Channel";
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -167,7 +167,6 @@
 "confirmDeleteTitle" = "Delete Channel";
 "confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
 "delete" = "Delete";
-"cancel" = "Cancel";
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -164,7 +164,6 @@
 "removeFavorite" = "Remove from Favorites";
 "sendMessage" = "Send Message";
 "deleteChannel" = "Delete Channel";
-"confirmDeleteTitle" = "Delete Channel";
 "confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
 "delete" = "Delete";
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -172,7 +172,7 @@ protocol MessagesService {
      * Perform a get request to retrieve channels which have unresolved messages
      */
     func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]>
-   
+
     /**
      * Perform a delete request to delete a specific channel in a specific course to the server.
      */

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -172,6 +172,11 @@ protocol MessagesService {
      * Perform a get request to retrieve channels which have unresolved messages
      */
     func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]>
+   
+    /**
+     * Perform a delete request to delete a specific channel in a specific course to the server.
+     */
+    func deleteChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse
 }
 
 extension MessagesService {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -95,7 +95,7 @@ extension MessagesServiceImpl {
             return .failure(error: error)
         }
     }
-   
+
     func deleteChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
         let result = await client.sendRequest(DeleteChannelRequest(courseId: courseId, channelId: channelId))
 
@@ -112,7 +112,7 @@ extension MessagesServiceImpl {
 
         let courseId: Int
         let channelId: Int64
-        
+
         var method: HTTPMethod {
             return .delete
         }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -95,6 +95,32 @@ extension MessagesServiceImpl {
             return .failure(error: error)
         }
     }
+   
+    func deleteChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
+        let result = await client.sendRequest(DeleteChannelRequest(courseId: courseId, channelId: channelId))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
+    struct DeleteChannelRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let courseId: Int
+        let channelId: Int64
+        
+        var method: HTTPMethod {
+            return .delete
+        }
+
+        var resourceName: String {
+            return "api/courses/\(courseId)/channels/\(channelId)"
+        }
+    }
 
     struct GetUnresolvedChannelsRequest: APIRequest {
         typealias Response = [UnresolvedChannelsResponse]

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -216,9 +216,8 @@ extension MessagesServiceStub: MessagesService {
     func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]> {
         .loading
     }
-    
-    func deleteChannel(for courseId: Int, channelId: Int64) async ->NetworkResponse {
+
+    func deleteChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse {
         .loading
     }
-    
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -216,4 +216,9 @@ extension MessagesServiceStub: MessagesService {
     func getUnresolvedChannelIds(for courseId: Int, and channelIds: [Int64]) async -> DataState<[Int64]> {
         .loading
     }
+    
+    func deleteChannel(for courseId: Int, channelId: Int64) async ->NetworkResponse {
+        .loading
+    }
+    
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -85,14 +85,14 @@ extension ConversationInfoSheetViewModel {
     var canRemoveUsers: Bool {
         canAddUsers
     }
-    
+
     var canDeleteChannel: Bool {
         guard let channel = conversation.baseConversation as? Channel else { return false }
         let isTutorialGroupChannel = channel.tutorialGroupId != nil || channel.tutorialGroupTitle != nil
         let hasChannelModerationRights = channel.hasChannelModerationRights ?? false
         let isChannelModerator = channel.isChannelModerator ?? false
         let isCreator = channel.isCreator ?? false
-    
+
         return !isTutorialGroupChannel && hasChannelModerationRights && isChannelModerator && isCreator
     }
 }
@@ -298,7 +298,7 @@ extension ConversationInfoSheetViewModel {
             isLoading = false
         }
     }
-  
+
     func deleteChannel() async -> Bool {
         let result = await messagesService.deleteChannel(for: course.id, channelId: conversation.id)
 

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -85,6 +85,16 @@ extension ConversationInfoSheetViewModel {
     var canRemoveUsers: Bool {
         canAddUsers
     }
+    
+    var canDeleteChannel: Bool {
+        guard let channel = conversation.baseConversation as? Channel else { return false }
+        let isTutorialGroupChannel = channel.tutorialGroupId != nil || channel.tutorialGroupTitle != nil
+        let hasChannelModerationRights = channel.hasChannelModerationRights ?? false
+        let isChannelModerator = channel.isChannelModerator ?? false
+        let isCreator = channel.isCreator ?? false
+    
+        return !isTutorialGroupChannel && hasChannelModerationRights && isChannelModerator && isCreator
+    }
 }
 
 extension ConversationInfoSheetViewModel {
@@ -288,7 +298,7 @@ extension ConversationInfoSheetViewModel {
             isLoading = false
         }
     }
-    
+  
     func deleteChannel() async -> Bool {
         let result = await messagesService.deleteChannel(for: course.id, channelId: conversation.id)
 
@@ -301,6 +311,5 @@ extension ConversationInfoSheetViewModel {
             presentError(userFacingError: UserFacingError(title: error.localizedDescription))
             return false
         }
-        
     }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -289,16 +289,18 @@ extension ConversationInfoSheetViewModel {
         }
     }
     
-    func deleteChannel() async {
+    func deleteChannel() async -> Bool {
         let result = await messagesService.deleteChannel(for: course.id, channelId: conversation.id)
 
         switch result {
         case .notStarted, .loading:
-            break
+            return false
         case .success:
-            await refreshConversation()
+            return true
         case .failure(let error):
             presentError(userFacingError: UserFacingError(title: error.localizedDescription))
+            return false
         }
+        
     }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -288,4 +288,17 @@ extension ConversationInfoSheetViewModel {
             isLoading = false
         }
     }
+    
+    func deleteChannel() async {
+        let result = await messagesService.deleteChannel(for: course.id, channelId: conversation.id)
+
+        switch result {
+        case .notStarted, .loading:
+            break
+        case .success:
+            await refreshConversation()
+        case .failure(let error):
+            presentError(userFacingError: UserFacingError(title: error.localizedDescription))
+        }
+    }
 }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -108,6 +108,15 @@ private extension ConversationInfoSheetView {
                     }
                     .foregroundColor(.Artemis.badgeWarningColor)
                 }
+                Button(R.string.localizable.deleteChannel(), systemImage: "trash") {
+                    viewModel.isLoading = true
+                    Task {
+                        await viewModel.deleteChannel()
+                        viewModel.isLoading = false
+                    }
+                }
+                .foregroundColor(.Artemis.badgeDangerColor)
+                
             }
             if viewModel.canLeaveConversation {
                 Button(R.string.localizable.leaveConversationButtonLabel(), systemImage: "rectangle.portrait.and.arrow.forward") {

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -69,7 +69,7 @@ struct ConversationInfoSheetView: View {
                         Task {
                             let success = await viewModel.deleteChannel()
                             if success {
-                                navigationController.goToCourseConversations(courseId: viewModel.course.id)
+                                navigationController.selectedPath = nil
                             } else {
                                 viewModel.isLoading = false
                             }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -129,7 +129,7 @@ private extension ConversationInfoSheetView {
                 }
                 if viewModel.canDeleteChannel {
                     Button(R.string.localizable.deleteChannel(), systemImage: "trash.fill", role: .destructive) {
-                    showDeleteConfirmation = true
+                        showDeleteConfirmation = true
                     }
                     .foregroundColor(.Artemis.badgeDangerColor)
                 }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -128,7 +128,7 @@ private extension ConversationInfoSheetView {
                     .foregroundColor(.Artemis.badgeWarningColor)
                 }
                 if viewModel.canDeleteChannel {
-                    Button(R.string.localizable.deleteChannel(), systemImage: "trash.fill") {
+                    Button(R.string.localizable.deleteChannel(), systemImage: "trash.fill", role: .destructive) {
                     showDeleteConfirmation = true
                     }
                     .foregroundColor(.Artemis.badgeDangerColor)

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -108,15 +108,18 @@ private extension ConversationInfoSheetView {
                     }
                     .foregroundColor(.Artemis.badgeWarningColor)
                 }
-                Button(R.string.localizable.deleteChannel(), systemImage: "trash") {
+                Button(R.string.localizable.deleteChannel(), systemImage: "trash.fill") {
                     viewModel.isLoading = true
                     Task {
-                        await viewModel.deleteChannel()
-                        viewModel.isLoading = false
+                        let success = await viewModel.deleteChannel()
+                        if success {
+                            navigationController.goToCourseConversations(courseId: viewModel.course.id)
+                        } else {
+                            viewModel.isLoading = false
+                        }
                     }
                 }
                 .foregroundColor(.Artemis.badgeDangerColor)
-                
             }
             if viewModel.canLeaveConversation {
                 Button(R.string.localizable.leaveConversationButtonLabel(), systemImage: "rectangle.portrait.and.arrow.forward") {

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -62,7 +62,7 @@ struct ConversationInfoSheetView: View {
             }
             .alert(isPresented: $showDeleteConfirmation) {
                 Alert(
-                    title: Text(R.string.localizable.confirmDeleteTitle()),
+                    title: Text(R.string.localizable.deleteChannel()),
                     message: Text(R.string.localizable.confirmDeleteMessage(conversation.baseConversation.conversationName)),
                     primaryButton: .destructive(Text(R.string.localizable.delete())) {
                         viewModel.isLoading = true

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -63,7 +63,7 @@ struct ConversationInfoSheetView: View {
             .alert(isPresented: $showDeleteConfirmation) {
                 Alert(
                     title: Text(R.string.localizable.confirmDeleteTitle()),
-                    message: Text(String(format: R.string.localizable.confirmDeleteMessage(conversation.baseConversation.conversationName))),
+                    message: Text(R.string.localizable.confirmDeleteMessage(conversation.baseConversation.conversationName)),
                     primaryButton: .destructive(Text(R.string.localizable.delete())) {
                         viewModel.isLoading = true
                         Task {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The delete channel functionality was previously available only on the web version of Artemis. However, there was no implementation for iOS, preventing moderators from deleting channels within the mobile app.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
✔️ Implemented channel deletion functionality.
✔️ Added a confirmation dialog before deletion to prevent accidental removals.
✔️ Integrated API call to delete the channel, ensuring consistency with the web version.
✔️ Updated UI elements to reflect the deletion process correctly.

### Steps for testing

Test Case 1 - Student/Tutor/Editor
1. Navigate to Conversation Settings of a channel.
2. Verify the Delete Channel button is not visible for users without moderation rights.

Test Case 2 - Moderator or channel owner
1. Navigate to Conversation Settings of a channel.
2. Verify the Delete Channel button is visible for users with moderation rights.
3. Click Delete Channel, and ensure a confirmation dialog appears.
          Confirm deletion and check:
            - The channel is removed from the overview.
            -  The user is redirected to conversation overview.

### Screenshots

<img width="220" alt="Screenshot 2025-03-01 at 16 37 40" src="https://github.com/user-attachments/assets/bbc4b270-9a80-4adf-be34-7e5f06d2d384" />
<img width="305" alt="Screenshot 2025-03-01 at 16 37 30" src="https://github.com/user-attachments/assets/2c011b96-d7b9-411e-9ffc-ce5c8856156a" />

