### PR TITLE
`Search`: Use feature toggle to show/hide search

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a6b2dbdae7f46850cca05c7d00b58be9fc9c1c3bf930099884afa276042ddcd4",
+  "originHash" : "eaed38c70ded99e5f9b6bb63913c68bf5a2617f0053b18ae06a57b39884e7641",
   "pins" : [
     {
       "identity" : "apollon-ios-module",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "revision" : "829f4301998ecc059c1944fad6bea73094194393",
-        "version" : "19.2.0"
+        "branch" : "fdde93c",
+        "revision" : "fdde93c6f1931e1bc6c9ee088a6aa053655ce82e"
       }
     },
     {

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "eaed38c70ded99e5f9b6bb63913c68bf5a2617f0053b18ae06a57b39884e7641",
+  "originHash" : "a7a8309c677a9d103b45fb5e6a92b6741c3d5cbbd9621d73f6ea1f0426f71da2",
   "pins" : [
-    {
-      "identity" : "apollon-ios-module",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ls1intum/apollon-ios-module",
-      "state" : {
-        "revision" : "5e4b1223bf33b542bcef2b844f7c451ac0ed7a9e",
-        "version" : "1.0.9"
-      }
-    },
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
         .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")),
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", from: "19.2.0"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "fdde93c"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
-        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")),
+//        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
         .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "fdde93c"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
@@ -60,12 +60,14 @@ let package = Package(
                 "Navigation",
                 "Notifications",
                 "Search",
-                .product(name: "ApollonEdit", package: "apollon-ios-module"),
-                .product(name: "ApollonView", package: "apollon-ios-module"),
-                .product(name: "ApollonShared", package: "apollon-ios-module"),
+                // Apollon disabled because not working
+//                .product(name: "ApollonEdit", package: "apollon-ios-module"),
+//                .product(name: "ApollonView", package: "apollon-ios-module"),
+//                .product(name: "ApollonShared", package: "apollon-ios-module"),
                 .product(name: "APIClient", package: "artemis-ios-core-modules"),
                 .product(name: "ArtemisMarkdown", package: "artemis-ios-core-modules"),
                 .product(name: "Common", package: "artemis-ios-core-modules"),
+                .product(name: "ProfileInfo", package: "artemis-ios-core-modules"),
                 .product(name: "SharedModels", package: "artemis-ios-core-modules"),
                 .product(name: "SharedServices", package: "artemis-ios-core-modules"),
                 .product(name: "UserStore", package: "artemis-ios-core-modules"),

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -4,6 +4,7 @@ import Common
 import SharedModels
 import Navigation
 import Messages
+import ProfileInfo
 import Search
 import DesignLibrary
 
@@ -11,6 +12,7 @@ public struct CourseView: View {
     @EnvironmentObject private var navigationController: NavigationController
 
     @StateObject private var viewModel: CourseViewModel
+    @FeatureAvailability(.globalSearch) private var searchEnabled
 
     private let courseId: Int
 
@@ -52,9 +54,11 @@ public struct CourseView: View {
                 }
             }
 
-            Tab(value: .search, role: .search) {
-                TabBarIpad {
-                    SearchTabView(courseId: viewModel.course.id)
+            if searchEnabled {
+                Tab(value: .search, role: .search) {
+                    TabBarIpad {
+                        SearchTabView(courseId: viewModel.course.id)
+                    }
                 }
             }
         }

--- a/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/ModelingExerciseViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/ModelingExerciseViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Alexander Görtzen on 21.11.23.
 //
 
+/* Not used at the moment, here for reference when fixing participation
 import ApollonShared
 import Common
 import Foundation
@@ -335,3 +336,4 @@ enum UMLBadgeSymbol {
         }
     }
 }
+*/

--- a/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/EditModelingExerciseView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/EditModelingExerciseView.swift
@@ -5,6 +5,7 @@
 //  Created by Alexander Görtzen on 21.11.23.
 //
 
+/* Not used at the moment, here for reference when fixing participation
 import SwiftUI
 import ApollonShared
 import ApollonEdit
@@ -116,3 +117,4 @@ private extension EditModelingExerciseView {
         }
     }
 }
+*/

--- a/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/ViewModelingExerciseResultView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/ViewModelingExerciseResultView.swift
@@ -5,6 +5,7 @@
 //  Created by Alexander Görtzen on 21.11.23.
 //
 
+/* Not used at the moment, here for reference when fixing participation
 import SwiftUI
 import ApollonShared
 import ApollonView
@@ -221,3 +222,4 @@ private struct AssessmentView: View {
         }
     }
 }
+*/

--- a/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/ViewModelingExerciseView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseParticipation/ModelingExercise/Views/ViewModelingExerciseView.swift
@@ -5,6 +5,7 @@
 //  Created by Alexander Görtzen on 21.11.23.
 //
 
+/* Not used at the moment, here for reference when fixing participation
 import SwiftUI
 import ApollonShared
 import ApollonView
@@ -44,3 +45,4 @@ struct ViewModelingExerciseView: View {
         .navigationTitle(R.string.localizable.viewSubmissionTitle())
     }
 }
+*/

--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -5,7 +5,7 @@
 // MARK: - CourseView
 "exercisesTabLabel" = "Exercises";
 "lectureTabLabel" = "Lectures";
-"messagesTabLabel" = "Communication";
+"messagesTabLabel" = "Messages";
 "faqTabLabel" = "FAQ";
 "exercisesUnavailable" = "No Exercises";
 "lecturesUnavailable" = "No Lectures";


### PR DESCRIPTION
This PR uses the feature toggle for the global search feature to enable it only when it is enabled server-side.

Also renames Communication to Messages because there is not enough space in the tab bar for the long name:
<img width="300" src="https://github.com/user-attachments/assets/8269f368-bc34-4506-81fe-44b5da30bfa9">
<img width="300" src="https://github.com/user-attachments/assets/240dde3e-50b7-4c29-be4c-592e700ccb23">

Dependency list is updated for the feature toggle, removes Apollon temporarily and uses a specific commit for core modules until the next release.