### PR TITLE
`Communication`: Fix archive icon not showing up in saved messages

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessagesView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessagesView.swift
@@ -25,6 +25,7 @@ struct SavedMessagesView: View {
             if posts.isEmpty {
                 Section {
                     ContentUnavailableView(R.string.localizable.noMessages(), systemImage: viewModel.selectedType.iconName)
+                        .frame(minHeight: 150)
                 }
             }
             ForEach(posts.sorted()) { post in


### PR DESCRIPTION
iOS 26 broke some icons in ContentUnavailableView. The default height of this view is too small for some icon. Because of this, the archive box icon was not displayed when there were no saved messages.

<img width="300" src="https://github.com/user-attachments/assets/d7f793c5-e54b-4090-b6c3-ae7e0b0c4502" />
