### PR TITLE
`Dashboard`: Fix crash with 0 achievable points

### DIFF
--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -162,7 +162,7 @@ private extension CourseGridCell {
 
     @ViewBuilder var statisticsChart: some View {
         if let totalScore = courseForDashboard.totalScores,
-           totalScore.studentScores.absoluteScore > 0 {
+           totalScore.studentScores.absoluteScore > 0 && totalScore.reachablePoints > 0 {
             ProgressBar(
                 value: totalScore.studentScores.absoluteScore,
                 total: totalScore.reachablePoints


### PR DESCRIPTION
There was a crash in a very rare edge case, if a student has achieved points in a course despite the number of reachable points being considered zero. This caused a division by zero.