### PR TITLE
`Notifications`: Make course notifications tappable

### DIFF
--- a/ArtemisKit/Sources/Notifications/Navigation/NotificationNavigationHandler.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/NotificationNavigationHandler.swift
@@ -15,13 +15,17 @@ extension View {
 }
 
 private struct NotificationNavigationHandler: ViewModifier {
+    @Environment(\.dismiss) var dismiss
     @EnvironmentObject var navController: NavigationController
     let notification: CourseNotification
 
     func body(content: Content) -> some View {
-        if let tappable = notification.notification as? TappableNotification {
+        if let tappable = notification.notification.displayable as? TappableNotification {
             Button {
-                tappable.handleTap(with: navController)
+                dismiss()
+                Task {
+                    await tappable.handleTap(with: navController)
+                }
             } label: {
                 content
             }

--- a/ArtemisKit/Sources/Notifications/Navigation/NotificationNavigationHandler.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/NotificationNavigationHandler.swift
@@ -1,0 +1,34 @@
+//
+//  NotificationNavigationHandler.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 26.03.25.
+//
+
+import Navigation
+import SwiftUI
+
+extension View {
+    func notificationTapHandler(for notification: CourseNotification) -> some View {
+        modifier(NotificationNavigationHandler(notification: notification))
+    }
+}
+
+private struct NotificationNavigationHandler: ViewModifier {
+    @EnvironmentObject var navController: NavigationController
+    let notification: CourseNotification
+
+    func body(content: Content) -> some View {
+        if let tappable = notification.notification as? TappableNotification {
+            Button {
+                tappable.handleTap(with: navController)
+            } label: {
+                content
+            }
+            .contentShape(.rect)
+            .buttonStyle(.plain)
+        } else {
+            content
+        }
+    }
+}

--- a/ArtemisKit/Sources/Notifications/Navigation/TappableNotification.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/TappableNotification.swift
@@ -1,0 +1,12 @@
+//
+//  TappableNotification.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 26.03.25.
+//
+
+import Navigation
+
+protocol TappableNotification {
+    func handleTap(with navController: NavigationController)
+}

--- a/ArtemisKit/Sources/Notifications/Navigation/TappableNotification.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/TappableNotification.swift
@@ -6,7 +6,19 @@
 //
 
 import Navigation
+import PushNotifications
 
 protocol TappableNotification {
-    func handleTap(with navController: NavigationController)
+    func handleTap(with navController: NavigationController) async
+}
+
+extension NewPostNotification: TappableNotification {
+    @MainActor
+    func handleTap(with navController: NavigationController) async {
+        // CoursePath always exists in context of CourseNotifications
+        guard let coursePath = navController.selectedCourse else { return }
+        navController.setTab(identifier: .communication)
+        guard let channelId else { return }
+        navController.selectedPath = ConversationPath(id: Int64(channelId), coursePath: coursePath)
+    }
 }

--- a/ArtemisKit/Sources/Notifications/Views/CourseNotificationView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/CourseNotificationView.swift
@@ -29,6 +29,7 @@ struct CourseNotificationView: View {
 
                     ForEach(viewModel.filteredNotifications) { notification in
                         SingleNotificationView(notification: notification)
+                            .notificationTapHandler(for: notification)
                     }
 
                     if viewModel.filteredNotifications.isEmpty {


### PR DESCRIPTION
This PR adds the ability to tap on a notification to open it.

New notification types be default have no action. To support tapping on a notification type, conform it to the `TappableNotification` protocol. (Note: If the type does not conform to `DisplayableNotification`, it won't be shown and thus the user can't tap on it.)

https://github.com/user-attachments/assets/8f71fe3d-d59e-49df-a2e7-c88aab48e2e5
