### PR TITLE
`Communication`: Display forwarded message when opening thread

### DIFF
--- a/ArtemisKit/Sources/Messages/Models/SavedPostDTO.swift
+++ b/ArtemisKit/Sources/Messages/Models/SavedPostDTO.swift
@@ -18,7 +18,7 @@ struct SavedPostDTO: Codable, Identifiable, Hashable, Comparable {
     let author: AuthorDTO
     let role: UserRole?
     let creationDate: Date
-    let content: String
+    let content: String?
     let isSaved: Bool
     let savedPostStatus: SavedPostStatus
     let reactions: [ReactionDTO]?

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -460,6 +460,9 @@ private extension ConversationViewModel {
         if inserted {
             diff += 1
         }
+        Task {
+            await loadForwardedMessages()
+        }
     }
 
     func handle(update message: Message) {

--- a/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/ConversationViewModels/ConversationViewModel.swift
@@ -147,10 +147,10 @@ extension ConversationViewModel {
         }
     }
 
-    func loadForwardedMessages() async {
+    func loadForwardedMessages(forceIds: [Int64] = []) async {
         let messagesWithForwarded = messages.filter { $0.rawValue.hasForwardedMessages ?? false }
         let loadedIds = Set(forwardedSourcePosts.map(\.id))
-        let missingIds = messagesWithForwarded.map(\.id).filter { !loadedIds.contains($0) }
+        let missingIds = messagesWithForwarded.map(\.id).filter { !loadedIds.contains($0) } + forceIds
         if !missingIds.isEmpty {
             let result = await messagesService.getForwardedMessages(for: missingIds, courseId: course.id)
             switch result {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -106,6 +106,15 @@ struct MessageDetailView: View {
         }
         .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if let message = message.value as? Message,
+               message.hasForwardedMessages ?? false &&
+               !viewModel.forwardedSourcePosts.contains(where: { $0.id == message.id }) {
+                Task {
+                    await viewModel.loadForwardedMessages(forceIds: [message.id])
+                }
+            }
+        }
     }
 }
 

--- a/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessageView.swift
@@ -25,8 +25,10 @@ struct SavedMessageView: View {
             } label: {
                 VStack(alignment: .leading) {
                     header
-                    ArtemisMarkdownView(string: post.content.surroundingMarkdownImagesWithNewlines())
-                        .allowsHitTesting(false)
+                    if let content = post.content {
+                        ArtemisMarkdownView(string: content.surroundingMarkdownImagesWithNewlines())
+                            .allowsHitTesting(false)
+                    }
                 }
             }
             .listRowInsets(EdgeInsets(top: .m, leading: .m, bottom: .s, trailing: .l))


### PR DESCRIPTION
When opening a thread directly without previously having opened the corresponding conversation, forwarded messages were not displayed. This was the case for example when a referenced message referenced another message (double-forward), or when navigating into a thread from a saved post.

This PR also fixes an issue where newly forwarded messages did not appear immediately.