### PR TITLE
`Search`: Connect to search API and display number of results

### DIFF
--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -54,7 +54,7 @@ public struct CourseView: View {
 
             Tab(value: .search, role: .search) {
                 TabBarIpad {
-                    SearchTabView()
+                    SearchTabView(courseId: viewModel.course.id)
                 }
             }
         }

--- a/ArtemisKit/Sources/Search/Models/ExerciseSearchResult.swift
+++ b/ArtemisKit/Sources/Search/Models/ExerciseSearchResult.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ExerciseSearchResult.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 22.03.26.

--- a/ArtemisKit/Sources/Search/Models/ExerciseSearchResult.swift
+++ b/ArtemisKit/Sources/Search/Models/ExerciseSearchResult.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 22.03.26.
+//
+
+import Foundation
+
+struct ExerciseSearchResult: SearchResultDetails {
+    let courseId: Int?
+    let courseName: String?
+
+    let dueDate: Date?
+    let releaseDate: Date?
+    let points: Int?
+    let difficulty: String?
+}

--- a/ArtemisKit/Sources/Search/Models/SearchFilterType.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchFilterType.swift
@@ -1,0 +1,28 @@
+//
+//  SearchFilterType.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 21.03.26.
+//
+
+import SharedModels
+
+enum SearchFilterType: String, Codable, ConstantsEnum {
+    case exercise
+    case lecture
+    case unknown
+
+    /// String describing the type for the API query param
+    var apiType: String { rawValue }
+
+    /// Returns how to decode the `metadata` property of the `SearchResultDTO` for the given type
+    var codableType: SearchResultDetails.Type? {
+        switch self {
+        case .exercise:
+            ExerciseSearchResult.self
+        // TODO: Add other types
+        default:
+            nil
+        }
+    }
+}

--- a/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SearchResultDTO.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 21.03.26.

--- a/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 21.03.26.
+//
+
+import Foundation
+
+struct SearchResultDTO: Decodable {
+    let id: String?
+    let type: SearchFilterType?
+    let title: String?
+    let description: String?
+    let badge: String?
+    let metadata: (any SearchResultDetails)?
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.type = try container.decodeIfPresent(SearchFilterType.self, forKey: .type)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.badge = try container.decodeIfPresent(String.self, forKey: .badge)
+        if let type, let decodable = type.codableType {
+            self.metadata = try container.decodeIfPresent(decodable, forKey: .metadata)
+        } else {
+            self.metadata = nil
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, type, title, description, badge, metadata
+    }
+}

--- a/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 22.03.26.
+//
+
+import Foundation
+
+protocol SearchResultDetails: Decodable {
+    var courseId: Int? { get }
+    var courseName: String? { get }
+}

--- a/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SearchResultDetails.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 22.03.26.

--- a/ArtemisKit/Sources/Search/SearchFilter.swift
+++ b/ArtemisKit/Sources/Search/SearchFilter.swift
@@ -45,6 +45,14 @@ enum SearchFilter: CaseIterable, Identifiable, Equatable {
         }
     }
 
+    var apiFilterType: SearchFilterType? {
+        switch self {
+        case .iris: nil
+        case .exercises: .exercise
+        case .lectures: .lecture
+        }
+    }
+
     var id: String {
         self.displayTitle
     }

--- a/ArtemisKit/Sources/Search/Services/SearchService.swift
+++ b/ArtemisKit/Sources/Search/Services/SearchService.swift
@@ -1,0 +1,19 @@
+//
+//  SearchService.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 21.03.26.
+//
+
+import Common
+
+protocol SearchService {
+    /// Send a GET Request to the server to perform a search with the given term and type in the given course.
+    /// If no type is specified, all types may be returned.
+    /// If no courseId is specified, the search is performed globally across all courses the user can access.
+    func search(for type: SearchFilterType?, in courseId: Int?, searchTerm: String) async -> DataState<[SearchResultDTO]>
+}
+
+enum SearchServiceFactory: DependencyFactory {
+    static let liveValue: SearchService = SearchServiceImpl()
+}

--- a/ArtemisKit/Sources/Search/Services/SearchServiceImpl.swift
+++ b/ArtemisKit/Sources/Search/Services/SearchServiceImpl.swift
@@ -1,0 +1,49 @@
+//
+//  SearchServiceImpl.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 21.03.26.
+//
+
+import APIClient
+import Common
+import Foundation
+
+struct SearchServiceImpl: SearchService {
+    let client = APIClient()
+
+    struct SearchAPIRequest: APIRequest {
+        typealias Response = [SearchResultDTO]
+
+        let type: SearchFilterType?
+        let courseId: Int?
+        let searchTerm: String
+
+        var resourceName: String {
+            "/api/search"
+        }
+
+        var method: HTTPMethod { .get }
+
+        var params: [URLQueryItem] {
+            [
+                .init(name: "q", value: searchTerm),
+                .init(name: "courseId", value: courseId.flatMap { "\($0)" }),
+                .init(name: "type", value: type?.apiType)
+            ]
+        }
+    }
+
+    func search(for type: SearchFilterType?, in courseId: Int?, searchTerm: String) async -> DataState<[SearchResultDTO]> {
+        let request = SearchAPIRequest(type: type, courseId: courseId, searchTerm: searchTerm)
+
+        let result = await client.sendRequest(request)
+
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: .init(error: error))
+        }
+    }
+}

