### PR TITLE
`CourseView`: Allow swiping to go back to dashboard

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "8f184e4e7981decbe79248e4e6e7e4f45d9dd273",
-        "version" : "19.0.0"
+        "revision" : "1c9aeb587dfa53685c003e77670e5afe1c705998",
+        "version" : "19.1.0"
       }
     },
     {

--- a/ArtemisKit/Sources/ArtemisKit/RootView.swift
+++ b/ArtemisKit/Sources/ArtemisKit/RootView.swift
@@ -81,6 +81,7 @@ extension RootView {
             .fullScreenCover(item: $navigationController.selectedCourse) { coursePath in
                 CoursePathView(path: coursePath)
                     .navigationTransition(.zoom(sourceID: coursePath.id, in: namespace))
+                    .disableSwipeDownToDismiss()
             }
             .zIndex(0)
 
@@ -92,8 +93,6 @@ extension RootView {
             .opacity(navigationController.outerPath.isEmpty ? 0 : 1)
             .zIndex(2)
         }
-        // TODO: Maybe for outer?
-//        .animation(.easeOut(duration: 0.3), value: navigationController.selectedCourse)
     }
 }
 

--- a/ArtemisKit/Sources/ArtemisKit/RootView.swift
+++ b/ArtemisKit/Sources/ArtemisKit/RootView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 public struct RootView: View {
 
+    @Namespace private var namespace
     @Environment(\.scenePhase) var scenePhase
     @StateObject private var viewModel = RootViewModel()
 
@@ -75,16 +76,13 @@ extension RootView {
     @ViewBuilder var contentView: some View {
         ZStack {
             NavigationStack {
-                DashboardView()
+                DashboardView(namespace: namespace)
+            }
+            .fullScreenCover(item: $navigationController.selectedCourse) { coursePath in
+                CoursePathView(path: coursePath)
+                    .navigationTransition(.zoom(sourceID: coursePath.id, in: namespace))
             }
             .zIndex(0)
-
-            if let selectedCourse = navigationController.selectedCourse {
-                CoursePathView(path: selectedCourse)
-                    .transition(.move(edge: .trailing))
-                    .id(selectedCourse.id)
-                    .zIndex(1)
-            }
 
             NavigationStack(path: $navigationController.outerPath) {
                 Color.clear
@@ -94,7 +92,8 @@ extension RootView {
             .opacity(navigationController.outerPath.isEmpty ? 0 : 1)
             .zIndex(2)
         }
-        .animation(.easeOut(duration: 0.3), value: navigationController.selectedCourse)
+        // TODO: Maybe for outer?
+//        .animation(.easeOut(duration: 0.3), value: navigationController.selectedCourse)
     }
 }
 

--- a/ArtemisKit/Sources/ArtemisKit/Util/DisableSwipeDownToDismiss.swift
+++ b/ArtemisKit/Sources/ArtemisKit/Util/DisableSwipeDownToDismiss.swift
@@ -1,0 +1,52 @@
+//
+//  DisableSwipeDownToDismiss.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 19.02.26.
+//
+
+// Adapted from - https://stackoverflow.com/a/79772679
+
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Disables the swipe down gesture for zoom navigation transitions.
+    /// Swiping from the leading edge remains enabled.
+    func disableSwipeDownToDismiss() -> some View {
+        modifier(DisableSwipeDownToDismissModifier())
+    }
+}
+
+private struct DisableSwipeDownToDismissModifier: ViewModifier {
+    func body(content: Self.Content) -> some View {
+        content
+            .background {
+                ZoomTransitionAdapter()
+                    .frame(width: 0, height: 0)
+            }
+    }
+}
+
+private struct ZoomTransitionAdapter: UIViewControllerRepresentable {
+    func makeUIViewController(context: Self.Context) -> ZoomTransitionAdapterController {
+        ZoomTransitionAdapterController()
+    }
+
+    func updateUIViewController(_ uiViewController: ZoomTransitionAdapterController,
+                                context: Self.Context) {}
+}
+
+private final class ZoomTransitionAdapterController: UIViewController {
+    private var zoomTransitionOptions: UIViewController.Transition.ZoomOptions? {
+        parent?.preferredTransition?.value(forKey: "options") as? UIViewController.Transition.ZoomOptions
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        zoomTransitionOptions?.interactiveDismissShouldBegin = { context in
+            // Only allow swipes from the leading edge
+            context.location.x < 20
+        }
+    }
+}

--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct CourseGrid: View {
     private static let layout = [GridItem(.adaptive(minimum: 380, maximum: .infinity), spacing: .l, alignment: .center)]
+    let namespace: Namespace.ID
 
     @Bindable var viewModel: DashboardViewModel
     @State private var isCourseRegistrationPresented = false
@@ -29,6 +30,7 @@ struct CourseGrid: View {
                     LazyVGrid(columns: Self.layout, spacing: .l) {
                         ForEach(viewModel.recentCourses) { course in
                             CourseGridCell(courseForDashboard: course, viewModel: viewModel)
+                                .matchedTransitionSource(id: course.id, in: namespace)
                         }
                     }
 
@@ -75,5 +77,5 @@ struct CourseGrid: View {
 }
 
 #Preview {
-    CourseGrid(viewModel: DashboardViewModel(courseService: CourseServiceStub()))
+    CourseGrid(namespace: Namespace().wrappedValue, viewModel: DashboardViewModel(courseService: CourseServiceStub()))
 }

--- a/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGridCell.swift
@@ -12,7 +12,6 @@ import SwiftUI
 
 struct CourseGridCell: View {
     @EnvironmentObject private var navigationController: NavigationController
-    @Environment(\.dismissSearch) private var dismissSearch
 
     let courseForDashboard: CourseForDashboardDTO
     let viewModel: DashboardViewModel
@@ -38,7 +37,6 @@ struct CourseGridCell: View {
                 // Update recents with a delay to not update grid during navigation transition
                 viewModel.addToRecents(courseId: courseForDashboard.id)
             }
-            dismissSearch()
         } label: {
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -150,7 +148,6 @@ private extension CourseGridCell {
                         .lineLimit(1)
                         .onTapGesture {
                             navigationController.goToExercise(courseId: courseForDashboard.id, exerciseId: nextExercise.id)
-                            dismissSearch()
                         }
                 } else {
                     Text(R.string.localizable.dashboardNoExercisePlannedLabel())

--- a/ArtemisKit/Sources/Dashboard/DashboardView.swift
+++ b/ArtemisKit/Sources/Dashboard/DashboardView.swift
@@ -12,11 +12,14 @@ import SwiftUI
 public struct DashboardView: View {
 
     @State private var viewModel = DashboardViewModel()
+    private let namespace: Namespace.ID
 
-    public init() {}
+    public init(namespace: Namespace.ID) {
+        self.namespace = namespace
+    }
 
     public var body: some View {
-        CourseGrid(viewModel: viewModel)
+        CourseGrid(namespace: namespace, viewModel: viewModel)
             .navigationTitle(Text(R.string.localizable.dashboardTitle()))
             .navigationBarBackButtonHidden()
             .accountMenu(error: Binding(

--- a/ArtemisKit/Sources/Navigation/PathViewModels.swift
+++ b/ArtemisKit/Sources/Navigation/PathViewModels.swift
@@ -38,19 +38,7 @@ final class CoursePathViewModel {
             break
         }
 
-        let start = Date().timeIntervalSince1970
-
         let result = await courseService.getCourse(courseId: path.id)
-        defer {
-            self.course = result.map(\.course)
-        }
-
-        // Ensure 0.3s for animation has passed
-        let end = Date().timeIntervalSince1970
-        let durationNanoSeconds = (end - start) * 1_000_000_000
-        let timeToWait = max(0, 300_000_000 - durationNanoSeconds)
-        do {
-            try await Task.sleep(nanoseconds: UInt64(timeToWait))
-        } catch {}
+        self.course = result.map(\.course)
     }
 }

--- a/ArtemisKit/Sources/Navigation/Paths.swift
+++ b/ArtemisKit/Sources/Navigation/Paths.swift
@@ -7,7 +7,7 @@
 
 import SharedModels
 
-public struct CoursePath: Hashable {
+public struct CoursePath: Hashable, Identifiable {
     public let id: Int
     public let course: Course?
 


### PR DESCRIPTION
Due to issues with nested navigations, we had a workaround in place to show courses with a custom animation. This prevented the system gesture of swiping to go back to the dashboard.

This PR removes the custom animation and associated workaround by implementing a nicer workaround:
- Courses are shown in a full screen cover, thus outside the navigation and with a system animation
- This allows the system gestures to dismiss a navigation sheet
- We only need to disable swiping down as it could interfere with other gestures.

Result: Swiping to go back works again:
https://github.com/user-attachments/assets/751fc0e1-cc04-4824-b727-1fd63c0f292d

