### PR TITLE
`Communication`: Adapt Announcement Title Styling

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -35,7 +35,6 @@ struct MessageCell: View {
                 if !title.isEmpty {
                     Text(title)
                         .fontWeight(.bold)
-                        .foregroundColor(.Artemis.artemisBlue)
                 }
                 ArtemisMarkdownView(string: content.surroundingMarkdownImagesWithNewlines())
                     .opacity(isMessageOffline ? 0.5 : 1)


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The post title on mobile clients was previously using a blue color to align with the web. However, as discussed in [this PR](https://github.com/ls1intum/artemis-ios/pull/305), this color choice could be misinterpreted as indicating a clickable link. This behavior was inconsistent with the intended design and could lead to user confusion.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
The title color change to base text color

### Steps for testing

1. Log in to Artemis.
2. Navigate to a course with active communication.
3. Open the announcement channel.
4. Verify that the post title: Uses the base text color (not blue).

### Screenshots
<img width="320" alt="Screenshot 2025-03-21 at 21 01 28" src="https://github.com/user-attachments/assets/951759a3-343e-476d-8e78-a0dab587ec79" />
