### PR TITLE
`FAQ`: Fix propose FAQ button overlapping content

### DIFF
--- a/ArtemisKit/Sources/Faq/Views/FaqListView.swift
+++ b/ArtemisKit/Sources/Faq/Views/FaqListView.swift
@@ -60,7 +60,7 @@ public struct FaqListView: View {
                 .refreshable {
                     await viewModel.loadFaq()
                 }
-                .contentMargins(.bottom, 50, for: .scrollContent)
+                .contentMargins(.bottom, 80, for: .scrollContent)
                 .overlay(alignment: .bottomTrailing) {
                     ProposeFaqButton(viewModel: viewModel)
                         .padding()


### PR DESCRIPTION
The Propose FAQ button could potentially overlap other content at the bottom of the FAQ list, this PR fixes that