### PR TITLE
`Communication`: Fix background color of saved message link

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -102,6 +102,7 @@ struct ConversationListView: View {
                             .foregroundStyle(.primary)
                     }
                     .listRowInsets(EdgeInsets(top: 0, leading: .s, bottom: 0, trailing: .s))
+                    .listRowBackground(Color.clear)
                 }
 
                 HStack {


### PR DESCRIPTION
In dark mode, the "Saved messages" link on the conversation list had a background color, which was not intentional.

<img src="https://github.com/user-attachments/assets/8d4612bb-50e4-4c09-9b08-9aaa0b353754" alt="Problem in dark mode" width="300">