### PR TITLE
`Communication`: Improve hardware keyboard handling

### DIFF
--- a/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel+MarkdownFormatting.swift
+++ b/ArtemisKit/Sources/Messages/ViewModels/SendMessageViewModels/SendMessageViewModel+MarkdownFormatting.swift
@@ -174,6 +174,19 @@ extension SendMessageViewModel {
         }
     }
 
+    /// Inserts the given character at the current position and moves the cursor after the inserted char
+    func insertAtCurrentPosition(_ string: Character) {
+        guard let selection = _selection?.indices else { return }
+        switch selection {
+        case .selection(let range):
+            // Insert newline and move cursor one step
+            text.insert("\n", at: range.upperBound)
+            _selection = .init(insertionPoint: text.index(after: range.upperBound))
+        default:
+            break
+        }
+    }
+
     /// Prepends/Appends the given snippets to text the user has selected.
     private func appendToSelection(before: String, after: String, placeholder: String) {
         let placeholderText = "\(before)\(placeholder)\(after)"

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -173,6 +173,7 @@ private extension SendMessageView {
             Image(systemName: "paperplane.fill")
                 .imageScale(.large)
         }
+        .keyboardShortcut(.return, modifiers: .command)
         .padding(isFocused ? .trailing : .leading, .l)
         .disabled(!viewModel.canSend)
         .loadingIndicator(isLoading: $viewModel.isLoading)

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -162,6 +162,12 @@ private extension SendMessageView {
                 .lineLimit(isFocused ? 8 : 5)
                 .animation(.smooth, value: isFocused)
                 .focused($isFocused)
+                .onKeyPress(.escape) {
+                    isFocused = false
+                    viewModel.keyboardVisible = false
+                    viewModel.previewVisible = false
+                    return .handled
+                }
             if !isFocused {
                 sendButton
             }

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageView.swift
@@ -168,6 +168,17 @@ private extension SendMessageView {
                     viewModel.previewVisible = false
                     return .handled
                 }
+                .onKeyPress { press in
+                    if press.key == .return && press.modifiers.isDisjoint(with: .command) {
+                        viewModel.insertAtCurrentPosition("\n")
+                        // Focus is always removed for some reason, so reset it
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            isFocused = true
+                        }
+                        return .handled
+                    }
+                    return .ignored
+                }
             if !isFocused {
                 sendButton
             }


### PR DESCRIPTION
This PR improves handling of certain hardware keyboard presses, useful on iPad and Mac:
- Command+Return send a message
- Escape correctly resigns focus from the text field
- Return adds a new line instead of resigning focus