### PR TITLE
`Communiation`: Disable taps on forward message preview

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/ForwardMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/ForwardMessageView.swift
@@ -96,6 +96,7 @@ private struct ForwardMessagePreviewView: View {
         ForwardedMessageView(viewModel: conversationViewModel, message: previewContainer)
             .fixedSize(horizontal: false, vertical: true)
             .padding()
+            .allowsHitTesting(false)
     }
 
     var previewContainer: Message {


### PR DESCRIPTION
In the preview for forwarding messages, it was possible to tap on the preview which would navigate to the message's thread in the background. This was not intentional and is thus disabled with this PR.