### PR TITLE
`CourseView`: Remove double space issue on course header

### DIFF
--- a/ArtemisKit/Sources/CourseView/TabBarIpad.swift
+++ b/ArtemisKit/Sources/CourseView/TabBarIpad.swift
@@ -21,7 +21,7 @@ struct TabBarIpad<Content: View>: View {
             content()
         } else {
             // Floating Tab Bar is shown
-            VStack(spacing: 0) {
+            layout {
                 HStack(alignment: .center) {
                     BackToRootButton(placement: .tabBar, sizeClass: sizeClass)
                     Spacer()
@@ -32,9 +32,20 @@ struct TabBarIpad<Content: View>: View {
                 .frame(height: 50)
                 .frame(maxWidth: .infinity)
                 .background(.thinMaterial)
+                .zIndex(1)
 
                 content()
             }
+        }
+    }
+
+    private var layout: AnyLayout {
+        if #available(iOS 18.4, *) {
+            // Change in iOS 18.4:
+            // SplitView inside TabView has space built in for TabBar at the top
+            AnyLayout(ZStackLayout(alignment: .top))
+        } else {
+            AnyLayout(VStackLayout(spacing: 0))
         }
     }
 }


### PR DESCRIPTION
Due to a change in iOS 18.4, NavigationSplitView has built-in space above for the toolbar. We previously added this manually as a workaround, which is now removed for iOS 18.4 and newer as it created the space twice.

### Before vs after
<img src="https://github.com/user-attachments/assets/6b4e1777-57cd-4d2c-a222-903dfad69c8a" alt="Before" width="300">
<img src="https://github.com/user-attachments/assets/b9eff516-51dd-413d-93f1-96aa09c97183" alt="After" width="300">
