### PR TITLE
`Communication`: Allow saving posts for later

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "77b7691acd16619f9dd8aff94b884a34c67a9bda8e57dc7aefd877a9e79c4cc5",
+  "originHash" : "f1c77e293243e8cb99eae1174577b63c635a3b392229555a98acd9b0dafb1d68",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "bb2c970ecccb3817bdb91095c35f0b39b044a404",
-        "version" : "16.0.0"
+        "branch" : "ceba6c1",
+        "revision" : "ceba6c145e5be41f2a718bb54c262065e926de1d"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f1c77e293243e8cb99eae1174577b63c635a3b392229555a98acd9b0dafb1d68",
+  "originHash" : "20f6f3bc95ee5b59f28b7d583e392393261fa7ef6c656c7f95976164bac4a53f",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "ceba6c1",
-        "revision" : "ceba6c145e5be41f2a718bb54c262065e926de1d"
+        "branch" : "bc1ab91",
+        "revision" : "bc1ab91bbf3f26a1d459c0c73138def9ef11a99b"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.0.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "ceba6c1"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "ceba6c1"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "bc1ab91"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Models/SavedPostDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/SavedPostDTO.swift
@@ -14,7 +14,7 @@ struct SavedPostDTO: Codable, Identifiable, Hashable, Comparable {
         lhs.id < rhs.id
     }
 
-    let id: Int
+    let id: Int64
     let author: AuthorDTO
     let role: UserRole?
     let creationDate: Date

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -87,7 +87,8 @@
 "unmarkAsResolving" = "Doesn't Resolve Post";
 "pinMessage" = "Pin Message";
 "unpinMessage" = "Unpin Message";
-"removeBookmark" = "Remove bookmark";
+"addBookmark" = "Save Message";
+"removeBookmark" = "Remove Bookmark";
 
 // MARK: Saved Messages
 "savedMessages" = "Saved Messages";
@@ -106,6 +107,7 @@
 "reply" = "reply";
 "new" = "New";
 "pinned" = "Pinned";
