### PR TITLE
`Communication`: Display forwarded messages

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/ForwardedMessages/ForwardedMessageDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/ForwardedMessages/ForwardedMessageDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ForwardedMessageDTO.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 16.05.25.
+//
+
+struct ForwardedMessageDTO: Codable {
+    let sourceId: Int64
+    let sourceType: PostType
+    // Other members like id, destinationPostId and destinationAnswerPostId are pointless and thus not decoded
+}

--- a/ArtemisKit/Sources/Messages/Models/ForwardedMessages/ForwardedMessagesGroupDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/ForwardedMessages/ForwardedMessagesGroupDTO.swift
@@ -1,0 +1,26 @@
+//
+//  ForwardedMessagesGroupDTO.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 16.05.25.
+//
+
+import SharedModels
+
+struct ForwardedMessagesGroupDTO: Codable {
+    let id: Int64
+    let messages: [ForwardedMessageDTO]
+
+    enum CodingKeys: CodingKey {
+        case id, messages
+    }
+
+    // Property used for storing message after loading it
+    var sourceMessage: (any BaseMessage)?
+    var sourceMessageId: Int64? {
+        messages.first?.sourceId
+    }
+    var sourceMessageType: PostType {
+        messages.first?.sourceType ?? .unknown
+    }
+}

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService+Forward.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService+Forward.swift
@@ -1,0 +1,124 @@
+//
+//  MessagesService+Forward.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 16.05.25.
+//
+
+import APIClient
+import Common
+import Foundation
+import SharedModels
+
+// The API for forwarded messages is super horrible, so we contain the logic for that here
+
+extension MessagesServiceImpl {
+    struct GetForwardedMessageIdsRequest: APIRequest {
+        typealias Response = [ForwardedMessagesGroupDTO]
+
+        var method: HTTPMethod { .get }
+
+        let ids: [Int64]
+
+        var resourceName: String {
+            "api/communication/forwarded-messages"
+        }
+
+        var params: [URLQueryItem] {
+            [
+                .init(name: "postingIds", value: ids.map(String.init).joined(separator: ",")),
+                .init(name: "type", value: "POST")
+            ]
+        }
+    }
+
+    func getForwardedMessages(for postIds: [Int64], courseId: Int) async -> DataState<[ForwardedMessagesGroupDTO]> {
+        var messageGroups: [ForwardedMessagesGroupDTO] = []
+
+        // Fetch ids for source posts
+        let response = await client.sendRequest(GetForwardedMessageIdsRequest(ids: postIds))
+        switch response {
+        case .failure(let error):
+            return .failure(error: .init(error: error))
+        case .success(let (groups, _)):
+            messageGroups = groups
+        }
+
+        let postGroups = messageGroups.filter { $0.sourceMessageType == .post }
+        let answerGroups = messageGroups.filter { $0.sourceMessageType == .answer }
+
+        // Fetch source posts/answers
+        async let sourcePosts = await loadForwardedPosts(with: postGroups.compactMap(\.sourceMessageId), courseId: courseId)
+        async let sourceAnswers = await loadForwardedAnswers(with: answerGroups.compactMap(\.sourceMessageId), courseId: courseId)
+
+        // Store them all in a list
+        var allSources: [any BaseMessage] = []
+        switch await sourcePosts {
+        case .done(let response): allSources += response
+        default: break
+        }
+        switch await sourceAnswers {
+        case .done(let response): allSources += response
+        default: break
+        }
+
+        messageGroups = messageGroups.map { group in
+            let message = allSources.first { $0.id == group.sourceMessageId }
+            return ForwardedMessagesGroupDTO(id: group.id, messages: [], sourceMessage: message)
+        }
+
+        return .done(response: messageGroups)
+    }
+
+    private struct GetSourcePostsRequest: APIRequest {
+        typealias Response = [Message]
+        var method: HTTPMethod { .get }
+
+        let courseId: Int
+        let postIds: [Int64]
+
+        var resourceName: String {
+            "api/communication/courses/\(courseId)/messages-source-posts"
+        }
+
+        var params: [URLQueryItem] {
+            [.init(name: "postIds", value: postIds.map(String.init).joined(separator: ","))]
+        }
+    }
+
+    private func loadForwardedPosts(with ids: [Int64], courseId: Int) async -> DataState<[Message]> {
+        let response = await client.sendRequest(GetSourcePostsRequest(courseId: courseId, postIds: ids))
+        switch response {
+        case .success(let (data, _)):
+            return .done(response: data)
+        case .failure(let error):
+            return .failure(error: .init(error: error))
+        }
+    }
+
+    private struct GetSourceAnswersRequest: APIRequest {
+        typealias Response = [AnswerMessage]
+        var method: HTTPMethod { .get }
+
+        let courseId: Int
+        let postIds: [Int64]
+
+        var resourceName: String {
+            "api/communication/courses/\(courseId)/answer-messages-source-posts"
+        }
+
+        var params: [URLQueryItem] {
+            [.init(name: "answerPostIds", value: postIds.map(String.init).joined(separator: ","))]
+        }
+    }
+
+    private func loadForwardedAnswers(with ids: [Int64], courseId: Int) async -> DataState<[AnswerMessage]> {
+        let response = await client.sendRequest(GetSourceAnswersRequest(courseId: courseId, postIds: ids))
+        switch response {
+        case .success(let (data, _)):
+            return .done(response: data)
+        case .failure(let error):
+            return .failure(error: .init(error: error))
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -203,6 +203,11 @@ protocol MessagesService {
      * Perform a delete request to remove the saved post with given id from the list of saved posts..
      */
     func deleteSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse
+
+    /**
+     * Performs necessary requests to fetch forwarded message source posts
+     */
+    func getForwardedMessages(for postIds: [Int64], courseId: Int) async -> DataState<[ForwardedMessagesGroupDTO]>
 }
 
 extension MessagesService {

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -240,4 +240,8 @@ extension MessagesServiceStub: MessagesService {
     func addSavedPost(with postId: Int64, of type: PostType) async -> NetworkResponse {
         .loading
     }
+
+    func getForwardedMessages(for postIds: [Int64], courseId: Int) async -> DataState<[ForwardedMessagesGroupDTO]> {
+        .loading
+    }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
@@ -1,0 +1,73 @@
+//
+//  ForwardedMessageView.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 16.05.25.
+//
+
+import ArtemisMarkdown
+import DesignLibrary
+import SharedModels
+import SwiftUI
+
+struct ForwardedMessageView: View {
+    @ObservedObject var viewModel: ConversationViewModel
+    let message: Message?
+
+    var body: some View {
+        if let message, message.hasForwardedMessages ?? false,
+           let forwardedDTO = viewModel.forwardedSourcePosts.first(where: { $0.id == message.id }) {
+               if let sourceMessage = forwardedDTO.sourceMessage {
+                   ForwardedMessageCell(message: sourceMessage)
+               } else {
+                   ArtemisHintBox(text: "Forwarded message not found", hintType: .warning)
+               }
+        }
+    }
+}
+
+private struct ForwardedMessageCell: View {
+    let message: BaseMessage
+
+    var body: some View {
+        HStack {
+            Capsule()
+                .foregroundStyle(Color.Artemis.artemisBlue)
+                .frame(width: .s)
+
+            VStack(alignment: .leading) {
+                Text("Forwarded from #\(conversation?.baseConversation.conversationName ?? "")")
+                    .font(.caption)
+                messageHeader
+                ArtemisMarkdownView(string: message.content ?? "")
+                    .frame(maxHeight: .largeImage)
+                    .allowsHitTesting(false)
+                    .offset(y: -5) // There is more space by default than we want
+            }
+            .padding(.vertical, .s)
+        }
+        .frame(maxWidth: .infinity)
+        .contentShape(.rect)
+    }
+
+    var conversation: Conversation? {
+        if let message = message as? Message {
+            return message.conversation
+        }
+        if let message = message as? AnswerMessage,
+           let parent = message.post {
+            return parent.conversation
+        }
+        return nil
+    }
+
+    @ViewBuilder var messageHeader: some View {
+        if let author = message.author {
+            HStack(spacing: .s) {
+                ProfilePictureView(user: author, role: nil, course: .mock, size: 25)
+                    .allowsHitTesting(false)
+                Text(author.name ?? "")
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
@@ -7,6 +7,7 @@
 
 import ArtemisMarkdown
 import DesignLibrary
+import Navigation
 import SharedModels
 import SwiftUI
 
@@ -27,6 +28,7 @@ struct ForwardedMessageView: View {
 }
 
 private struct ForwardedMessageCell: View {
+    @EnvironmentObject var navController: NavigationController
     let message: BaseMessage
 
     var body: some View {
@@ -46,8 +48,14 @@ private struct ForwardedMessageCell: View {
             }
             .padding(.vertical, .s)
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(.rect)
+        .onTapGesture {
+            if let conversation, let coursePath = navController.selectedCourse, let baseThreadId {
+                let threadPath = ThreadPath(postId: baseThreadId, conversation: conversation, coursePath: coursePath)
+                navController.tabPath.append(threadPath)
+            }
+        }
     }
 
     var conversation: Conversation? {
@@ -57,6 +65,17 @@ private struct ForwardedMessageCell: View {
         if let message = message as? AnswerMessage,
            let parent = message.post {
             return parent.conversation
+        }
+        return nil
+    }
+
+    var baseThreadId: Int64? {
+        if let message = message as? Message {
+            return message.id
+        }
+        if let message = message as? AnswerMessage,
+           let parent = message.post {
+            return parent.id
         }
         return nil
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
@@ -38,17 +38,17 @@ private struct ForwardedMessageCell: View {
                 .frame(width: .s)
 
             VStack(alignment: .leading) {
-                Text("Forwarded from #\(conversation?.baseConversation.conversationName ?? "")")
-                    .font(.caption)
+                forwardedFromHeader
                 messageHeader
                 ArtemisMarkdownView(string: message.content ?? "")
                     .frame(maxHeight: .largeImage)
                     .allowsHitTesting(false)
                     .offset(y: -5) // There is more space by default than we want
             }
-            .padding(.vertical, .s)
+            .padding([.vertical, .trailing], .s)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: .rect(cornerRadius: .s))
         .contentShape(.rect)
         .onTapGesture {
             if let conversation, let coursePath = navController.selectedCourse, let baseThreadId {
@@ -78,6 +78,21 @@ private struct ForwardedMessageCell: View {
             return parent.id
         }
         return nil
+    }
+
+    @ViewBuilder var forwardedFromHeader: some View {
+        if let conversationName = conversation?.baseConversation.conversationName {
+            HStack {
+                Text("Forwarded from #\(conversationName)")
+
+                Spacer()
+
+                if let creationDate = message.creationDate {
+                    Text(creationDate, formatter: DateFormatter.superShortDateAndTime)
+                }
+            }
+            .font(.caption)
+        }
     }
 
     @ViewBuilder var messageHeader: some View {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
@@ -101,6 +101,7 @@ private struct ForwardedMessageCell: View {
                 ProfilePictureView(user: author, role: nil, course: .mock, size: 25)
                     .allowsHitTesting(false)
                 Text(author.name ?? "")
+                    .fontWeight(.medium)
             }
         }
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -44,6 +44,8 @@ struct MessageCell: View {
                     .environment(\.imagePreviewsEnabled, viewModel.conversationPath == nil)
                 editedLabel
                 resolvedIndicator
+                ForwardedMessageView(viewModel: conversationViewModel,
+                                     message: message.value as? Message)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(.rect)


### PR DESCRIPTION
This PR adds the ability to display forwarded messages in the iOS app.

Users can tap on a forwarded message to navigate to the originating thread.

<img src="https://github.com/user-attachments/assets/ce4249e9-774e-41bc-9b7f-2ae558457776" alt="Forwarded message" width="300">
<img src="https://github.com/user-attachments/assets/c90594e5-ec4f-46ce-8684-ea91c37e1764" alt="Forwarded message in thread view" width="300">
