### PR TITLE
`Notifications`: Add notification settings

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e4159d16423fba7bcc85a8da7897fa481d49b9edf75425e7ac9ff4abf5a0d41d",
+  "originHash" : "f75e8b349b959cdc5e4a3e740cf7b9e9ecdf862ee252b4ba92690d5fbb595de2",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "de48cdf3148b9d1be683ed673f7c9bc329749f5e",
-        "version" : "16.3.0"
+        "branch" : "3afda2e",
+        "revision" : "3afda2e42e8527e08ac987f8e1fbe737b973b2c2"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "16.3.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "3afda2e"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "notificationsTitle" = "Notifications";
 "notificationAuthorLabel" = "%@ by %@";
 "noNotifications" = "No Notifications";
+"settings" = "Settings";
 
 "communication" = "Communication";
 "general" = "General";

--- a/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Notifications/Resources/en.lproj/Localizable.strings
@@ -8,5 +8,3 @@
 
 "communication" = "Communication";
 "general" = "General";
-
-"settingsDisclaimer" = "Changing notification settings is currently not possible in the mobile app.\nTo enable/disable certain notifications, please use your browser.";

--- a/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
@@ -23,9 +23,6 @@ struct NotificationView: View {
                 await viewModel.loadNotifications()
             } content: { _ in
                 List {
-                    ArtemisHintBox(text: R.string.localizable.settingsDisclaimer(), hintType: .info)
-                        .listRowInsets(EdgeInsets())
-
                     if viewModel.skippedNotifications {
                         Section {
                             PushNotificationSetupView(shouldCloseOnSkip: true)

--- a/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
+++ b/ArtemisKit/Sources/Notifications/Views/NotificationView.swift
@@ -56,6 +56,13 @@ struct NotificationView: View {
                     .foregroundStyle(.gray)
                     .font(.title2)
                 }
+                ToolbarItem(placement: .topBarLeading) {
+                    NavigationLink {
+                        NotificationSettingsView(courseId: viewModel.courseId)
+                    } label: {
+                        Label(R.string.localizable.settings(), systemImage: "gearshape")
+                    }
+                }
             }
         }
         .task {


### PR DESCRIPTION
This PR adds a settings screen for the new notification system. The settings can be accessed by tapping on the gear icon at the top of the notification tray.

Future considerations:
- Add previews or a description for each notification type
- Possibly: Add a "Settings" Tab for each course -> we will likely need to rename "Communication" back to "Messages" due to limited space.

<img src="https://github.com/user-attachments/assets/45e18c7c-92b5-4bf1-9d09-878ed5b69ab7" alt="Settings view" width="300">
<img src="https://github.com/user-attachments/assets/de4a8133-544c-4537-9c98-1d9edcef572e" alt="Notification view" width="300">