### PR TITLE
`Communication`: Improve message actions menu

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -79,7 +79,7 @@
 "attachment" = "Attachment";
 
 // MARK: Message Actions
-"replyInThread" = "Reply in Thread";
+"replyInThread" = "Reply";
 "copyText" = "Copy Text";
 "editMessage" = "Edit Message";
 "deleteMessage" = "Delete Message";
@@ -89,8 +89,8 @@
 "unmarkAsResolving" = "Doesn't Resolve Post";
 "pinMessage" = "Pin Message";
 "unpinMessage" = "Unpin Message";
-"addBookmark" = "Save Message";
-"removeBookmark" = "Remove Bookmark";
+"addBookmark" = "Save";
+"removeBookmark" = "Remove";
 "forwardMessage" = "Forward message";
 "forwardMessageShort" = "Forward";
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -42,11 +42,11 @@ private struct MessageActions: View {
     var body: some View {
         MenuGroup {
             HorizontalMenuGroup {
-                ReplyInThreadButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
+                ReplyButton(viewModel: viewModel, message: $message, conversationPath: conversationPath)
                 ForwardButton(viewModel: viewModel, message: $message)
-                CopyTextButton(viewModel: viewModel, message: $message)
+                BookmarkButton(viewModel: viewModel, message: $message)
             }
-            BookmarkButton(viewModel: viewModel, message: $message)
+            CopyTextButton(viewModel: viewModel, message: $message)
             PinButton(viewModel: viewModel, message: $message)
             MarkResolvingButton(viewModel: viewModel, message: $message)
             EditDeleteSection(viewModel: viewModel, message: $message)
@@ -55,7 +55,7 @@ private struct MessageActions: View {
         .font(.title3)
     }
 
-    struct ReplyInThreadButton: View {
+    struct ReplyButton: View {
         @EnvironmentObject var navigationController: NavigationController
         @ObservedObject var viewModel: ConversationViewModel
         @Binding var message: DataState<BaseMessage>
@@ -64,7 +64,7 @@ private struct MessageActions: View {
         var body: some View {
             if message.value is Message,
                let conversationPath {
-                Button(R.string.localizable.replyInThread(), systemImage: "text.bubble") {
+                Button(R.string.localizable.replyInThread(), systemImage: "arrowshape.turn.up.left") {
                     if let messagePath = MessagePath(
                         message: $message,
                         conversationPath: conversationPath,
@@ -89,7 +89,7 @@ private struct MessageActions: View {
         }
 
         var body: some View {
-            Button(R.string.localizable.forwardMessageShort(), systemImage: "arrowshape.turn.up.right.fill") {
+            Button(R.string.localizable.forwardMessageShort(), systemImage: "arrowshape.turn.up.right") {
                 viewModel.showForwardSheet = true
             }
             .sheet(isPresented: $viewModel.showForwardSheet) {

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -143,15 +143,13 @@ private struct MessageActions: View {
         }
 
         var body: some View {
-            Group {
-                if message.value?.isBookmarked ?? false {
-                    Button(R.string.localizable.removeBookmark(), systemImage: "bookmark.slash") {
-                        viewModel.toggleBookmark()
-                    }
-                } else {
-                    Button(R.string.localizable.addBookmark(), systemImage: "bookmark") {
-                        viewModel.toggleBookmark()
-                    }
+            if message.value?.isBookmarked ?? false {
+                Button(R.string.localizable.removeBookmark(), systemImage: "bookmark.slash") {
+                    viewModel.toggleBookmark()
+                }
+            } else {
+                Button(R.string.localizable.addBookmark(), systemImage: "bookmark") {
+                    viewModel.toggleBookmark()
                 }
             }
         }
@@ -166,30 +164,28 @@ private struct MessageActions: View {
         }
 
         var body: some View {
-            Group {
-                if viewModel.canEdit {
-                    Button(R.string.localizable.editMessage(), systemImage: "pencil") {
-                        viewModel.showEditSheet = true
-                    }
-                    .sheet(isPresented: $viewModel.showEditSheet) {
-                        viewModel.conversationViewModel.selectedMessageId = nil
-                    } content: {
-                        EditMessageView(viewModel: viewModel)
-                            .font(nil)
-                    }
+            if viewModel.canEdit {
+                Button(R.string.localizable.editMessage(), systemImage: "pencil") {
+                    viewModel.showEditSheet = true
                 }
-                if viewModel.canDelete {
-                    Button(R.string.localizable.deleteMessage(), systemImage: "trash", role: .destructive) {
-                        viewModel.showDeleteAlert = true
+                .sheet(isPresented: $viewModel.showEditSheet) {
+                    viewModel.conversationViewModel.selectedMessageId = nil
+                } content: {
+                    EditMessageView(viewModel: viewModel)
+                        .font(nil)
+                }
+            }
+            if viewModel.canDelete {
+                Button(R.string.localizable.deleteMessage(), systemImage: "trash", role: .destructive) {
+                    viewModel.showDeleteAlert = true
+                }
+                .foregroundStyle(.red)
+                .alert(R.string.localizable.confirmDeletionTitle(), isPresented: $viewModel.showDeleteAlert) {
+                    Button(R.string.localizable.confirm(), role: .destructive) {
+                        viewModel.deleteMessage(navController: navigationController)
                     }
-                    .foregroundStyle(.red)
-                    .alert(R.string.localizable.confirmDeletionTitle(), isPresented: $viewModel.showDeleteAlert) {
-                        Button(R.string.localizable.confirm(), role: .destructive) {
-                            viewModel.deleteMessage(navController: navigationController)
-                        }
-                        Button(R.string.localizable.cancel(), role: .cancel) {
-                            viewModel.conversationViewModel.selectedMessageId = nil
-                        }
+                    Button(R.string.localizable.cancel(), role: .cancel) {
+                        viewModel.conversationViewModel.selectedMessageId = nil
                     }
                 }
             }
@@ -206,13 +202,11 @@ private struct MessageActions: View {
         }
 
         var body: some View {
-            Group {
-                if viewModel.canPin {
-                    if (message.value as? Message)?.displayPriority == .pinned {
-                        Button(R.string.localizable.unpinMessage(), systemImage: "pin.slash", action: viewModel.togglePinned)
-                    } else {
-                        Button(R.string.localizable.pinMessage(), systemImage: "pin", action: viewModel.togglePinned)
-                    }
+            if viewModel.canPin {
+                if (message.value as? Message)?.displayPriority == .pinned {
+                    Button(R.string.localizable.unpinMessage(), systemImage: "pin.slash", action: viewModel.togglePinned)
+                } else {
+                    Button(R.string.localizable.pinMessage(), systemImage: "pin", action: viewModel.togglePinned)
                 }
             }
         }
@@ -242,13 +236,11 @@ private struct MessageActions: View {
         }
 
         var body: some View {
-            Group {
-                if isAbleToMarkResolving {
-                    if (message.value as? AnswerMessage)?.resolvesPost ?? false {
-                        Button(R.string.localizable.unmarkAsResolving(), systemImage: "xmark", action: toggleResolved)
-                    } else {
-                        Button(R.string.localizable.markAsResolving(), systemImage: "checkmark", action: toggleResolved)
-                    }
+            if isAbleToMarkResolving {
+                if (message.value as? AnswerMessage)?.resolvesPost ?? false {
+                    Button(R.string.localizable.unmarkAsResolving(), systemImage: "xmark", action: toggleResolved)
+                } else {
+                    Button(R.string.localizable.markAsResolving(), systemImage: "checkmark", action: toggleResolved)
                 }
             }
         }
@@ -261,56 +253,6 @@ private struct MessageActions: View {
                 }
             }
         }
-    }
-}
-
-struct HorizontalMenuGroup<Content: View>: View {
-    @Environment(\.actionsDisplayMode) private var displayMode
-    @ViewBuilder var content: Content
-
-    var isMenu: Bool { displayMode == .menu }
-
-    var body: some View {
-        HStack {
-            Group(subviews: content) { subviews in
-                ForEach(subviews.dropLast()) { subview in
-                    subview
-                        .frame(maxWidth: isMenu ? .infinity : nil)
-                    Divider()
-                }
-                subviews.last
-                    .frame(maxWidth: isMenu ? .infinity : nil)
-            }
-        }
-        .fixedSize(horizontal: false, vertical: true)
-        .environment(\.actionsDisplayMode, isMenu ? .menuCompact : displayMode)
-    }
-}
-
-struct MenuGroup<Content: View>: View {
-    @Environment(\.actionsDisplayMode) private var displayMode
-    @ViewBuilder var content: Content
-
-    var layout: AnyLayout {
-        if displayMode == .menu {
-            AnyLayout(VStackLayout(spacing: 0))
-        } else {
-            AnyLayout(HStackLayout(spacing: 10))
-        }
-    }
-
-    var body: some View {
-        layout {
-            Group(subviews: content) { subviews in
-                ForEach(subviews.dropLast()) { subview in
-                    subview
-                    Divider()
-                }
-                subviews.last
-            }
-        }
-        .fixedSize(horizontal: false, vertical: true)
-        .modifier(MessageActionsStyleModifier())
     }
 }
 
@@ -357,27 +299,6 @@ private struct ContextMenuLabelStyle: LabelStyle {
     }
 }
 
-private enum ActionsDisplayMode {
-    case menu, menuCompact, bar
-}
-
-// MARK: - Environment+ActionsDisplayMode
-
-private enum ActionsDisplayModeEnvironmentKey: EnvironmentKey {
-    static let defaultValue: ActionsDisplayMode = .menu
-}
-
-private extension EnvironmentValues {
-    var actionsDisplayMode: ActionsDisplayMode {
-        get {
-            self[ActionsDisplayModeEnvironmentKey.self]
-        }
-        set {
-            self[ActionsDisplayModeEnvironmentKey.self] = newValue
-        }
-    }
-}
-
 // MARK: - Environment+OriginalPostAuthor
 
 private enum OriginalPostAuthorEnvironmentKey: EnvironmentKey {
@@ -391,6 +312,78 @@ extension EnvironmentValues {
         }
         set {
             self[OriginalPostAuthorEnvironmentKey.self] = newValue
+        }
+    }
+}
+
+// MARK: - Layout
+private enum ActionsDisplayMode {
+    case menu, menuCompact, bar
+}
+
+private struct HorizontalMenuGroup<Content: View>: View {
+    @Environment(\.actionsDisplayMode) private var displayMode
+    @ViewBuilder var content: Content
+
+    var isMenu: Bool { displayMode == .menu }
+
+    var body: some View {
+        HStack {
+            Group(subviews: content) { subviews in
+                ForEach(subviews.dropLast()) { subview in
+                    subview
+                        .frame(maxWidth: isMenu ? .infinity : nil)
+                    Divider()
+                }
+                subviews.last
+                    .frame(maxWidth: isMenu ? .infinity : nil)
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .environment(\.actionsDisplayMode, isMenu ? .menuCompact : displayMode)
+    }
+}
+
+private struct MenuGroup<Content: View>: View {
+    @Environment(\.actionsDisplayMode) private var displayMode
+    @ViewBuilder var content: Content
+
+    var layout: AnyLayout {
+        if displayMode == .menu {
+            AnyLayout(VStackLayout(spacing: 0))
+        } else {
+            AnyLayout(HStackLayout(spacing: 10))
+        }
+    }
+
+    var body: some View {
+        layout {
+            Group(subviews: content) { subviews in
+                ForEach(subviews.dropLast()) { subview in
+                    subview
+                    Divider()
+                }
+                subviews.last
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .modifier(MessageActionsStyleModifier())
+    }
+}
+
+// MARK: Environment+ActionsDisplayMode
+
+private enum ActionsDisplayModeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ActionsDisplayMode = .menu
+}
+
+private extension EnvironmentValues {
+    var actionsDisplayMode: ActionsDisplayMode {
+        get {
+            self[ActionsDisplayModeEnvironmentKey.self]
+        }
+        set {
+            self[ActionsDisplayModeEnvironmentKey.self] = newValue
         }
     }
 }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/MessageActions.swift
@@ -328,7 +328,7 @@ private struct HorizontalMenuGroup<Content: View>: View {
     var isMenu: Bool { displayMode == .menu }
 
     var body: some View {
-        HStack {
+        HStack(spacing: isMenu ? 0 : .m) {
             Group(subviews: content) { subviews in
                 ForEach(subviews.dropLast()) { subview in
                     subview
@@ -352,7 +352,7 @@ private struct MenuGroup<Content: View>: View {
         if displayMode == .menu {
             AnyLayout(VStackLayout(spacing: 0))
         } else {
-            AnyLayout(HStackLayout(spacing: 10))
+            AnyLayout(HStackLayout(spacing: .m))
         }
     }
 

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageCell.swift
@@ -68,7 +68,7 @@ struct MessageCell: View {
         .background(messageBackground,
                     in: .rect(cornerRadii: viewModel.roundedCorners(isSelected: isSelected)))
         .padding(.top, viewModel.isHeaderVisible ? .m : 0)
-        .padding(.horizontal, useFullWidth ? 0 : (.m + .l) / 2)
+        .padding(.horizontal, useFullWidth ? 0 : .m)
         .opacity(opacity)
         .id(message.value?.id.description)
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -145,14 +145,10 @@ private extension MessageDetailView {
 
                 // Only display labels if we have enough space
                 ViewThatFits(in: .horizontal) {
-                    HStack {
-                        MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
-                    }
-                    HStack(spacing: .l) {
-                        MessageActions(viewModel: viewModel, message: $message, conversationPath: nil)
-                            .labelStyle(.iconOnly)
-                            .fontWeight(.bold)
-                    }
+                    MessageActionsBar(viewModel: viewModel, message: $message, conversationPath: nil)
+                    MessageActionsBar(viewModel: viewModel, message: $message, conversationPath: nil)
+                        .labelStyle(.iconOnly)
+                        .fontWeight(.bold)
                 }
                 .loadingIndicator(isLoading: $viewModel.isLoading)
             }


### PR DESCRIPTION
Due to the amount of actions recently added to the message actions menu, it often got very large. We try to improve the user experience here by grouping some options horizontally, as can be seen in the iOS Mail app or Slack.

<img src="https://github.com/user-attachments/assets/1f2cb7df-dee8-44ba-873d-6298d88c5ecb" alt="More compact menu" width="300">
