### PR TITLE
`Exercises`/`Lectures`: Reverse list order and update grouping

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseListView.swift
@@ -112,29 +112,16 @@ private extension ExerciseListView {
             let end = exercise.baseExercise.dueDate
             let type: ExerciseGroup.GroupType
 
-            // Future release items (has release date in future)
-            if start == nil && end == nil && start ?? .now > .now {
+            if let start, start > .now {
                 type = .future
-            }
-            // Past items (has ended)
-            else if (start == nil || start ?? .now < .now) && (end != nil && end ?? .now < .now) {
+            } else if let end, end < .now {
                 type = .past
-            }
-            // No date items
-            else if (start == nil || start ?? .now < .now) && end == nil && (start == nil || start ?? .now <= .now) {
-                type = .noDate
-            }
-            // Due soon items (due within 3 days)
-            else if end != nil && end ?? .now > .now && end?.distance(to: .now) ?? 0 <= 3 * 24 * 60 * 60 {
+            } else if let end, end > .now, end.timeIntervalSince(.now) <= 3 * 24 * 60 * 60 {
                 type = .dueSoon
-            }
-            // Current items (has started but not ended)
-            else if (start == nil || start ?? .now <= .now) && (end != nil && end ?? .now > .now) {
+            } else if let end, end > .now {
                 type = .current
-            }
-            // Future items
-            else {
-                type = .future
+            } else {
+                type = .noDate
             }
 
             if partialResult[type] == nil {

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -116,25 +116,14 @@ private extension LectureListView {
             let end = lecture.endDate
             let type: LectureGroup.GroupType
 
-            // Future release items (has release date in future)
-            if start == nil && end == nil && start ?? .now > .now {
+            if let start, start > .now {
                 type = .future
-            }
-            // Past items (has ended)
-            else if (start == nil || start ?? .now < .now) && (end != nil && end ?? .now < .now) {
+            } else if let end, end < .now {
                 type = .past
-            }
-            // No date items
-            else if (start == nil || start ?? .now < .now) && end == nil && (start == nil || start ?? .now <= .now) {
-                type = .noDate
-            }
-            // Current items (has started but not ended)
-            else if (start == nil || start ?? .now <= .now) && (end != nil && end ?? .now > .now) {
+            } else if let end, end > .now {
                 type = .current
-            }
-            // Future items
-            else {
-                type = .future
+            } else {
+                type = .noDate
             }
 
             if partialResult[type] == nil {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The exercises list had two issues:

- Grouping issue
  - Exercises/Lectures with a future release date but no due date were incorrectly grouped under "No Date" instead of "Future".
  - Also due soon and current was not grouped correctly.
- Sorting issue
  - The exercise/lectures groups were not displayed same way like in web.


### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 

- Fixed the grouping logic:
  - Exercises /Lectures with a future release date and no due date are now properly categorized under the Future section, not under No Date.
- Adjusted the group ordering to match the desired sequence:
  - Future → Due Soon → Current → Past → No Date.
- Updated sorting logic:
  - Exercises /Lectures inside each group are now sorted descending by due date (most urgent at the top).
  - Exercises /Lectures inside each weekly group are also sorted descending by due date/end date/start date.
- Minor code cleanup: Improved clarity of sorting behavior when due dates are missing.

### Steps for testing
Open a course with multiple exercises (some released in the future, some ongoing, some past).

Verify that:

1. Exercises/Lectures with a future release date but no due date appear under the Future section.
2. The sections are ordered as: Future → Due Soon → Current → Past → No Date.
3. Inside sections and inside weekly groups are ordered newest first (by due date/start date/ end date).
4. Verify everything works as before

### Screenshots
<img width="206" alt="Screenshot 2025-05-07 at 16 29 27" src="https://github.com/user-attachments/assets/2db58629-fe4d-4bc1-8e86-7925a7ccd9b3" />
