### PR TITLE
`Communication`: Fix forwarded messages not being clipped correctly

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ForwardedMessageView.swift
@@ -41,7 +41,8 @@ private struct ForwardedMessageCell: View {
                 forwardedFromHeader
                 messageHeader
                 ArtemisMarkdownView(string: message.content ?? "")
-                    .frame(maxHeight: .largeImage)
+                    .frame(maxHeight: .largeImage, alignment: .top)
+                    .clipped()
                     .allowsHitTesting(false)
                     .offset(y: -5) // There is more space by default than we want
             }


### PR DESCRIPTION
Due to issues with bounding the size of Markdown Views, forwarded messages were not clipped correctly if they contained certain kinds of formatted text, e.g. code blocks. This made the message overlay everything else.

Fixes https://github.com/ls1intum/Artemis/issues/11001