### PR TITLE
`Communication`: Fix saved posts not navigating to thread

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a4085264584eed6d4de303be61ad4b9cc8e02f46589799d20c1bd4c0046dc808",
+  "originHash" : "6ae08708dc845e744b093458d2b3e8b755760ab9c9330debed55583e66607f3f",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "41edea44cc1597aeca3473a2a85e90151c79d94f",
-        "version" : "16.1.0"
+        "revision" : "2d855c1b679672de8bb558a77a5aefccfff8b889",
+        "version" : "16.1.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.1.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.1.1")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -182,7 +182,7 @@ struct MessagesServiceImpl: MessagesService {
 
         var params: [URLQueryItem] {
             [
-                .init(name: "conversationId", value: String(describing: conversationId)),
+                .init(name: "conversationIds", value: String(describing: conversationId)),
                 .init(name: "searchText", value: "#\(messageId)")
             ]
         }


### PR DESCRIPTION
Saved posts failed to open their respective conversation. This was due to it using the wrong parameter name that did not match the breaking changes in server 8.0.

also includes: Update core modules to fix profile pictures not loading