### PR TITLE
`Communication`: Prevent horizontal scrolling in threads

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -21,7 +21,7 @@ public struct ExerciseDetailView: View {
         DataStateView(data: $viewModel.exercise) {
             await viewModel.loadExercise()
         } content: { exercise in
-            ScrollView {
+            ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: .l) {
                     hint
                     ExerciseOverviewChipsRow(exercise: exercise, score: viewModel.score)


### PR DESCRIPTION
Sometimes, the scroll area in message threads (especially on iPad) allowed users to scroll horizontally, even though there was no scrollable content there. As there is no benefit in scrolling horizontally here, and it only made scrolling look less good, we don't need it and explicitly make this view only vertically scrollable.