### PR TITLE
`General`: Disable multi window support

### DIFF
--- a/Artemis/Supporting/Info.plist
+++ b/Artemis/Supporting/Info.plist
@@ -42,7 +42,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>


### PR DESCRIPTION
Artemis currently allowed uses on iPad to open multiple app windows. This was not intentional and does not work correctly, as one NavigationController is shared across all windows – which means all windows show the same thing most of the time, making it pointless.