### PR TITLE
`Communication`:  Adjust message pin visibility

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageActions/MessageActionsViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/MessageDetailViewModels/MessageActions/MessageActionsViewModel.swift
@@ -56,7 +56,7 @@ class MessageActionsViewModel {
         }
 
         // Channel: Only Moderators can pin
-        let isModerator = (conversationViewModel.conversation.baseConversation as? Channel)?.isChannelModerator ?? false
+        let isModerator = (conversationViewModel.conversation.baseConversation as? Channel)?.hasChannelModerationRights ?? false
         if conversationViewModel.conversation.baseConversation is Channel && !isModerator {
             return false
         }


### PR DESCRIPTION
Pinning a message was managed by isChannelModerator, and this cause for some user the pining is not visible.

Changed isChannelModerator to hasModerationsRights, people with moderations right should pin message.
Students should not be able to pin messages