### PR TITLE
`Communication`: Simplify request for starting DM from Profile

### DIFF
--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesService.swift
@@ -147,6 +147,7 @@ protocol MessagesService {
      * Perform a post request to create a specific oneToOne chat in a specific course to the server.
      */
     func createOneToOneChat(for courseId: Int, usernames: [String]) async -> DataState<OneToOneChat>
+    func createOneToOneChat(for courseId: Int, userId: Int) async -> DataState<OneToOneChat>
 
     /**
      * Perform a get request to find 20 users with paging of a specific conversation in a specific course to the server.

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -786,6 +786,32 @@ struct MessagesServiceImpl: MessagesService {
         }
     }
 
+    struct CreateOneToOneChatByIdRequest: APIRequest {
+        typealias Response = OneToOneChat
+
+        let courseId: Int
+        let userId: Int
+
+        var method: HTTPMethod {
+            .post
+        }
+
+        var resourceName: String {
+            "api/communication/courses/\(courseId)/one-to-one-chats/\(userId)"
+        }
+    }
+
+    func createOneToOneChat(for courseId: Int, userId: Int) async -> DataState<OneToOneChat> {
+        let result = await client.sendRequest(CreateOneToOneChatByIdRequest(courseId: courseId, userId: userId))
+
+        switch result {
+        case let .success((oneToOneChat, _)):
+            return .done(response: oneToOneChat)
+        case let .failure(error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
     struct GetMembersOfConversationRequest: APIRequest {
         typealias Response = [ConversationUser]
 

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceStub.swift
@@ -197,6 +197,10 @@ extension MessagesServiceStub: MessagesService {
         .loading
     }
 
+    func createOneToOneChat(for courseId: Int, userId: Int) async -> DataState<OneToOneChat> {
+        .loading
+    }
+
     func getMembersOfConversation(for courseId: Int, conversationId: Int64, page: Int) async -> DataState<[ConversationUser]> {
         .loading
     }

--- a/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
+++ b/ArtemisKit/Sources/Messages/Views/MessageDetailView/ProfilePictureView.swift
@@ -156,9 +156,6 @@ struct ProfileInfoSheet: View {
             .scrollContentBackground(.hidden)
             .background(backgroundImage)
         }
-        .task {
-            await viewModel.loadUserLogin()
-        }
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(isPresented: Binding(get: {
             viewModel.error != nil

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -60,7 +60,7 @@ struct SendMessageKeyboardToolbar<SendButton: View>: View {
             ], startPoint: .leading, endPoint: .trailing)
         }
         .safeAreaInset(edge: .trailing) {
-            HStack(spacing: .m * 1.5) {
+            HStack(spacing: .l) {
                 previewButton
                 sendButton
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -95,6 +95,7 @@ struct SendMessageView: View {
                         // down
                         isFocused = false
                         viewModel.keyboardVisible = false
+                        viewModel.previewVisible = false
                         let impactMed = UIImpactFeedbackGenerator(style: .medium)
                         impactMed.impactOccurred()
                     }


### PR DESCRIPTION
For starting a DM from the profile picture screen, we needed multiple API calls. When this was implemented, DMs could only be started by username. As this screen often did not have the username, a request had to be made to fetch it. We now have an API endpoint to create DMs from user ids, which we always have. Thus, we use this API here to save us from making an additional API call.