--- a/ArtemisKit/Sources/Search/ViewModels/SearchRequest.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchRequest.swift
@@ -1,0 +1,14 @@
+//
+//  SearchRequest.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 22.03.26.
+//
+
+import Foundation
+
+struct SearchRequest: Hashable {
+    let type: SearchFilterType?
+    let courseId: Int?
+    let searchTerm: String
+}

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -10,18 +10,24 @@ import Foundation
 
 @Observable
 class SearchTabViewModel {
+    let courseId: Int
+
     var searchTerm = ""
     var scope: SearchScope = .course
     var selectedFilters = [SearchFilter]()
 
     var searchRequest: SearchRequest {
         .init(type: selectedFilters.first?.apiFilterType,
-              courseId: scope == .course ? 0 : nil,
+              courseId: scope == .course ? courseId : nil,
               searchTerm: searchTerm)
     }
 
     var searchResults: DataState<[SearchResultDTO]> = .loading
     var isLoading = false
+
+    init(courseId: Int) {
+        self.courseId = courseId
+    }
 
     private var updateSearchTask: Task<(), Never>?
     /// Observes changes to search request related properties, sending a new request when values change

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -1,10 +1,11 @@
 //
-//  File.swift
+//  SearchTabViewModel.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 21.03.26.
 //
 
+import Common
 import Foundation
 
 @Observable
@@ -12,4 +13,44 @@ class SearchTabViewModel {
     var searchTerm = ""
     var scope: SearchScope = .course
     var selectedFilters = [SearchFilter]()
+
+    var searchRequest: SearchRequest {
+        .init(type: selectedFilters.first?.apiFilterType,
+              courseId: scope == .course ? 0 : nil,
+              searchTerm: searchTerm)
+    }
+
+    var searchResults: DataState<[SearchResultDTO]> = .loading
+    var isLoading = false
+
+    private var updateSearchTask: Task<(), Never>?
+    /// Observes changes to search request related properties, sending a new request when values change
+    private func observeChanges() {
+        withObservationTracking {
+            _ = searchRequest
+        } onChange: { [weak self] in
+            guard let self else { return }
+            updateSearchTask?.cancel()
+            updateSearchTask = Task { [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: 350_000_000)
+                    await self?.performSearch()
+                } catch {
+                    // task cancelled -> new change was triggered within 350ms
+                }
+            }
+        }
+    }
+
+    func performSearch() async {
+        isLoading = true
+
+        let service = SearchServiceFactory.shared
+
+        searchResults = await service.search(for: selectedFilters.first?.apiFilterType,
+                                             in: scope == .course ? 0 : nil,
+                                             searchTerm: searchTerm)
+        observeChanges()
+        isLoading = false
+    }
 }

--- a/ArtemisKit/Sources/Search/Views/SearchResultsView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchResultsView.swift
@@ -5,16 +5,30 @@
 //  Created by Anian Schleyer on 21.03.26.
 //
 
+import DesignLibrary
 import SwiftUI
 
 struct SearchResultsView: View {
-    let results: [String]
+    @Bindable var viewModel: SearchTabViewModel
 
     var body: some View {
-        if results.isEmpty {
-            ContentUnavailableView.search
-        } else {
-            // TODO: Show search results
+        DataStateView(data: $viewModel.searchResults) {
+            await viewModel.performSearch()
+        } content: { results in
+            Group {
+                if results.isEmpty {
+                    ContentUnavailableView.search
+                } else {
+                    // TODO: Show search results
+                    Text("\(results.count) results")
+                }
+            }
+            .loadingIndicator(isLoading: $viewModel.isLoading)
+        }
+        .task(id: "getRecents") {
+            if case .loading = viewModel.searchResults {
+                await viewModel.performSearch()
+            }
         }
     }
 }

--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -9,9 +9,11 @@ import Notifications
 import SwiftUI
 
 public struct SearchTabView: View {
-    @State private var viewModel = SearchTabViewModel()
+    @State private var viewModel: SearchTabViewModel
 
-    public init() {}
+    public init(courseId: Int) {
+        _viewModel = State(initialValue: SearchTabViewModel(courseId: courseId))
+    }
 
     public var body: some View {
         NavigationStack {

--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -21,9 +21,10 @@ public struct SearchTabView: View {
                 scopeSuggestions
 
                 Section {
-                    SearchResultsView(results: [])
+                    SearchResultsView(viewModel: viewModel)
                 }
             }
+            .submitLabel(.search)
             .searchable(text: $viewModel.searchTerm, tokens: $viewModel.selectedFilters) { token in
                 Label(token.displayTitle, systemImage: token.systemImage)
             }


### PR DESCRIPTION
This PR (sort of) adds functionality to the search function:
- Search text changes trigger a search request (debounced to 350ms)
- Number of suggestions for exercises can be displayed to show that request was successful
- Course vs global scope works
- Filtering to exercises/lectures works

TODO (follow up):
- Respect feature toggle
- Display results
- Navigate to results
- Enable decoding lectures
- Add further types
- Connect to Iris after implemented 