### PR TITLE
`Communication`: Toggle channel privacy in ConversationInfoSheet

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -182,6 +182,18 @@
 "deleteChannel" = "Delete Channel";
 "confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
 "delete" = "Delete";
+"deleteChannel" = "Delete Channel";
+"confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
+"delete" = "Delete";
+"toggleToPrivateChannel" = "Change to Private Channel";
+"toggleToPublicChannel" = "Change to Public Channel";
+"confirmPrivateChannelTitle" = "Change to a private channel?";
+"confirmPublicChannelTitle" = "Change to a public channel?";
+"confirmPrivateChannelMessage" = "Are you sure you want to make this channel private?\n\nOnly users with moderation rights will be able to add new members.";
+"confirmPublicChannelMessage" = "Do you really want to change this channel to public?\n\nKeep in mind that making a channel public allows anyone in the course to join, and new members will be able to see past messages.";
+"toggleToPrivateButton" = "Change to Private";
+"toggleToPublicButton" = "Change to Public";
+
 
 // MARK: Errors
 "detailViewCantBeOpened" = "Detail View can not be opened. Please try again later.";

--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -182,9 +182,6 @@
 "deleteChannel" = "Delete Channel";
 "confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
 "delete" = "Delete";
-"deleteChannel" = "Delete Channel";
-"confirmDeleteMessage" = "Are you sure you want to delete the channel with name '%@'? This is a permanent action and cannot be undone.";
-"delete" = "Delete";
 "toggleToPrivateChannel" = "Change to Private Channel";
 "toggleToPublicChannel" = "Change to Public Channel";
 "confirmPrivateChannelTitle" = "Change to a private channel?";

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -178,6 +178,11 @@ protocol MessagesService {
      */
     func deleteChannel(for courseId: Int, channelId: Int64) async -> NetworkResponse
 
+    /**
+     * Perform a post request to toggle privacy of a specific channel in a specific course to the server.
+     */
+    func toggleChannelPrivacy(for courseId: Int, channelId: Int64) async -> NetworkResponse
+
     // MARK: Saved Messages
     /**
      * Perform a post request to add the specified post to the list of saved posts..

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Management.swift
@@ -123,6 +123,29 @@ extension MessagesServiceImpl {
         }
     }
 
+    func toggleChannelPrivacy(for courseId: Int, channelId: Int64) async -> NetworkResponse {
+        let result = await client.sendRequest(ToggleChannelPrivacyRequest(courseId: courseId, channelId: channelId))
+
+        switch result {
+        case .success:
+            return .success
+        case let .failure(error):
+            return .failure(error: error)
+        }
+    }
+
+    struct ToggleChannelPrivacyRequest: APIRequest {
+        typealias Response = RawResponse
+        let courseId: Int
+        let channelId: Int64
+
+        var method: HTTPMethod { .post }
+
+        var resourceName: String {
+            "api/communication/courses/\(courseId)/channels/\(channelId)/toggle-privacy"
+        }
+    }
+
     struct GetUnresolvedChannelsRequest: APIRequest {
         typealias Response = [UnresolvedChannelsResponse]
         struct UnresolvedChannelsResponse: Codable {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -221,6 +221,10 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
+    func toggleChannelPrivacy(for courseId: Int, channelId: Int64) async -> NetworkResponse {
+        .loading
+    }
+
     func getSavedPosts(for courseId: Int, status: SavedPostStatus) async -> DataState<[SavedPostDTO]> {
         .loading
     }

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationInfoSheetViewModel.swift
@@ -312,4 +312,16 @@ extension ConversationInfoSheetViewModel {
             return false
         }
     }
+
+    func toggleChannelPrivacy() async {
+        let result = await messagesService.toggleChannelPrivacy(for: course.id, channelId: conversation.id)
+
+        switch result {
+        case .success:
+            await refreshConversation()
+        case .failure(let error):
+            presentError(userFacingError: UserFacingError(title: error.localizedDescription))
+        default: break
+        }
+    }
 }

--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationInfoSheetView.swift
@@ -135,20 +135,13 @@ private extension ConversationInfoSheetView {
 
             if let channel = conversation.baseConversation as? Channel,
                channel.hasChannelModerationRights ?? false {
-
-                if channel.isPublic == true {
-                    Button(R.string.localizable.toggleToPrivateChannel(), systemImage: "lock.fill") {
-                        togglePrivacyTargetIsPublic = false
-                        showTogglePrivacyAlert = true
-                    }
-                    .foregroundColor(.Artemis.artemisBlue)
-                } else {
-                    Button(R.string.localizable.toggleToPublicChannel(), systemImage: "number") {
-                        togglePrivacyTargetIsPublic = true
-                        showTogglePrivacyAlert = true
-                    }
-                    .foregroundColor(.Artemis.artemisBlue)
+                let isPublic = channel.isPublic == true
+                Button(isPublic ? R.string.localizable.toggleToPrivateChannel() : R.string.localizable.toggleToPublicChannel(),
+                       systemImage: isPublic ? "lock.fill" : "number") {
+                    togglePrivacyTargetIsPublic = !isPublic
+                    showTogglePrivacyAlert = true
                 }
+                .foregroundColor(.Artemis.artemisBlue)
 
                 if channel.isArchived ?? false {
                     Button(R.string.localizable.unarchiveChannelButtonLabel(), systemImage: "archivebox.fill") {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
iOS app currently lacks the ability to toggle channel privacy,  currently web app have this function. Adding this option enables users to seamlessly switch between public and private channels, improving flexibility and access control.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
The ability to toggle channel privacy has been added. This feature is integrated into the Channel Settings.
 It allows switching a public channel to private and vice versa. I
 nformative confirmation dialogs have also been implemented.

### Steps for testing
1 user with moderation rights

Open course activated Channel 
- Create a new public channel (or use existing one )  and from channel setting toggle the privacy
- Create a new private channel (or use existing one ) and from channel setting toggle the privacy

In each case should display a pop up to inform user about the changes that will be made. (See Screenshot)
And verify the privacy is toggled from public to private or vice versa

### Screenshots
![Screenshot 2025-04-03 at 23 51 31](https://github.com/user-attachments/assets/c1077155-34d5-4c0c-af6c-8b46091836cf)
![Screenshot 2025-04-03 at 23 51 20](https://github.com/user-attachments/assets/388d3bd1-8ed7-48ec-b045-e9ac029e730d)


