### PR TITLE
`Notifications`: Add icons for communication notifications

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac9a25ce4cae5bc282a4065e185d8873c4f0f86ef41f18b926dd130040afae4d",
+  "originHash" : "a1bc264a6668c5e0150ef58125b34d8b51054ead1312e5619eab12e26c9d6587",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "11a692a",
-        "revision" : "11a692a51f91044976de3c299f0f1080fd3d73c8"
+        "branch" : "0ea91b1",
+        "revision" : "0ea91b149888efbfc6c1012847dc1f284fc7d2b7"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark",
       "state" : {
-        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
-        "version" : "0.5.0"
+        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703",
+        "version" : "0.6.0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "11a692a"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "0ea91b1"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Notifications/Navigation/NotificationToolbarButton.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/NotificationToolbarButton.swift
@@ -41,7 +41,7 @@ public struct NotificationToolbarButton: View {
             .labelStyle(.iconOnly)
             .popover(isPresented: $showNotificationSheet, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
                 NotificationView(courseId: courseId)
-                    .frame(minWidth: 400, minHeight: 600)
+                    .frame(minWidth: 350, minHeight: 500)
             }
         }
     }

--- a/ArtemisKit/Sources/Notifications/Views/NotificationIconView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/NotificationIconView.swift
@@ -18,6 +18,18 @@ struct NotificationIconView: View {
             profilePicture(name: postNotification.authorName,
                            id: postNotification.authorId,
                            url: postNotification.authorImageUrl)
+        case .newAnnouncement(let postNotification):
+            profilePicture(name: postNotification.authorName,
+                           id: postNotification.authorId,
+                           url: postNotification.authorImageUrl)
+        case .newAnswer(let postNotification):
+            profilePicture(name: postNotification.replyAuthorName,
+                           id: postNotification.replyAuthorId,
+                           url: postNotification.replyImageUrl)
+        case .newMention(let postNotification):
+            profilePicture(name: postNotification.replyAuthorName ?? postNotification.postAuthorName,
+                           id: postNotification.replyAuthorId,
+                           url: postNotification.replyImageUrl)
         default:
             EmptyView()
         }


### PR DESCRIPTION
Icons for communication notifications newAnnouncement, newAnswer and newMention were missing. This PR adds them.

<img src="https://github.com/user-attachments/assets/544eae0a-67b4-443e-ae8b-1d84485c7794" alt="Notification with icon" width="300">
