### PR TITLE
`Development`: Fix missing artifact for TestFlight upload

### DIFF
--- a/.github/workflows/build-and-test-ios-app.yml
+++ b/.github/workflows/build-and-test-ios-app.yml
@@ -41,5 +41,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios-app
-          path: Artemis.ipa
-
+          path: /opt/actions-runner/_work/artemis-ios/artemis-ios/build/App.ipa

--- a/.github/workflows/build-and-test-ios-app.yml
+++ b/.github/workflows/build-and-test-ios-app.yml
@@ -25,11 +25,16 @@ jobs:
 
       - name: Install Gems
         run: eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)" && bundle install
+
+      - name: Generate build number
+        run: |
+          # Build number is current date/time in format YYYYMMDDHHMMSS
+          BUILD_NUMBER=$(date +'%Y%m%d%H%M%S')
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
         
       - name: Build iOS App 
         run: eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)" &&  bundle exec fastlane build
         env: 
-          BUILD_NUMBER: ${{ github.run_number }}
           MATCH_GITLAB_AUTH: ${{ secrets.IOS_MATCH_GITLAB_AUTH }}
           MATCH_PASSWORD: ${{ secrets.IOS_MATCH_PASSWORD }}
           MATCH_GIT_URL: ${{ vars.IOS_MATCH_GIT_URL }}

--- a/.github/workflows/build-and-test-ios-app.yml
+++ b/.github/workflows/build-and-test-ios-app.yml
@@ -38,7 +38,7 @@ jobs:
           API_KEY_PASSWORD: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_PASSWORD }}
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ios-app
           path: Artemis.ipa

--- a/.github/workflows/build-and-test-ios-app.yml
+++ b/.github/workflows/build-and-test-ios-app.yml
@@ -36,3 +36,10 @@ jobs:
           API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY_ID }}
           API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           API_KEY_PASSWORD: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_PASSWORD }}
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ios-app
+          path: Artemis.ipa
+

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - bugfix/ci/missing-artifact
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -17,12 +17,16 @@ jobs:
   release:
     permissions:
       contents: read
+    needs: build
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build
-        uses: ./.github/workflows/build-and-test-ios-app.yml
+      - name: Download IPA Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ios-app
+          path: .
 
       - name: Upload iOS App to TestFlight
         run: eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)" && bundle exec fastlane release

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - bugfix/ci/missing-artifact
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -16,10 +16,12 @@ jobs:
   release:
     permissions:
       contents: read
-    needs: build
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Build
+        uses: ./.github/workflows/build-and-test-ios-app.yml
 
       - name: Upload iOS App to TestFlight
         run: eval "$(/opt/homebrew/bin/rbenv init - --no-rehash bash)" && bundle exec fastlane release

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download IPA Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ios-app
           path: .

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,7 +102,7 @@ platform :ios do
   desc "[CI] Upload the newest build to TestFlight"
   lane :release do
     upload_to_testflight(
-      ipa: "#{Dir.pwd}/../build/App.ipa",
+      ipa: "App.ipa",
       demo_account_required: true,
       api_key: api_key,
       # submit_beta_review: false,


### PR DESCRIPTION
Uploading the App to TestFlight didn't work due to another issue: The build artifact was not accessible by the release workflow. This is resolved by uploading the build result as an artifact in the build workflow and then downloading it in the release workflow. 