### PR TITLE
`Communication`: Add course-wide channel option

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -113,8 +113,12 @@
 "channelNameWarningText" = "Names can only contain lowercase letters, numbers, and dashes. Only Artemis can create channels that start with a $.";
 "descriptionOptional" = "Description (Optional)";
 "description" = "Description";
-"privateChannelLabel" = "Private Channel?";
-"privateChannelDescription" = "Every user except instructors will need an invitation to join a private channel. Everybody can join a public channel.";
+"privateChannelLabel" = "Private";
+"publicChannelLabel" = "Public";
+"courseWideChannelLabel" = "Course-wide";
+"privateChannelDescription" = "Every user except instructors will need an invitation to join a private channel.";
+"publicChannelDescription" = "Everybody can join a public channel.";
+"courseWideChannelDescription" = "All users of this course will be added to a course-wide channel.";
 "announcementChannelLabel" = "Announcement Channel?";
 "announcementChannelDescription" = "Only instructors and channel moderators can create new messages in an announcement channel. Students can only read the messages and answer to them.";
 "createChannelButtonLabel" = "Create Channel";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -113,12 +113,13 @@
 "channelNameWarningText" = "Names can only contain lowercase letters, numbers, and dashes. Only Artemis can create channels that start with a $.";
 "descriptionOptional" = "Description (Optional)";
 "description" = "Description";
+"channelType" = "Channel Type";
 "privateChannelLabel" = "Private";
 "publicChannelLabel" = "Public";
 "courseWideChannelLabel" = "Course-wide";
 "privateChannelDescription" = "Every user except instructors will need an invitation to join a private channel.";
 "publicChannelDescription" = "Everybody can join a public channel.";
