### PR TITLE
`Communication`: Redesign message toolbar

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageFilePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageFilePickerView.swift
@@ -3,11 +3,12 @@ import UniformTypeIdentifiers
 
 struct SendMessageFilePickerView: View {
     var sendViewModel: SendMessageViewModel
-    @Bindable private var viewModel: SendMessageUploadFileViewModel
+    @State private var viewModel: SendMessageUploadFileViewModel
 
-    init(sendViewModel: SendMessageViewModel, viewModel: SendMessageUploadFileViewModel) {
-        self.viewModel = viewModel
-        self.sendViewModel = sendViewModel
+    init(sendMessageViewModel: SendMessageViewModel) {
+        self._viewModel = State(initialValue: .init(courseId: sendMessageViewModel.course.id,
+                                                    conversationId: sendMessageViewModel.conversation.id))
+        self.sendViewModel = sendMessageViewModel
     }
 
     var body: some View {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageFilePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageFilePickerView.swift
@@ -3,12 +3,11 @@ import UniformTypeIdentifiers
 
 struct SendMessageFilePickerView: View {
     var sendViewModel: SendMessageViewModel
-    @State private var viewModel: SendMessageUploadFileViewModel
+    @Bindable private var viewModel: SendMessageUploadFileViewModel
 
-    init(sendMessageViewModel: SendMessageViewModel) {
-        self._viewModel = State(initialValue: .init(courseId: sendMessageViewModel.course.id,
-                                                    conversationId: sendMessageViewModel.conversation.id))
-        self.sendViewModel = sendMessageViewModel
+    init(sendViewModel: SendMessageViewModel, viewModel: SendMessageUploadFileViewModel) {
+        self.viewModel = viewModel
+        self.sendViewModel = sendViewModel
     }
 
     var body: some View {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageImagePickerView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/SendMessageImagePickerView.swift
@@ -10,12 +10,11 @@ import SwiftUI
 struct SendMessageImagePickerView: View {
 
     var sendViewModel: SendMessageViewModel
-    @State private var viewModel: SendMessageUploadImageViewModel
+    @Bindable private var viewModel: SendMessageUploadImageViewModel
 
-    init(sendMessageViewModel: SendMessageViewModel) {
-        self._viewModel = State(initialValue: .init(courseId: sendMessageViewModel.course.id,
-                                                    conversationId: sendMessageViewModel.conversation.id))
-        self.sendViewModel = sendMessageViewModel
+    init(sendViewModel: SendMessageViewModel, viewModel: SendMessageUploadImageViewModel) {
+        self.viewModel = viewModel
+        self.sendViewModel = sendViewModel
     }
 
     var body: some View {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -11,14 +11,17 @@ struct SendMessageKeyboardToolbar<SendButton: View>: View {
     let sendButton: SendButton
     let viewModel: SendMessageViewModel
 
+    let uploadFileViewModel: SendMessageUploadFileViewModel
+    let uploadImageViewModel: SendMessageUploadImageViewModel
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(alignment: .firstTextBaseline, spacing: .l) {
                 mentionContentMenu
 
-                Menu {
-                    SendMessageImagePickerView(sendMessageViewModel: viewModel)
-                    SendMessageFilePickerView(sendMessageViewModel: viewModel)
+                InlineExpandableMenu {
+                    SendMessageImagePickerView(sendViewModel: viewModel, viewModel: uploadImageViewModel)
+                    SendMessageFilePickerView(sendViewModel: viewModel, viewModel: uploadFileViewModel)
                 } label: {
                     Label("Attachments", systemImage: "paperclip") // TODO: Localize
                 }
@@ -180,6 +183,8 @@ struct InlineExpandableMenu<Content: View, Label: View>: View {
                         .matchedGeometryEffect(id: offset, in: namespace)
                     }
                 }
+                // Spacer (0) + spacing (.l) ensures separability to nearby menus
+                Spacer().frame(width: 0)
             }
         } else {
             ZStack(alignment: .leading) {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -1,0 +1,203 @@
+//
+//  SendMessageKeyboardToolbar.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 31.08.25.
+//
+
+import SwiftUI
+
+struct SendMessageKeyboardToolbar<SendButton: View>: View {
+    let sendButton: SendButton
+    let viewModel: SendMessageViewModel
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .firstTextBaseline, spacing: .l) {
+                mentionContentMenu
+
+                Menu {
+                    SendMessageImagePickerView(sendMessageViewModel: viewModel)
+                    SendMessageFilePickerView(sendMessageViewModel: viewModel)
+                } label: {
+                    Label("Attachments", systemImage: "paperclip") // TODO: Localize
+                }
+
+                InlineExpandableMenu {
+                    textFormatMenu
+                    listFormatMenu
+                    codeFormatMenu
+
+                    Button {
+                        viewModel.didTapLinkButton()
+                    } label: {
+                        Label(R.string.localizable.link(), systemImage: "link")
+                    }
+                    Button {
+                        viewModel.didTapBlockquoteButton()
+                    } label: {
+                        Label(R.string.localizable.quote(), systemImage: "quote.opening")
+                    }
+                } label: {
+                    Label("Text formatting", systemImage: "textformat") // TODO: Localize
+                }
+            }
+            .labelStyle(.iconOnly)
+            .font(.title3)
+            .padding(.trailing)
+        }
+        .contentMargins(.horizontal, .l, for: .scrollContent)
+        .contentMargins(.vertical, .m, for: .scrollContent)
+        .mask {
+            LinearGradient(stops: [
+                .init(color: .black.opacity(1), location: 0.9),
+                .init(color: .black.opacity(0), location: 1)
+            ], startPoint: .leading, endPoint: .trailing)
+        }
+        .safeAreaInset(edge: .trailing) {
+            sendButton
+        }
+    }
+
+    var mentionContentMenu: some View {
+        Menu {
+            Button {
+                viewModel.didTapAtButton()
+            } label: {
+                Label(R.string.localizable.members(), systemImage: "at")
+            }
+            Button {
+                viewModel.didTapNumberButton()
+            } label: {
+                Label(R.string.localizable.channels(), systemImage: "number")
+            }
+            Button {
+                viewModel.wantsToAddMessageMentionContentType = .exercise
+            } label: {
+                Label(R.string.localizable.exercises(), systemImage: "list.bullet.clipboard")
+            }
+            Button {
+                viewModel.wantsToAddMessageMentionContentType = .lecture
+            } label: {
+                Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
+            }
+            if viewModel.course.faqEnabled == true {
+                Button {
+                    viewModel.wantsToAddMessageMentionContentType = .faq
+                } label: {
+                    Label(R.string.localizable.faqs(), systemImage: "questionmark.circle")
+                }
+            }
+        } label: {
+            Label(R.string.localizable.mention(), systemImage: "plus.circle.fill")
+        }
+    }
+
+    var textFormatMenu: some View {
+        Menu {
+            Button {
+                viewModel.didTapBoldButton()
+            } label: {
+                Label(R.string.localizable.bold(), systemImage: "bold")
+            }
+            Button {
+                viewModel.didTapItalicButton()
+            } label: {
+                Label(R.string.localizable.italic(), systemImage: "italic")
+            }
+            Button {
+                viewModel.didTapUnderlineButton()
+            } label: {
+                Label(R.string.localizable.underline(), systemImage: "underline")
+            }
+            Button {
+                viewModel.didTapStrikethroughButton()
+            } label: {
+                Label(R.string.localizable.strikethrough(), systemImage: "strikethrough")
+            }
+        } label: {
+            Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
+        }
+    }
+
+    var listFormatMenu: some View {
+        Menu {
+            Button {
+                viewModel.insertListPrefix(unordered: true)
+            } label: {
+                Label(R.string.localizable.unorderedList(), systemImage: "list.bullet")
+            }
+            Button {
+                viewModel.insertListPrefix(unordered: false)
+            } label: {
+                Label(R.string.localizable.orderedList(), systemImage: "list.number")
+            }
+        } label: {
+            Label(R.string.localizable.listFormatting(), systemImage: "list.triangle")
+        }
+    }
+
+    var codeFormatMenu: some View {
+        Menu {
+            Button {
+                viewModel.didTapCodeButton()
+            } label: {
+                Label(R.string.localizable.inlineCode(), systemImage: "curlybraces")
+            }
+            Button {
+                viewModel.didTapCodeBlockButton()
+            } label: {
+                Label(R.string.localizable.codeBlock(), systemImage: "curlybraces.square.fill")
+            }
+        } label: {
+            Label(R.string.localizable.code(), systemImage: "curlybraces")
+        }
+    }
+}
+
+struct InlineExpandableMenu<Content: View, Label: View>: View {
+    @State private var isExpanded = false
+    @Namespace private var namespace
+
+    @ViewBuilder var content: () -> Content
+    @ViewBuilder var label: () -> Label
+
+    var body: some View {
+        if isExpanded {
+            HStack(alignment: .firstTextBaseline, spacing: .l) {
+                Button("Close", systemImage: "xmark.circle") {
+                    withAnimation {
+                        isExpanded = false
+                    }
+                }
+                .labelsHidden()
+                .opacity(0.7)
+                .matchedGeometryEffect(id: "btn", in: namespace)
+                .padding(.leading, .l)
+                Group(subviews: content()) { subviews in
+                    ForEach(Array(subviews.enumerated()), id: \.0) { offset, subview in
+                        subview
+                        .matchedGeometryEffect(id: offset, in: namespace)
+                    }
+                }
+            }
+        } else {
+            ZStack(alignment: .leading) {
+                Group(subviews: content()) { subviews in
+                    ForEach(Array(subviews.enumerated()), id: \.0) { offset, subview in
+                        subview.disabled(true).opacity(0)
+                            .matchedGeometryEffect(id: offset, in: namespace)
+                    }
+                }
+                Button {
+                    withAnimation {
+                        isExpanded = true
+                    }
+                } label: {
+                    label()
+                }
+                .matchedGeometryEffect(id: "btn", in: namespace)
+            }
+        }
+    }
+}

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -16,12 +16,14 @@ struct SendMessageView: View {
     /// This has to be in here, otherwise it gets deinitialized while file picker is open,
     /// due to the textfield losing focus and the toolbar disappearing
     @State private var uploadFileViewModel: SendMessageUploadFileViewModel
+    @State private var uploadImageViewModel: SendMessageUploadImageViewModel
 
     @FocusState private var isFocused: Bool
 
     init(viewModel: SendMessageViewModel) {
         self._viewModel = State(initialValue: viewModel)
         self._uploadFileViewModel = State(initialValue: .init(courseId: viewModel.course.id, conversationId: viewModel.conversation.id))
+        self._uploadImageViewModel = State(initialValue: .init(courseId: viewModel.course.id, conversationId: viewModel.conversation.id))
     }
 
     var body: some View {
@@ -53,7 +55,10 @@ struct SendMessageView: View {
                 .padding(.bottom, .m)
             ImageAttachmentsPreview(viewModel: viewModel)
             if isFocused || viewModel.keyboardVisible {
-                SendMessageKeyboardToolbar(sendButton: sendButton, viewModel: viewModel)
+                SendMessageKeyboardToolbar(sendButton: sendButton,
+                                           viewModel: viewModel,
+                                           uploadFileViewModel: uploadFileViewModel,
+                                           uploadImageViewModel: uploadImageViewModel)
                     .background(.bar)
                     .padding(.top, .s)
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -53,9 +53,7 @@ struct SendMessageView: View {
                 .padding(.bottom, .m)
             ImageAttachmentsPreview(viewModel: viewModel)
             if isFocused || viewModel.keyboardVisible {
-                keyboardToolbarContent
-                    .padding(.horizontal, .l)
-                    .padding(.vertical, .m)
+                SendMessageKeyboardToolbar(sendButton: sendButton, viewModel: viewModel)
                     .background(.bar)
                     .padding(.top, .s)
             }
@@ -146,120 +144,12 @@ private extension SendMessageView {
         }
     }
 
-    var keyboardToolbarContent: some View {
-        HStack {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .firstTextBaseline, spacing: .l) {
-                    Menu {
-                        Button {
-                            viewModel.didTapAtButton()
-                        } label: {
-                            Label(R.string.localizable.members(), systemImage: "at")
-                        }
-                        Button {
-                            viewModel.didTapNumberButton()
-                        } label: {
-                            Label(R.string.localizable.channels(), systemImage: "number")
-                        }
-                        Button {
-                            viewModel.wantsToAddMessageMentionContentType = .exercise
-                        } label: {
-                            Label(R.string.localizable.exercises(), systemImage: "list.bullet.clipboard")
-                        }
-                        Button {
-                            viewModel.wantsToAddMessageMentionContentType = .lecture
-                        } label: {
-                            Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
-                        }
-                        if viewModel.course.faqEnabled == true {
-                            Button {
-                                viewModel.wantsToAddMessageMentionContentType = .faq
-                            } label: {
-                                Label(R.string.localizable.faqs(), systemImage: "questionmark.circle")
-                            }
-                        }
-                    } label: {
-                        Label(R.string.localizable.mention(), systemImage: "plus.circle.fill")
-                    }
-                    Menu {
-                        Button {
-                            viewModel.didTapBoldButton()
-                        } label: {
-                            Label(R.string.localizable.bold(), systemImage: "bold")
-                        }
-                        Button {
-                            viewModel.didTapItalicButton()
-                        } label: {
-                            Label(R.string.localizable.italic(), systemImage: "italic")
-                        }
-                        Button {
-                            viewModel.didTapUnderlineButton()
-                        } label: {
-                            Label(R.string.localizable.underline(), systemImage: "underline")
-                        }
-                        Button {
-                            viewModel.didTapStrikethroughButton()
-                        } label: {
-                            Label(R.string.localizable.strikethrough(), systemImage: "strikethrough")
-                        }
-                    } label: {
-                        Label(R.string.localizable.style(), systemImage: "bold.italic.underline")
-                    }
-                    Menu {
-                        Button {
-                            viewModel.insertListPrefix(unordered: true)
-                        } label: {
-                            Label(R.string.localizable.unorderedList(), systemImage: "list.bullet")
-                        }
-                        Button {
-                            viewModel.insertListPrefix(unordered: false)
-                        } label: {
-                            Label(R.string.localizable.orderedList(), systemImage: "list.number")
-                        }
-                    } label: {
-                        Label(R.string.localizable.listFormatting(), systemImage: "list.triangle")
-                    }
-                    Button {
-                        viewModel.didTapBlockquoteButton()
-                    } label: {
-                        Label(R.string.localizable.quote(), systemImage: "quote.opening")
-                    }
-                    Menu {
-                        Button {
-                            viewModel.didTapCodeButton()
-                        } label: {
-                            Label(R.string.localizable.inlineCode(), systemImage: "curlybraces")
-                        }
-                        Button {
-                            viewModel.didTapCodeBlockButton()
-                        } label: {
-                            Label(R.string.localizable.codeBlock(), systemImage: "curlybraces.square.fill")
-                        }
-                    } label: {
-                        Label(R.string.localizable.code(), systemImage: "curlybraces")
-                    }
-                    Button {
-                        viewModel.didTapLinkButton()
-                    } label: {
-                        Label(R.string.localizable.link(), systemImage: "link")
-                    }
-                    SendMessageImagePickerView(sendMessageViewModel: viewModel)
-                    SendMessageFilePickerView(sendViewModel: viewModel, viewModel: uploadFileViewModel)
-                }
-                .labelStyle(.iconOnly)
-                .font(.title3)
-            }
-            Spacer()
-            sendButton
-        }
-    }
-
     var sendButton: some View {
         Button(action: viewModel.didTapSendButton) {
             Image(systemName: "paperplane.fill")
                 .imageScale(.large)
         }
-        .padding(.leading, .l)
+        .padding(isFocused ? .trailing : .leading, .l)
         .disabled(!viewModel.canSend)
         .loadingIndicator(isLoading: $viewModel.isLoading)
     }


### PR DESCRIPTION
This PR redesigns the message toolbar. The current version has too many icons which makes it look crowded. We improve and simplify the design by combining text formatting options into an expandable group, thus separating it from mentioning content and attaching files.

Expanded groups create a small space to adjacent menu items to ensure they are visually separated from them. Potential future improvement: Auto-open the text format menu when highlighting text like Slack.

<img width="250" alt="Default menu state" src="https://github.com/user-attachments/assets/309363ff-b980-4a0b-b00c-55f69e15f986" />
<img width="250" alt="Menu with expanded text formatting options" src="https://github.com/user-attachments/assets/9bb9c992-7e3b-49ae-9c30-68cfa081f217" />
