### PR TITLE
`Lectures`: Improve attachment loading

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
@@ -28,9 +28,11 @@ struct LectureAttachmentSheet: View {
 
     private func loadAttachment() async {
         var link: String?
+        var fileName: String?
         switch attachment {
         case .file(let attachment):
             link = attachment.link
+            fileName = attachment.name
         case .url(let attachment):
             // TODO
             link = nil
@@ -44,6 +46,6 @@ struct LectureAttachmentSheet: View {
         }
 
         let normalizedLink = link.hasPrefix("/api/core/files/") ? link : "/api/core/files/\(link)"
-        previewURL = await LectureServiceFactory.shared.getAttachmentFile(link: normalizedLink)
+        previewURL = await LectureServiceFactory.shared.getAttachmentFile(link: normalizedLink, name: fileName)
     }
 }

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureService.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureService.swift
@@ -11,7 +11,7 @@ import SharedModels
 
 protocol LectureService {
     func getLectureDetails(lectureId: Int) async -> DataState<Lecture>
-    func getAttachmentFile(link: String) async -> DataState<URL>
+    func getAttachmentFile(link: String, name: String?) async -> DataState<URL>
     func updateLectureUnitCompletion(lectureId: Int, lectureUnitId: Int64, completed: Bool) async -> NetworkResponse
     func getAssociatedChannel(for lectureId: Int, in courseId: Int) async -> DataState<Channel>
 }

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
@@ -87,7 +87,8 @@ class LectureServiceImpl: LectureService {
                 (data, _) = try await URLSession.shared.data(from: newUrl)
             }
 
-            let suggestedFilename = name ?? url.lastPathComponent
+            let fileExtension = url.pathExtension
+            let suggestedFilename = name?.appending("." + fileExtension) ?? url.lastPathComponent
             let previewURL = FileManager.default.temporaryDirectory.appendingPathComponent(suggestedFilename)
             try data.write(to: previewURL, options: .atomic)   // atomic option overwrites it if needed
             return .done(response: previewURL)

--- a/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseView/Services/LectureService/LectureServiceImpl.swift
@@ -69,14 +69,25 @@ class LectureServiceImpl: LectureService {
         }
     }
 
-    func getAttachmentFile(link: String) async -> DataState<URL> {
+    func getAttachmentFile(link: String, name: String? = nil) async -> DataState<URL> {
         guard let url = URL(string: link, relativeTo: UserSessionFactory.shared.institution?.baseURL) else {
             return .failure(error: UserFacingError(title: "Wrong URL"))
         }
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            var (data, response) = try await URLSession.shared.data(from: url)
 
-            guard let suggestedFilename = URL(string: link)?.lastPathComponent else { return .failure(error: UserFacingError(title: "")) }
+            // Accessing lecture attachment as student needs a different URL sometimes
+            if (response as? HTTPURLResponse)?.statusCode == 403 {
+                let lastPathComponent = url.lastPathComponent
+                let newUrl = url
+                    .deletingLastPathComponent()
+                    .appending(path: "student")
+                    .appending(path: lastPathComponent)
+
+                (data, _) = try await URLSession.shared.data(from: newUrl)
+            }
+
+            let suggestedFilename = name ?? url.lastPathComponent
             let previewURL = FileManager.default.temporaryDirectory.appendingPathComponent(suggestedFilename)
             try data.write(to: previewURL, options: .atomic)   // atomic option overwrites it if needed
             return .done(response: previewURL)


### PR DESCRIPTION
Due to some server side change, attachment files might fail to load for students due to them having a different URL than tutors or instructors.

With this PR, we add a workaround for this and improve the displayName by making use of the attachment's name.