### PR TITLE
`Messages`: Make retrying offline messages more consistent

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationOfflineSection.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationOfflineSection.swift
@@ -23,8 +23,10 @@ struct ConversationOfflineSection: View {
                 roundBottomCorners: true,
                 retryButtonAction: viewModel.retryButtonAction
             )
-            .task {
-                await viewModel.sendMessage()
+            .onAppear {
+                Task {
+                    await viewModel.sendMessage()
+                }
             }
             .onDisappear {
                 viewModel.task?.cancel()


### PR DESCRIPTION
Due to the nature of the .task modifier starting and cancelling tasks sometimes multiple times, offline messages were not consistently retried. This PR exchanges it for .onAppear to ensure it works more well