### PR TITLE
`Dashboard`: Hide keyboard after navigating to search result

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct CourseGridCell: View {
     @EnvironmentObject private var navigationController: NavigationController
+    @Environment(\.dismissSearch) private var dismissSearch
 
     let courseForDashboard: CourseForDashboardDTO
     let viewModel: DashboardViewModel
@@ -37,6 +38,7 @@ struct CourseGridCell: View {
                 // Update recents with a delay to not update grid during navigation transition
                 viewModel.addToRecents(courseId: courseForDashboard.id)
             }
+            dismissSearch()
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -148,6 +150,7 @@ private extension CourseGridCell {
                         .lineLimit(1)
                         .onTapGesture {
                             navigationController.goToExercise(courseId: courseForDashboard.id, exerciseId: nextExercise.id)
+                            dismissSearch()
                         }
                 } else {
                     Text(R.string.localizable.dashboardNoExercisePlannedLabel())


### PR DESCRIPTION
When searching for a course on the dashboard and tapping on it, the keyboard did not dismiss.