### PR TITLE
`Communication`: Change image upload name to human readable string

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/FileUpload/SendMessageUploadImageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/FileUpload/SendMessageUploadImageViewModel.swift
@@ -60,7 +60,7 @@ final class SendMessageUploadImageViewModel: UploadViewModel {
         uploadState = .uploading
 
         uploadTask = Task {
-            let result = await messagesService.uploadFile(for: courseId, and: conversationId, file: imageData, filename: "\(UUID().uuidString).jpg", mimeType: "image/jpeg")
+            let result = await messagesService.uploadFile(for: courseId, and: conversationId, file: imageData, filename: "image.jpg", mimeType: "image/jpeg")
             if Task.isCancelled {
                 return
             }


### PR DESCRIPTION
As we don't have access to the original image name from the photos picker, we used a UUID as the image's name. However, we will show this file name to users in the future. Thus, we change the file name to "image.jpg".