### PR TITLE
`Communication`: Fix image picker dismissing when opening collection

### DIFF
--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -55,8 +55,9 @@ public struct CourseView: View {
             }
         }
         .courseToolbar(title: viewModel.course.title  ?? R.string.localizable.loading())
-        // Add a file picker here, inside the navigation it doesn't work sometimes
+        // Add a file and image picker here, inside the navigation it doesn't work sometimes
         .supportsFilePicker()
+        .supportsImagePicker()
     }
 }
 

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/FileUpload/SendMessageUploadImageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/FileUpload/SendMessageUploadImageViewModel.swift
@@ -15,6 +15,7 @@ final class SendMessageUploadImageViewModel: UploadViewModel {
 
     var selection: PhotosPickerItem?
     var image: UIImage?
+    var isImagePickerPresented = false
 
     private let messagesService: MessagesService
 

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImagePickerViewModifier.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImagePickerViewModifier.swift
@@ -27,8 +27,6 @@ public extension View {
 private struct AddImagePickerViewModifier: ViewModifier {
     @State var manager = ImagePickerManager()
     func body(content: Content) -> some View {
-        @Bindable var manager = manager
-
         content
             .environment(\.imagePickerManager, manager)
             .photosPicker(isPresented: manager.isPresented, selection: manager.selectedItem, matching: .images, preferredItemEncoding: .compatible)

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImagePickerViewModifier.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImagePickerViewModifier.swift
@@ -1,0 +1,74 @@
+//
+//  ImagePickerViewModifier.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 23.06.25.
+//
+
+import PhotosUI
+import SwiftUI
+
+public extension View {
+    /// Add this further up in the view hierarchy to use an image picker somewhere below
+    func supportsImagePicker() -> some View {
+        modifier(AddImagePickerViewModifier())
+    }
+
+    /// Use this to utitlize the previously added image picker
+    func imagePicker(isPresented: Binding<Bool>,
+                     selectedImage: Binding<PhotosPickerItem?>) -> some View {
+        modifier(UseImagePickerViewModifier(presentImagePicker: isPresented,
+                                            selectedImage: selectedImage))
+    }
+}
+
+/// Adds a photoPicker in the view hierarchy for use in lower levels.
+/// Use this before you can use `.imagePicker` on a View.
+private struct AddImagePickerViewModifier: ViewModifier {
+    @State var manager = ImagePickerManager()
+    func body(content: Content) -> some View {
+        @Bindable var manager = manager
+
+        content
+            .environment(\.imagePickerManager, manager)
+            .photosPicker(isPresented: manager.isPresented, selection: manager.selectedItem, matching: .images, preferredItemEncoding: .compatible)
+    }
+}
+
+/// This uses the previously injected photoPicker.
+/// *Prerequesite*: Use `.supportsImagePicker()` on a view further up
+private struct UseImagePickerViewModifier: ViewModifier {
+    @Environment(\.imagePickerManager) var manager
+
+    @Binding var presentImagePicker: Bool
+    @Binding var selectedImage: PhotosPickerItem?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                manager.isPresented = _presentImagePicker
+                manager.selectedItem = _selectedImage
+            }
+    }
+}
+
+@Observable
+class ImagePickerManager {
+    var isPresented: Binding<Bool> = .constant(false)
+    var selectedItem: Binding<PhotosPickerItem?> = .constant(nil)
+}
+
+private enum ImagePickerManagerKey: EnvironmentKey {
+    static let defaultValue = ImagePickerManager()
+}
+
+private extension EnvironmentValues {
+    var imagePickerManager: ImagePickerManager {
+        get {
+            self[ImagePickerManagerKey.self]
+        }
+        set {
+            self[ImagePickerManagerKey.self] = newValue
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageImagePickerView.swift
@@ -5,7 +5,6 @@
 //  Created by Anian Schleyer on 09.11.24.
 //
 
-import PhotosUI
 import SwiftUI
 
 struct SendMessageImagePickerView: View {
@@ -20,11 +19,10 @@ struct SendMessageImagePickerView: View {
     }
 
     var body: some View {
-        PhotosPicker(selection: $viewModel.selection,
-                     matching: .images,
-                     preferredItemEncoding: .compatible) {
-            Label(R.string.localizable.uploadImage(), systemImage: "photo.fill")
+        Button(R.string.localizable.uploadImage(), systemImage: "photo.fill") {
+            viewModel.isImagePickerPresented = true
         }
+        .imagePicker(isPresented: $viewModel.isImagePickerPresented, selectedImage: $viewModel.selection)
         .onChange(of: viewModel.selection) {
             viewModel.onChange()
         }


### PR DESCRIPTION
When opening the image picker when composing a message, switching to the collections tab and opening a collection, the image picker would just disappear. This PR fixes this by implementing the same workaround used for the file picker. (Underlying problem: Using the picker in a UI element that can disappear after losing focus breaks things, as well as navigation problems)