### PR TITLE
`Communication`: Add message markdown preview

### DIFF
--- a/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Messages/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "addMessage" = "Add a message";
 "removeImage" = "Remove";
 "attachments" = "Attachments";
+"preview" = "Preview";
 
 // MARK: SendMessageMentionContentView
 "members" = "Members";

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -186,6 +186,7 @@ extension SendMessageViewModel {
 
     func didTapSendButton() {
         isLoading = true
+        previewVisible = false
         Task { @MainActor in
             var result: NetworkResponse?
             switch configuration {

--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel.swift
@@ -87,12 +87,17 @@ final class SendMessageViewModel {
         }
     }
 
+    var canPreview: Bool {
+        !text.isEmpty
+    }
+
     var isMemberPickerSuppressed = false
     var isChannelPickerSuppressed = false
 
     var wantsToAddMessageMentionContentType: MessageMentionContentType?
     var presentKeyboardOnAppear: Bool
     var keyboardVisible = false
+    var previewVisible = false
 
     // MARK: Life cycle
 

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/FileUpload/ImageAttachmentsPreview.swift
@@ -12,7 +12,7 @@ struct ImageAttachmentsPreview: View {
 
     var body: some View {
         let mentionedImages = viewModel.mentionedImages
-        if !mentionedImages.isEmpty {
+        if !mentionedImages.isEmpty && !viewModel.previewVisible {
             ScrollView(.horizontal) {
                 HStack {
                     ForEach(viewModel.mentionedImages, id: \.image.hashValue) { name, path, image in

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 struct SendMessageKeyboardToolbar<SendButton: View>: View {
     let sendButton: SendButton
-    let viewModel: SendMessageViewModel
+    @Bindable var viewModel: SendMessageViewModel
 
     let uploadFileViewModel: SendMessageUploadFileViewModel
     let uploadImageViewModel: SendMessageUploadImageViewModel
+
+    @Namespace private var namespace
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -58,8 +60,28 @@ struct SendMessageKeyboardToolbar<SendButton: View>: View {
             ], startPoint: .leading, endPoint: .trailing)
         }
         .safeAreaInset(edge: .trailing) {
-            sendButton
+            HStack(spacing: .m * 1.5) {
+                previewButton
+                sendButton
+            }
         }
+    }
+
+    @ViewBuilder var previewButton: some View {
+        Group {
+            if viewModel.canPreview && !viewModel.previewVisible {
+                Button("Preview", systemImage: "eye") {
+                    viewModel.previewVisible = true
+                }
+                .labelStyle(.iconOnly)
+                .matchedGeometryEffect(id: "previewBtn", in: namespace, anchor: .leading)
+            } else if viewModel.previewVisible {
+                Toggle("Preview", systemImage: "eye", isOn: $viewModel.previewVisible)
+                    .toggleStyle(.button)
+                    .matchedGeometryEffect(id: "previewBtn", in: namespace, anchor: .leading)
+            }
+        }
+        .animation(.snappy, value: viewModel.previewVisible)
     }
 
     var mentionContentMenu: some View {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -70,13 +70,13 @@ struct SendMessageKeyboardToolbar<SendButton: View>: View {
     @ViewBuilder var previewButton: some View {
         Group {
             if viewModel.canPreview && !viewModel.previewVisible {
-                Button("Preview", systemImage: "eye") {
+                Button(R.string.localizable.preview(), systemImage: "eye") {
                     viewModel.previewVisible = true
                 }
                 .labelStyle(.iconOnly)
                 .matchedGeometryEffect(id: "previewBtn", in: namespace, anchor: .leading)
             } else if viewModel.previewVisible {
-                Toggle("Preview", systemImage: "eye", isOn: $viewModel.previewVisible)
+                Toggle(R.string.localizable.preview(), systemImage: "eye", isOn: $viewModel.previewVisible)
                     .toggleStyle(.button)
                     .matchedGeometryEffect(id: "previewBtn", in: namespace, anchor: .leading)
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -18,7 +18,6 @@ struct SendMessageView: View {
     /// due to the textfield losing focus and the toolbar disappearing
     @State private var uploadFileViewModel: SendMessageUploadFileViewModel
     @State private var uploadImageViewModel: SendMessageUploadImageViewModel
-    @State private var showPreview = false
 
     @FocusState private var isFocused: Bool
 

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -5,6 +5,7 @@
 //  Created by Sven Andabaka on 08.04.23.
 //
 
+import ArtemisMarkdown
 import Common
 import DesignLibrary
 import SharedModels
@@ -17,6 +18,7 @@ struct SendMessageView: View {
     /// due to the textfield losing focus and the toolbar disappearing
     @State private var uploadFileViewModel: SendMessageUploadFileViewModel
     @State private var uploadImageViewModel: SendMessageUploadImageViewModel
+    @State private var showPreview = false
 
     @FocusState private var isFocused: Bool
 
@@ -51,6 +53,9 @@ struct SendMessageView: View {
             }
             textField
                 .fixedSize(horizontal: false, vertical: true)
+                .overlay {
+                    preview
+                }
                 .padding(isFocused ? .horizontal : [.horizontal, .top], .l)
                 .padding(.bottom, .m)
             ImageAttachmentsPreview(viewModel: viewModel)
@@ -105,6 +110,20 @@ struct SendMessageView: View {
 
 @MainActor
 private extension SendMessageView {
+    @ViewBuilder var preview: some View {
+        if viewModel.previewVisible {
+            ScrollView {
+                ArtemisMarkdownView(string: viewModel.text.surroundingMarkdownImagesWithNewlines())
+                    .allowsHitTesting(false)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            }
+            .contentMargins(.s, for: .scrollContent)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.background)
+            .clipShape(.rect(cornerRadius: .s))
+        }
+    }
+
     @ViewBuilder var mentions: some View {
         if let presentation = viewModel.conditionalPresentation {
             VStack(spacing: 0) {


### PR DESCRIPTION
This PR adds a preview button to the message toolbar. While composing a message, this button can be useful for verifying the message for syntactical markdown correctness and whether the message looks as intended.

<img width="250" alt="Message text field" src="https://github.com/user-attachments/assets/72ec1af0-3c27-4f50-929d-6f24aaa1b9b1" />
<img width="250" alt="Preview opened" src="https://github.com/user-attachments/assets/05919741-df55-4b63-bfb9-c2a0401e2b16" />
