### PR TITLE
`Lecture`: Add missing prefix to lecture attachment link

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
@@ -43,6 +43,7 @@ struct LectureAttachmentSheet: View {
             return
         }
 
-        previewURL = await LectureServiceFactory.shared.getAttachmentFile(link: link)
+        let normalizedLink = link.hasPrefix("/api/core/files/") ? link : "/api/core/files/\(link)"
+        previewURL = await LectureServiceFactory.shared.getAttachmentFile(link: normalizedLink)
     }
 }


### PR DESCRIPTION
Lecture attachment could not be previewed due to wrong url. After adding the missing prefix now its accessible again.

https://github.com/user-attachments/assets/334af45a-f0f4-4728-899c-c2209cc9e426

