### PR TITLE
`Notifications`: Always enable notifications and show setup if applicable

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6ae08708dc845e744b093458d2b3e8b755760ab9c9330debed55583e66607f3f",
+  "originHash" : "4f2609a564b90847e5e07cd796f33a96ec4afdf3e888c16734d71e2806fe2e8a",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "2d855c1b679672de8bb558a77a5aefccfff8b889",
-        "version" : "16.1.1"
+        "revision" : "ee2c08eec083888ca5031c8eb6defc8976757c5c",
+        "version" : "16.2.0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile.git", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.1.1")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.2.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Notifications/Navigation/NotificationToolbarButton.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/NotificationToolbarButton.swift
@@ -18,8 +18,6 @@ public struct NotificationToolbarButton: View {
     private let sizeClass: UserInterfaceSizeClass?
 
     @State private var showNotificationSheet = false
-    @FeatureAvailability(.courseNotifications)
-    var featureEnabled
 
     @EnvironmentObject private var navController: NavigationController
     private var courseId: Int {
@@ -34,7 +32,7 @@ public struct NotificationToolbarButton: View {
     public var body: some View {
         // Only show this button in the NavBar if we are on compact width,
         // Otherwise we have a separate bar (iPad)
-        if featureEnabled && (placement != .navBar || sizeClass == .compact || !iPad) {
+        if placement != .navBar || sizeClass == .compact || !iPad {
             Button(R.string.localizable.notificationsTitle(), systemImage: "bell.fill") {
                 showNotificationSheet = true
             }

--- a/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
@@ -23,6 +23,12 @@ struct NotificationView: View {
                 await viewModel.loadNotifications()
             } content: { _ in
                 List {
+                    if viewModel.skippedNotifications {
+                        Section {
+                            PushNotificationSetupView(shouldCloseOnSkip: true)
+                        }
+                    }
+
                     Section {
                         FilterBarPicker(selectedFilter: $viewModel.filter, hiddenFilters: [])
                     }


### PR DESCRIPTION
This PR removes the feature toggle for course notifications as they are now always enabled. 

It also adds the ability to register for push notifications if the user has previously skipped setting them up.

<img src="https://github.com/user-attachments/assets/80940b2e-054b-4ff7-b7e7-6d44f04f0f63" alt="Notification settings" width="300">
