### PR TITLE
`Communication`: Add preview for image thumbnails

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
@@ -64,5 +64,6 @@ private struct ImageAttachmentThumbnail: View {
                     }
                 }
         }
+        .frame(minWidth: 250, minHeight: 250)
     }
 }


### PR DESCRIPTION
This PR adds a tap action to the image thumbnails for uploaded images in a message. It allows the user to preview the image in a sheet/popover.

<img width="400" alt="Image preview on iPad" src="https://github.com/user-attachments/assets/518112bf-aa14-4c79-ae87-394081d576e2">
<video src="https://github.com/user-attachments/assets/4822be9f-cdee-4b3c-8566-32b18a6ae329">

