### PR TITLE
`Communication`: Fix conversation unread counter not increasing

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "95dfd274c5c744da97b08f00a2def75e9c2dbb7dcb97dd2392aab0d1d36a0f61",
+  "originHash" : "238b86cfa8650d26367b7e3dc6f37311835a6f7847f454db15ef1c85779da2f1",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "ba00419e925d77890d48c2adf446a6224b7e2b06",
-        "version" : "17.1.0"
+        "revision" : "cf8259b1731fed28ab7ddd0d4bd56db0d7e4da68",
+        "version" : "17.1.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "17.1.0")),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "17.1.1")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.7.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessagesTabView/MessagesAvailableView.swift
@@ -46,8 +46,8 @@ public struct MessagesAvailableView: View {
             .task {
                 await viewModel.loadConversations()
             }
-            .task {
-                await viewModel.subscribeToConversationMembershipTopic()
+            .onAppear {
+                viewModel.subscribeToWebsocketUpdates()
             }
             .alert(isPresented: $viewModel.showError, error: viewModel.error, actions: {})
             .loadingIndicator(isLoading: $viewModel.isLoading)


### PR DESCRIPTION
Due to server side changes a very long time ago, no "New Message" notifications are sent to the conversation list websocket topic anymore. As this issue was not addressed server side, this PR implements a client side workaround like the web app to just subscribe to all communication websocket topics in the conversation list.