### PR TITLE
`Communication`: Fix detail view on iPad not updating from search results

### DIFF
--- a/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SavedMessagesView/SavedMessageView.swift
@@ -129,6 +129,7 @@ struct MessagePreview: View {
                                   conversation: conversation,
                                   coursePath: CoursePath(course: course))
             ThreadPathView(path: path)
+                .id(path.postId)
         } label: {
             VStack(alignment: .leading) {
                 header


### PR DESCRIPTION
When searching for messages on the iPad, you couldn't switch between the search results because the view did not update