### PR TITLE
`Communiation`: Fix icon not showing when all messages resolved

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/ConversationListView.swift
@@ -35,7 +35,7 @@ struct ConversationListView: View {
 
                 if viewModel.filter == .unresolved && viewModel.allChannelsResolved {
                     ContentUnavailableView(R.string.localizable.allDone(),
-                                           image: "checkmark",
+                                           systemImage: "checkmark",
                                            description: Text(R.string.localizable.allDoneDescription()))
                 }
 


### PR DESCRIPTION
In the conversation list, when filtering for unresolved messages, the icon for "All messages resolved" did not show up properly