### PR TITLE
`Communication`: Add pinned messages filter

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
+++ b/ArtemisKit/Sources/Messages/Models/MessageRequestFilter.swift
@@ -15,11 +15,13 @@ class MessageRequestFilter: Codable {
 
     init(filterToUnresolved: Bool = false,
          filterToOwn: Bool = false,
-         filterToAnsweredOrReacted: Bool = false) {
+         filterToAnsweredOrReacted: Bool = false,
+         pinnedOnly: Bool = false) {
         self.filters = [
             .init(name: .filterToUnresolved, enabled: filterToUnresolved),
             .init(name: .filterToOwn, enabled: filterToOwn),
-            .init(name: .filterToAnsweredOrReacted, enabled: filterToAnsweredOrReacted)
+            .init(name: .filterToAnsweredOrReacted, enabled: filterToAnsweredOrReacted),
+            .init(name: .pinnedOnly, enabled: pinnedOnly)
         ]
     }
 
@@ -56,6 +58,8 @@ class MessageRequestFilter: Codable {
             return isOwn || didReply
         case .filterToUnresolved:
             return !(message.resolved ?? false)
+        case .pinnedOnly:
+            return message.displayPriority == .pinned
         default:
             return true
         }
@@ -85,6 +89,8 @@ struct FilterOption: Codable, Hashable {
             return R.string.localizable.messageFilterUnresolved()
         case .filterToOwn:
             return R.string.localizable.messageFilterOwn()
+        case .pinnedOnly:
+            return R.string.localizable.pinned()
         default:
             return ""
         }
@@ -96,4 +102,5 @@ fileprivate extension String {
     static let filterToAnsweredOrReacted = "filterToAnsweredOrReacted"
     static let filterToUnresolved = "filterToUnresolved"
     static let filterToOwn = "filterToOwn"
+    static let pinnedOnly = "pinnedOnly"
 }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -304,6 +304,13 @@ extension ConversationViewModel {
             presentError(userFacingError: error)
             return .failure(error: error)
         case .done(let message):
+            if let message = message as? Message, !filter.messageMatchesSelectedFilter(message) {
+                // Ensure message is removed if no longer matches filter
+                let equal = messages.remove(.of(id: message.id))
+                if equal != nil {
+                    diff -= 1
+                }
+            }
             return .done(response: message)
         case .loading:
             return .loading


### PR DESCRIPTION
With this PR, we add the ability to filter messages in a conversation to only display pinned messages. This is in addition to the existing filters (unresolved, own, reacted) and matches the new filter introduced in the web app.

<img src="https://github.com/user-attachments/assets/10c25ff2-3d43-4fcc-a4bc-f568e33eb161" width="300" alt="New filters">