-"courseWideChannelDescription" = "All users of this course will be added to a course-wide channel.";
+"courseWideChannelDescription" = "All users of a course are automatically added to a course-wide channel.";
 "announcementChannelLabel" = "Announcement Channel?";
 "announcementChannelDescription" = "Only instructors and channel moderators can create new messages in an announcement channel. Students can only read the messages and answer to them.";
 "createChannelButtonLabel" = "Create Channel";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -131,7 +131,7 @@ protocol MessagesService {
     /**
      * Perform a post request to create a specific channels in a specific course to the server.
      */
-    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> DataState<Channel>
+    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool, isCourseWide: Bool) async -> DataState<Channel>
 
     /**
      * Perform a get request to find users in a specific course to the server.

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -21,6 +21,7 @@ extension MessagesServiceImpl {
         let description: String?
         let isPublic: Bool
         let isAnnouncementChannel: Bool
+        let isCourseWide: Bool
 
         var method: HTTPMethod {
             return .post
@@ -31,9 +32,9 @@ extension MessagesServiceImpl {
         }
     }
 
-    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> DataState<Channel> {
+    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool, isCourseWide: Bool) async -> DataState<Channel> {
         let result = await client.sendRequest(
-            CreateChannelRequest(courseId: courseId, name: name, description: description, isPublic: !isPrivate, isAnnouncementChannel: isAnnouncement)
+            CreateChannelRequest(courseId: courseId, name: name, description: description, isPublic: !isPrivate, isAnnouncementChannel: isAnnouncement, isCourseWide: isCourseWide)
         )
 
         switch result {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -181,7 +181,7 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
-    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> DataState<Channel> {
+    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool, isCourseWide: Bool) async -> DataState<Channel> {
         .loading
     }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/CreateConversationViewModels/CreateChannelViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/CreateConversationViewModels/CreateChannelViewModel.swift
@@ -13,7 +13,9 @@ class CreateChannelViewModel: BaseViewModel {
 
     @Published var nameFormatText: String?
 
-    func createChannel(for courseId: Int, name: String, description: String?, isPrivate: Bool, isAnnouncement: Bool) async -> Int64? {
+    @Published var channelType: ChannelType = .public
+
+    func createChannel(for courseId: Int, name: String, description: String?, isAnnouncement: Bool) async -> Int64? {
         if !validateChannelName(name: name) {
             return nil
         }
@@ -21,8 +23,9 @@ class CreateChannelViewModel: BaseViewModel {
         let result = await MessagesServiceFactory.shared.createChannel(for: courseId,
                                                                        name: name,
                                                                        description: description,
-                                                                       isPrivate: isPrivate,
-                                                                       isAnnouncement: isAnnouncement)
+                                                                       isPrivate: channelType.isPrivate,
+                                                                       isAnnouncement: isAnnouncement,
+                                                                       isCourseWide: channelType.isCourseWide)
 
         switch result {
         case .loading:
@@ -44,5 +47,39 @@ class CreateChannelViewModel: BaseViewModel {
             nameFormatText = R.string.localizable.channelNameWarningText()
         }
         return isValid
+    }
+}
+
+enum ChannelType: CaseIterable, Hashable {
+    case `private`, `public`, courseWide
+
+    var isPrivate: Bool {
+        self == .private
+    }
+
+    var isCourseWide: Bool {
+        self == .courseWide
+    }
+
+    var title: String {
+        switch self {
+        case .public:
+            R.string.localizable.publicChannelLabel()
+        case .private:
+            R.string.localizable.privateChannelLabel()
+        case .courseWide:
+            R.string.localizable.courseWideChannelLabel()
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .public:
+            R.string.localizable.publicChannelDescription()
+        case .private:
+            R.string.localizable.privateChannelDescription()
+        case .courseWide:
+            R.string.localizable.courseWideChannelDescription()
+        }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
@@ -16,45 +16,37 @@ struct CreateChannelView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var navigationController: NavigationController
 
-    @StateObject private var viewModel = CreateChannelViewModel()
-
-    @State private var name = ""
-    @State private var description = ""
-
-    @State private var isAnnouncement = false
+    @State private var viewModel = CreateChannelViewModel()
 
     let courseId: Int
 
     var body: some View {
-        NavigationView {
-            VStack(alignment: .leading, spacing: .l) {
-                Text(R.string.localizable.channelNameLabel())
-                    .font(.headline)
-                HStack {
-                    Text("#")
-                    TextField(R.string.localizable.channelNameLabel(), text: $name)
-                        .textFieldStyle(ArtemisTextField())
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled(true)
+        NavigationStack {
+            Form {
+                Section(R.string.localizable.channelNameLabel()) {
+                    VStack {
+                        HStack {
+                            Text("#")
+                            TextField(R.string.localizable.channelNameLabel(), text: $viewModel.name)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled(true)
+                        }
+
+                        if let warningText = viewModel.nameFormatText {
+                            Text(warningText)
+                                .foregroundColor(.Artemis.badgeDangerColor)
+                                .font(.caption)
+                        }
+                    }
                 }
 
-                if let warningText = viewModel.nameFormatText {
-                    Text(warningText)
-                        .foregroundColor(.Artemis.badgeDangerColor)
-                        .font(.caption)
+                Section(R.string.localizable.descriptionOptional()) {
+                    TextField(R.string.localizable.description(), text: $viewModel.description)
                 }
 
-                Divider()
-
-                Text(R.string.localizable.descriptionOptional())
-                    .font(.headline)
-                TextField(R.string.localizable.description(), text: $description)
-                    .textFieldStyle(ArtemisTextField())
-
-                Divider()
-                Group {
+                Section {
                     VStack(alignment: .leading) {
-                        Picker("Channel Type", selection: $viewModel.channelType) {
+                        Picker(R.string.localizable.channelType(), selection: $viewModel.channelType) {
                             ForEach(ChannelType.allCases, id: \.self) { type in
                                 Text(type.title)
                             }
@@ -65,7 +57,7 @@ struct CreateChannelView: View {
                     }
 
                     VStack(alignment: .leading) {
-                        Toggle(R.string.localizable.announcementChannelLabel(), isOn: $isAnnouncement)
+                        Toggle(R.string.localizable.announcementChannelLabel(), isOn: $viewModel.isAnnouncement)
                             .tint(.Artemis.toggleColor)
                         Text(R.string.localizable.announcementChannelDescription())
                             .font(.caption2)
@@ -75,30 +67,28 @@ struct CreateChannelView: View {
 
                 Button(R.string.localizable.createChannelButtonLabel()) {
                     Task(priority: .userInitiated) {
-                        let newChannelId = await viewModel.createChannel(for: courseId,
-                                                                         name: name,
-                                                                         description: description.isEmpty ? nil : description,
-                                                                         isAnnouncement: isAnnouncement)
+                        let newChannelId = await viewModel.createChannel(for: courseId)
 
                         if let newChannelId {
                             dismiss()
                             navigationController.goToCourseConversation(courseId: courseId, conversationId: newChannelId)
                         }
                     }
-                }.buttonStyle(ArtemisButton())
-
-                Spacer()
+                }
+                .buttonStyle(ArtemisButton())
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .listRowBackground(Color.clear)
             }
-                .padding(.horizontal, .l)
-                .navigationTitle(R.string.localizable.createChannelNavTitel())
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(R.string.localizable.cancel()) {
-                            dismiss()
-                        }
+            .listRowSpacing(0)
+            .navigationTitle(R.string.localizable.createChannelNavTitel())
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(R.string.localizable.cancel()) {
+                        dismiss()
                     }
                 }
-                .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+            }
+            .alert(isPresented: viewModel.showError, error: viewModel.error, actions: {})
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
@@ -58,7 +58,6 @@ struct CreateChannelView: View {
 
                     VStack(alignment: .leading) {
                         Toggle(R.string.localizable.announcementChannelLabel(), isOn: $viewModel.isAnnouncement)
-                            .tint(.Artemis.toggleColor)
                         Text(R.string.localizable.announcementChannelDescription())
                             .font(.caption2)
                             .foregroundColor(.Artemis.secondaryLabel)

--- a/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
+++ b/ArtemisKit/Sources/Messages/Views/CreateConversationViews/CreateChannelView.swift
@@ -21,7 +21,6 @@ struct CreateChannelView: View {
     @State private var name = ""
     @State private var description = ""
 
-    @State private var isPrivate = false
     @State private var isAnnouncement = false
 
     let courseId: Int
@@ -55,9 +54,12 @@ struct CreateChannelView: View {
                 Divider()
                 Group {
                     VStack(alignment: .leading) {
-                        Toggle(R.string.localizable.privateChannelLabel(), isOn: $isPrivate)
-                            .tint(.Artemis.toggleColor)
-                        Text(R.string.localizable.privateChannelDescription())
+                        Picker("Channel Type", selection: $viewModel.channelType) {
+                            ForEach(ChannelType.allCases, id: \.self) { type in
+                                Text(type.title)
+                            }
+                        }
+                        Text(viewModel.channelType.description)
                             .font(.caption2)
                             .foregroundColor(.Artemis.secondaryLabel)
                     }
@@ -76,7 +78,6 @@ struct CreateChannelView: View {
                         let newChannelId = await viewModel.createChannel(for: courseId,
                                                                          name: name,
                                                                          description: description.isEmpty ? nil : description,
-                                                                         isPrivate: isPrivate,
                                                                          isAnnouncement: isAnnouncement)
 
                         if let newChannelId {


### PR DESCRIPTION
This PR adds the ability to create course-wide channels.

Included is a slight modernization of the Create channel sheet, as well as a migration of its viewModel to `Observable`.

<img src="https://github.com/user-attachments/assets/e0ea6c2c-5da8-49ba-8606-aaecc2414fa3" alt="New design" width="300">
<img src="https://github.com/user-attachments/assets/5c29a817-b07c-4885-923f-bc1aead61597" alt="New option" width="300">
