### PR TITLE
`General`: Add version code registration

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "10232a113a3f41ac1d582168d08890b465baed89ee0aa0e97ac3d3b2ebd1566f",
+  "originHash" : "098e3541141dae6d20dd5e9eeeea4f63b4dc52d33bee923957938fd961b02b34",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "857842e50f13123453fad1259ca82914e826d87f",
-        "version" : "15.6.0"
+        "revision" : "bd70c4bf9c317f6dd839528f7afe7dbbafe0e707",
+        "version" : "15.6.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.6.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "15.6.1")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [


### PR DESCRIPTION
This PR updates core modules to take advantage of version code registration using PushNotificationRegistration. This allows us to keep track of which app versions are in use by storing the versionCode on the server.