### PR TITLE
`Communication`: Improve forwarded message loading

### DIFF
--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Forward.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl+Forward.swift
@@ -1,5 +1,5 @@
 //
-//  MessagesService+Forward.swift
+//  MessagesServiceImpl+Forward.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 16.05.25.
@@ -87,6 +87,7 @@ extension MessagesServiceImpl {
     }
 
     private func loadForwardedPosts(with ids: [Int64], courseId: Int) async -> DataState<[Message]> {
+        if ids.isEmpty { return .done(response: []) }
         let response = await client.sendRequest(GetSourcePostsRequest(courseId: courseId, postIds: ids))
         switch response {
         case .success(let (data, _)):
@@ -113,6 +114,7 @@ extension MessagesServiceImpl {
     }
 
     private func loadForwardedAnswers(with ids: [Int64], courseId: Int) async -> DataState<[AnswerMessage]> {
+        if ids.isEmpty { return .done(response: []) }
         let response = await client.sendRequest(GetSourceAnswersRequest(courseId: courseId, postIds: ids))
         switch response {
         case .success(let (data, _)):


### PR DESCRIPTION
There was an inefficiency in loading forwarded messages: If there were forwarded answers but no posts (or the other way round), still both were queried. This PR improves this.