### PR TITLE
`Communication`: Fix message textfield not growing

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/ForwardMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageActions/ForwardMessageView.swift
@@ -36,25 +36,27 @@ struct ForwardMessageView: View {
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading) {
-                NavigationLink {
-                    PickConversationView(viewModel: viewModel)
-                } label: {
-                    HStack {
-                        Text(R.string.localizable.conversation())
-                        Spacer()
-                        Text("\(conversationName) \(Image(systemName: "chevron.forward"))")
-                            .foregroundStyle(.secondary)
+                ScrollView {
+                    NavigationLink {
+                        PickConversationView(viewModel: viewModel)
+                    } label: {
+                        HStack {
+                            Text(R.string.localizable.conversation())
+                            Spacer()
+                            Text("\(conversationName) \(Image(systemName: "chevron.forward"))")
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.m * 1.5)
+                        .contentShape(.rect)
                     }
-                    .padding(.m * 1.5)
-                    .contentShape(.rect)
+                    .buttonStyle(.plain)
+                    .cardModifier(backgroundColor: .gray.opacity(0.2))
+                    .padding()
+
+                    Spacer()
+
+                    ForwardMessagePreviewView(viewModel: viewModel)
                 }
-                .buttonStyle(.plain)
-                .cardModifier(backgroundColor: .gray.opacity(0.2))
-                .padding()
-
-                Spacer()
-
-                ForwardMessagePreviewView(viewModel: viewModel)
 
                 SendMessageView(viewModel: sendViewModel)
             }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/MessageDetailView.swift
@@ -71,9 +71,8 @@ struct MessageDetailView: View {
                                 .frame(height: .m * 1.5)
                         }
                         .frame(maxWidth: 25)
-                        // Workaround: Trailing spaces, otherwise SwiftUI shortens this prematurely
-                        Text(viewModel.conversation.baseConversation.conversationName + "    ")
-                            .frame(maxWidth: 220)
+                        Text(viewModel.conversation.baseConversation.conversationName)
+                            .frame(minWidth: 100, maxWidth: 220, alignment: .leading)
                     }
                     .font(.footnote)
                 }.padding(.leading, .m)

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -48,6 +48,7 @@ struct SendMessageView: View {
                     .padding(.vertical, .m)
             }
             textField
+                .fixedSize(horizontal: false, vertical: true)
                 .padding(isFocused ? [.horizontal, .bottom] : .all, .l)
             if isFocused || viewModel.keyboardVisible {
                 keyboardToolbarContent
@@ -133,7 +134,8 @@ private extension SendMessageView {
                       selection: viewModel.selection,
                       axis: .vertical)
                 .textFieldStyle(.roundedBorder)
-                .lineLimit(10)
+                .lineLimit(isFocused ? 10 : 5)
+                .animation(.smooth, value: isFocused)
                 .focused($isFocused)
             if !isFocused {
                 sendButton


### PR DESCRIPTION
The message text field was supposed to show up to 10 lines. However, it never reached this size when the keyboard was open due to layout priorities. This PR addresses this issue. In addition, we now use a smaller max size when the text field is not focused to save space.

Fixes premature truncation of thread title bar