### PR TITLE
`Messages`: Fix offline message section not updating correctly

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
+++ b/ArtemisKit/Sources/Messages/Views/ConversationView/ConversationView.swift
@@ -57,7 +57,7 @@ public struct ConversationView: View {
                             }
                             ConversationOfflineSection(viewModel)
                                 // Force re-evaluation, when offline messages change.
-                                .id(viewModel.offlineMessages.first)
+                                .id(viewModel.offlineMessages)
                             Spacer()
                                 .id("bottom")
                         }


### PR DESCRIPTION
When sending multiple messages that fail to send, or when retrying these messages automatically, the view did not update correctly due to the wrong id being used.