### PR TITLE
`Communication`: Add button to remove image attachment

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "orderedList" = "Ordered List";
 "listFormatting" = "List Formatting";
 "addMessage" = "Add a message";
+"removeImage" = "Remove";
 
 // MARK: SendMessageMentionContentView
 "members" = "Members";

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel+MarkdownFormatting.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel+MarkdownFormatting.swift
@@ -128,6 +128,12 @@ extension SendMessageViewModel {
         }
     }
 
+    func removeImage(name: String, path: String) {
+        uploadedImages.removeValue(forKey: path)
+        text = text.replacing("![\(name)](\(path))", with: "")
+        moveCursorToEnd()
+    }
+
     var mentionedImages: [(name: String, path: String, image: UIImage)] {
         let pattern = #"\!\[([^\]]+)\]\(([^\)]+)\)"#
         var results = [(String, String, UIImage)]()

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
@@ -15,8 +15,8 @@ struct ImageAttachmentsPreview: View {
         if !mentionedImages.isEmpty {
             ScrollView(.horizontal) {
                 HStack {
-                    ForEach(viewModel.mentionedImages, id: \.image.hashValue) { name, _, image in
-                        ImageAttachmentThumbnail(image: image, name: name)
+                    ForEach(viewModel.mentionedImages, id: \.image.hashValue) { name, path, image in
+                        ImageAttachmentThumbnail(viewModel: viewModel, image: image, name: name, path: path)
                     }
                 }
             }
@@ -27,12 +27,16 @@ struct ImageAttachmentsPreview: View {
 
 private struct ImageAttachmentThumbnail: View {
     @State private var showPreview = false
+    let viewModel: SendMessageViewModel
     let image: UIImage
     let name: String
+    let path: String
 
     var body: some View {
-        Button {
-            showPreview = true
+        Menu {
+            Button(R.string.localizable.removeImage(), systemImage: "minus.circle", role: .destructive) {
+                viewModel.removeImage(name: name, path: path)
+            }
         } label: {
             VStack(spacing: .s) {
                 Image(uiImage: image)
@@ -46,6 +50,8 @@ private struct ImageAttachmentThumbnail: View {
                     .lineLimit(1)
                     .frame(maxWidth: .largeImage)
             }
+        } primaryAction: {
+            showPreview = true
         }
         .buttonStyle(.plain)
         .popover(isPresented: $showPreview, attachmentAnchor: .point(.top), arrowEdge: .bottom) {
@@ -59,8 +65,16 @@ private struct ImageAttachmentThumbnail: View {
                 .resizable()
                 .scaledToFit()
                 .toolbar {
-                    Button(R.string.localizable.done()) {
-                        showPreview = false
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(R.string.localizable.done()) {
+                            showPreview = false
+                        }
+                    }
+                    ToolbarItem(placement: .bottomBar) {
+                        Button(R.string.localizable.removeImage(), systemImage: "minus.circle", role: .destructive) {
+                            showPreview = false
+                            viewModel.removeImage(name: name, path: path)
+                        }
                     }
                 }
         }


### PR DESCRIPTION
Users can remove images they attached to a message by long pressing on the thumbnail or using the toolbar button in the full screen preview.