+"savedMessage" = "Saved for later";
 "resolved" = "Resolved";
 "resolvesPost" = "Resolves Post";
 "filterMessages" = "Filter Messages";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -182,7 +182,7 @@ protocol MessagesService {
     /**
      * Perform a post request to add the specified post to the list of saved posts..
      */
-    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse
+    func addSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse
 
     /**
      * Perform a get request to find all saved posts in a course that have the given status.
@@ -192,12 +192,12 @@ protocol MessagesService {
     /**
      * Perform a put request to update a saved post's status.
      */
-    func updateSavedPostStatus(for postId: Int, with type: PostType, status: SavedPostStatus) async -> NetworkResponse
+    func updateSavedPostStatus(for postId: Int64, with type: PostType, status: SavedPostStatus) async -> NetworkResponse
 
     /**
      * Perform a delete request to remove the saved post with given id from the list of saved posts..
      */
-    func deleteSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse
+    func deleteSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse
 }
 
 extension MessagesService {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -180,6 +180,11 @@ protocol MessagesService {
 
     // MARK: Saved Messages
     /**
+     * Perform a post request to add the specified post to the list of saved posts..
+     */
+    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse
+
+    /**
      * Perform a get request to find all saved posts in a course that have the given status.
      */
     func getSavedPosts(for courseId: Int, status: SavedPostStatus) async -> DataState<[SavedPostDTO]>

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
@@ -9,6 +9,32 @@ import APIClient
 import Common
 
 extension MessagesServiceImpl {
+    struct AddSavedPostRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let postId: Int
+        let postType: PostType
+
+        var method: HTTPMethod {
+            return .post
+        }
+
+        var resourceName: String {
+            return "api/communication/saved-posts/\(postId)/\(postType)"
+        }
+    }
+
+    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+        let result = await client.sendRequest(AddSavedPostRequest(postId: postId, postType: type))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
     struct GetSavedPostsRequest: APIRequest {
         typealias Response = [SavedPostDTO]
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
@@ -12,7 +12,7 @@ extension MessagesServiceImpl {
     struct AddSavedPostRequest: APIRequest {
         typealias Response = RawResponse
 
-        let postId: Int
+        let postId: Int64
         let postType: PostType
 
         var method: HTTPMethod {
@@ -24,7 +24,7 @@ extension MessagesServiceImpl {
         }
     }
 
-    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+    func addSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse {
         let result = await client.sendRequest(AddSavedPostRequest(postId: postId, postType: type))
 
         switch result {
@@ -64,7 +64,7 @@ extension MessagesServiceImpl {
     struct UpdateSavedPostStatusRequest: APIRequest {
         typealias Response = RawResponse
 
-        let postId: Int
+        let postId: Int64
         let postType: PostType
         let status: SavedPostStatus
 
@@ -77,7 +77,7 @@ extension MessagesServiceImpl {
         }
     }
 
-    func updateSavedPostStatus(for postId: Int, with type: PostType, status: SavedPostStatus) async -> NetworkResponse {
+    func updateSavedPostStatus(for postId: Int64, with type: PostType, status: SavedPostStatus) async -> NetworkResponse {
         let result = await client.sendRequest(UpdateSavedPostStatusRequest(postId: postId, postType: type, status: status))
 
         switch result {
@@ -91,7 +91,7 @@ extension MessagesServiceImpl {
     struct DeleteSavedPostRequest: APIRequest {
         typealias Response = RawResponse
 
-        let postId: Int
+        let postId: Int64
         let postType: PostType
 
         var method: HTTPMethod {
@@ -103,7 +103,7 @@ extension MessagesServiceImpl {
         }
     }
 
-    func deleteSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+    func deleteSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse {
         let result = await client.sendRequest(DeleteSavedPostRequest(postId: postId, postType: type))
 
         switch result {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+SavedPosts.swift
@@ -20,7 +20,7 @@ extension MessagesServiceImpl {
         }
 
         var resourceName: String {
-            return "api/communication/saved-posts/\(postId)/\(postType)"
+            return "api/communication/saved-posts/\(postId)/\(postType.rawValue)"
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -225,15 +225,15 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
-    func updateSavedPostStatus(for postId: Int, with type: PostType, status: SavedPostStatus) async -> NetworkResponse {
+    func updateSavedPostStatus(for postId: Int64, with type: PostType, status: SavedPostStatus) async -> NetworkResponse {
         .loading
     }
 
-    func deleteSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+    func deleteSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse {
         .loading
     }
 
-    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+    func addSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse {
         .loading
     }
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -232,4 +232,8 @@ extension MessagesServiceStub: MessagesService {
     func deleteSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
         .loading
     }
+
+    func addSavedPost(with postId: Int, of type: PostType) async -> NetworkResponse {
+        .loading
+    }
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageActions/MessageActionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageActions/MessageActionsViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  MessageActionsViewModel.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 18.03.25.
+//
+
+import Common
+import Foundation
+import Navigation
+import SharedModels
+import SwiftUI
+
+@Observable
+class MessageActionsViewModel {
+    @ObservationIgnored @ObservedObject var conversationViewModel: ConversationViewModel
+    @ObservationIgnored @Binding var message: DataState<BaseMessage>
+
+    var showDeleteAlert = false
+    @MainActor var canDelete: Bool {
+        guard let message = message.value else {
+            return false
+        }
+
+        if message.isCurrentUserAuthor {
+            return true
+        }
+
+        guard let channel = conversationViewModel.conversation.baseConversation as? Channel else {
+            return false
+        }
+        if channel.hasChannelModerationRights ?? false {
+            return true
+        }
+
+        return false
+    }
+
+    var showEditSheet = false
+    var canEdit: Bool {
+        guard let message = message.value else {
+            return false
+        }
+
+        if message.isCurrentUserAuthor {
+            return true
+        }
+
+        return false
+    }
+
+    init(conversationViewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
+        self.conversationViewModel = conversationViewModel
+        self._message = message
+    }
+
+    @MainActor
+    func deleteMessage(navController: NavigationController) {
+        conversationViewModel.isLoading = true
+        Task(priority: .userInitiated) {
+            let success: Bool
+            let tempMessage = message.value
+            if message.value is AnswerMessage {
+                success = await conversationViewModel.deleteAnswerMessage(messageId: message.value?.id)
+            } else {
+                success = await conversationViewModel.deleteMessage(messageId: message.value?.id)
+            }
+            conversationViewModel.isLoading = false
+            conversationViewModel.selectedMessageId = nil
+            if success {
+                // if we deleted a Message and are in the MessageDetailView we pop it
+                if !navController.tabPath.isEmpty && tempMessage is Message {
+                    navController.tabPath.removeLast()
+                }
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/EditMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/EditMessageView.swift
@@ -1,0 +1,52 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 18.03.25.
+//
+
+import SharedModels
+import SwiftUI
+
+struct EditMessageView: View {
+    let viewModel: MessageActionsViewModel
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if let message = viewModel.message.value as? Message {
+                    SendMessageView(
+                        viewModel: SendMessageViewModel(
+                            course: viewModel.conversationViewModel.course,
+                            conversation: viewModel.conversationViewModel.conversation,
+                            configuration: .editMessage(message, { viewModel.showEditSheet = false }),
+                            delegate: SendMessageViewModelDelegate(viewModel.conversationViewModel)
+                        )
+                    )
+                } else if let answerMessage = viewModel.message.value as? AnswerMessage {
+                    SendMessageView(
+                        viewModel: SendMessageViewModel(
+                            course: viewModel.conversationViewModel.course,
+                            conversation: viewModel.conversationViewModel.conversation,
+                            configuration: .editAnswerMessage(answerMessage, { viewModel.showEditSheet = false }),
+                            delegate: SendMessageViewModelDelegate(viewModel.conversationViewModel)
+                        )
+                    )
+                } else {
+                    Text(R.string.localizable.loading())
+                }
+            }
+            .navigationTitle(R.string.localizable.editMessage())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(R.string.localizable.cancel()) {
+                        viewModel.showEditSheet = false
+                    }
+                }
+            }
+        }
+        .fontWeight(.regular)
+        .presentationDetents([.height(200), .medium])
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -8,7 +8,6 @@
 import Common
 import Navigation
 import SharedModels
-import Smile
 import SwiftUI
 import UserStore
 
@@ -322,44 +321,6 @@ struct MessageActions: View {
     }
 }
 
-struct MessageReactionsPopover: View {
-    @ObservedObject var viewModel: ConversationViewModel
-    @Binding var message: DataState<BaseMessage>
-    @State var reactionsViewModel: ReactionsViewModel
-
-    init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>, conversationPath: ConversationPath?) {
-        self.viewModel = viewModel
-        self._message = message
-        self._reactionsViewModel = State(initialValue: ReactionsViewModel(conversationViewModel: viewModel, message: message))
-    }
-
-    var body: some View {
-        HStack(alignment: .center) {
-            HStack(spacing: .m) {
-                EmojiTextButton(viewModel: reactionsViewModel, emoji: "😂")
-                EmojiTextButton(viewModel: reactionsViewModel, emoji: "👍")
-                EmojiTextButton(viewModel: reactionsViewModel, emoji: "➕")
-                EmojiTextButton(viewModel: reactionsViewModel, emoji: "🚀")
-                EmojiPickerButton(viewModel: reactionsViewModel)
-            }
-            .padding(.m)
-            .buttonStyle(.plain)
-            .font(.headline)
-            .symbolVariant(.fill)
-            .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
-            .background(.bar, in: .rect(cornerRadius: 10))
-
-            Button {
-                viewModel.selectedMessageId = nil
-            } label: {
-                Image(systemName: "xmark.circle")
-            }
-            .font(.title2)
-            .frame(maxWidth: .infinity, alignment: .center)
-        }
-    }
-}
-
 struct MessageActionsMenu: View {
     @ObservedObject var viewModel: ConversationViewModel
     @Binding var message: DataState<BaseMessage>
@@ -396,58 +357,6 @@ private struct ContextMenuLabelStyle: LabelStyle {
         .padding(.horizontal)
         .padding(.vertical, .s)
         .contentShape(.rect)
-    }
-}
-
-private struct EmojiTextButton: View {
-
-    var viewModel: ReactionsViewModel
-
-    let emoji: String
-
-    var body: some View {
-        Text("\(emoji)")
-            .font(.title3)
-            .foregroundColor(Color.Artemis.primaryLabel)
-            .frame(width: .mediumImage * 0.75, height: .mediumImage * 0.75)
-            .padding(.s)
-            .background(
-                Capsule().fill(Color.Artemis.reactionCapsuleColor)
-            )
-            .onTapGesture {
-                if let emojiId = Smile.alias(emoji: emoji) {
-                    Task {
-                        await viewModel.addReaction(emojiId: emojiId)
-                    }
-                }
-            }
-    }
-}
-
-private struct EmojiPickerButton: View {
-
-    var viewModel: ReactionsViewModel
-
-    @State private var showEmojiPicker = false
-
-    var body: some View {
-        Button {
-            showEmojiPicker = true
-        } label: {
-            Image("face-smile", bundle: .module)
-                .renderingMode(.template)
-                .resizable()
-                .scaledToFit()
-                .foregroundColor(Color.Artemis.secondaryLabel)
-                .frame(width: .smallImage * 0.75, height: .smallImage * 0.75)
-                .padding(.m * 1.5)
-                .background(Capsule().fill(Color.Artemis.reactionCapsuleColor))
-        }
-        .sheet(isPresented: $showEmojiPicker) {
-            NavigationStack {
-                EmojiPicker(viewModel: viewModel)
-            }
-        }
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -105,7 +105,7 @@ struct MessageActions: View {
                     .sheet(isPresented: $viewModel.showEditSheet) {
                         viewModel.conversationViewModel.selectedMessageId = nil
                     } content: {
-                        editMessage
+                        EditMessageView(viewModel: viewModel)
                             .font(nil)
                     }
                 }
@@ -124,45 +124,6 @@ struct MessageActions: View {
                     }
                 }
             }
-        }
-
-        var editMessage: some View {
-            NavigationView {
-                Group {
-                    if let message = viewModel.message.value as? Message {
-                        SendMessageView(
-                            viewModel: SendMessageViewModel(
-                                course: viewModel.conversationViewModel.course,
-                                conversation: viewModel.conversationViewModel.conversation,
-                                configuration: .editMessage(message, { viewModel.showEditSheet = false }),
-                                delegate: SendMessageViewModelDelegate(viewModel.conversationViewModel)
-                            )
-                        )
-                    } else if let answerMessage = viewModel.message.value as? AnswerMessage {
-                        SendMessageView(
-                            viewModel: SendMessageViewModel(
-                                course: viewModel.conversationViewModel.course,
-                                conversation: viewModel.conversationViewModel.conversation,
-                                configuration: .editAnswerMessage(answerMessage, { viewModel.showEditSheet = false }),
-                                delegate: SendMessageViewModelDelegate(viewModel.conversationViewModel)
-                            )
-                        )
-                    } else {
-                        Text(R.string.localizable.loading())
-                    }
-                }
-                .navigationTitle(R.string.localizable.editMessage())
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(R.string.localizable.cancel()) {
-                            viewModel.showEditSheet = false
-                        }
-                    }
-                }
-            }
-            .fontWeight(.regular)
-            .presentationDetents([.height(200), .medium])
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -99,11 +99,11 @@ struct MessageActions: View {
             Group {
                 Divider()
                 if message.value?.isBookmarked ?? false {
-                    Button("Remove bookmark", systemImage: "bookmark.slash") {
+                    Button(R.string.localizable.removeBookmark(), systemImage: "bookmark.slash") {
                         viewModel.toggleBookmark()
                     }
                 } else {
-                    Button("Add bookmark", systemImage: "bookmark") {
+                    Button(R.string.localizable.addBookmark(), systemImage: "bookmark") {
                         viewModel.toggleBookmark()
                     }
                 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -20,6 +20,7 @@ struct MessageActions: View {
         Group {
             ReplyInThreadButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
             CopyTextButton(viewModel: viewModel, message: $message)
+            BookmarkButton(viewModel: viewModel, message: $message)
             PinButton(viewModel: viewModel, message: $message)
             MarkResolvingButton(viewModel: viewModel, message: $message)
             EditDeleteSection(viewModel: viewModel, message: $message)
@@ -85,6 +86,31 @@ struct MessageActions: View {
         }
     }
 
+    struct BookmarkButton: View {
+        @State private var viewModel: MessageActionsViewModel
+        @Binding private var message: DataState<BaseMessage>
+
+        init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
+            _viewModel = State(initialValue: MessageActionsViewModel(conversationViewModel: viewModel, message: message))
+            _message = message
+        }
+
+        var body: some View {
+            Group {
+                Divider()
+                if message.value?.isBookmarked ?? false {
+                    Button("Remove bookmark", systemImage: "bookmark.slash") {
+                        viewModel.toggleBookmark()
+                    }
+                } else {
+                    Button("Add bookmark", systemImage: "bookmark") {
+                        viewModel.toggleBookmark()
+                    }
+                }
+            }
+        }
+    }
+
     struct EditDeleteSection: View {
         @EnvironmentObject var navigationController: NavigationController
         @State private var viewModel: MessageActionsViewModel
@@ -129,9 +155,11 @@ struct MessageActions: View {
 
     struct PinButton: View {
         @State private var viewModel: MessageActionsViewModel
+        @Binding private var message: DataState<BaseMessage>
 
         init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>) {
-            self._viewModel = State(initialValue: MessageActionsViewModel(conversationViewModel: viewModel, message: message))
+            _viewModel = State(initialValue: MessageActionsViewModel(conversationViewModel: viewModel, message: message))
+            _message = message
         }
 
         var body: some View {
@@ -139,7 +167,7 @@ struct MessageActions: View {
                 if viewModel.canPin {
                     Divider()
 
-                    if (viewModel.message.value as? Message)?.displayPriority == .pinned {
+                    if (message.value as? Message)?.displayPriority == .pinned {
                         Button(R.string.localizable.unpinMessage(), systemImage: "pin.slash", action: viewModel.togglePinned)
                     } else {
                         Button(R.string.localizable.pinMessage(), systemImage: "pin", action: viewModel.togglePinned)

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageReactionsPopover.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageReactionsPopover.swift
@@ -1,0 +1,102 @@
+//
+//  MessageReactionsPopover.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 18.03.25.
+//
+
+import Common
+import Navigation
+import SharedModels
+import Smile
+import SwiftUI
+
+struct MessageReactionsPopover: View {
+    @ObservedObject var viewModel: ConversationViewModel
+    @Binding var message: DataState<BaseMessage>
+    @State var reactionsViewModel: ReactionsViewModel
+
+    init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>, conversationPath: ConversationPath?) {
+        self.viewModel = viewModel
+        self._message = message
+        self._reactionsViewModel = State(initialValue: ReactionsViewModel(conversationViewModel: viewModel, message: message))
+    }
+
+    var body: some View {
+        HStack(alignment: .center) {
+            HStack(spacing: .m) {
+                EmojiTextButton(viewModel: reactionsViewModel, emoji: "😂")
+                EmojiTextButton(viewModel: reactionsViewModel, emoji: "👍")
+                EmojiTextButton(viewModel: reactionsViewModel, emoji: "➕")
+                EmojiTextButton(viewModel: reactionsViewModel, emoji: "🚀")
+                EmojiPickerButton(viewModel: reactionsViewModel)
+            }
+            .padding(.m)
+            .buttonStyle(.plain)
+            .font(.headline)
+            .symbolVariant(.fill)
+            .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
+            .background(.bar, in: .rect(cornerRadius: 10))
+
+            Button {
+                viewModel.selectedMessageId = nil
+            } label: {
+                Image(systemName: "xmark.circle")
+            }
+            .font(.title2)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+}
+
+private struct EmojiTextButton: View {
+
+    var viewModel: ReactionsViewModel
+
+    let emoji: String
+
+    var body: some View {
+        Text("\(emoji)")
+            .font(.title3)
+            .foregroundColor(Color.Artemis.primaryLabel)
+            .frame(width: .mediumImage * 0.75, height: .mediumImage * 0.75)
+            .padding(.s)
+            .background(
+                Capsule().fill(Color.Artemis.reactionCapsuleColor)
+            )
+            .onTapGesture {
+                if let emojiId = Smile.alias(emoji: emoji) {
+                    Task {
+                        await viewModel.addReaction(emojiId: emojiId)
+                    }
+                }
+            }
+    }
+}
+
+private struct EmojiPickerButton: View {
+
+    var viewModel: ReactionsViewModel
+
+    @State private var showEmojiPicker = false
+
+    var body: some View {
+        Button {
+            showEmojiPicker = true
+        } label: {
+            Image("face-smile", bundle: .module)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .foregroundColor(Color.Artemis.secondaryLabel)
+                .frame(width: .smallImage * 0.75, height: .smallImage * 0.75)
+                .padding(.m * 1.5)
+                .background(Capsule().fill(Color.Artemis.reactionCapsuleColor))
+        }
+        .sheet(isPresented: $showEmojiPicker) {
+            NavigationStack {
+                EmojiPicker(viewModel: viewModel)
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageReactionsPopover.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageReactionsPopover.swift
@@ -13,12 +13,10 @@ import SwiftUI
 
 struct MessageReactionsPopover: View {
     @ObservedObject var viewModel: ConversationViewModel
-    @Binding var message: DataState<BaseMessage>
     @State var reactionsViewModel: ReactionsViewModel
 
     init(viewModel: ConversationViewModel, message: Binding<DataState<BaseMessage>>, conversationPath: ConversationPath?) {
         self.viewModel = viewModel
-        self._message = message
         self._reactionsViewModel = State(initialValue: ReactionsViewModel(conversationViewModel: viewModel, message: message))
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -29,6 +29,7 @@ struct MessageCell: View {
             reactionMenuIfAvailable
 
             VStack(alignment: .leading, spacing: .s) {
+                savedIndicator
                 pinnedIndicator
                 resolvesPostIndicator
                 headerIfVisible
@@ -119,6 +120,10 @@ private extension MessageCell {
         (message.value as? Message)?.title ?? ""
     }
 
+    var isSaved: Bool {
+        message.value?.isBookmarked ?? false
+    }
+
     var isPinned: Bool {
         (message.value as? Message)?.displayPriority == .pinned
     }
@@ -150,6 +155,7 @@ private extension MessageCell {
 
     var messageBackground: Color {
         useFullWidth ? .clear :
+        isSaved ? .blue.opacity(0.2) :
         isPinned ? .orange.opacity(0.25) :
         resolvesPost ? .green.opacity(0.2) :
         Color(uiColor: .secondarySystemBackground)
@@ -164,6 +170,13 @@ private extension MessageCell {
                 verticalPadding: .s
             )
             .font(.footnote)
+        }
+    }
+
+    @ViewBuilder var savedIndicator: some View {
+        if isSaved {
+            Label(R.string.localizable.savedMessage(), systemImage: "bookmark")
+                .font(.caption)
         }
     }
 


### PR DESCRIPTION
This PR adds the ability for users to Save posts for later and remove them again using a button in the Message Actions Menu as well as Quick Actions Bar.

Prerequisite:
- [ ] Merge & Release https://github.com/ls1intum/artemis-ios-core-modules/pull/127

`Development`: Refactor MessageActions because file was too long before already, and make use of MVVM more.

<img src="https://github.com/user-attachments/assets/33479be4-2775-4093-9b60-05aee51dc1be" alt="Saved message" width="250">
<img src="https://github.com/user-attachments/assets/44bb3ddb-ebfb-424b-ba25-a8c279c3724f" alt="Menu" width="250">
<img src="https://github.com/user-attachments/assets/c66d35aa-7ab2-4e7f-93fd-62d9aa598f74" alt="Quick Actions" width="250">
