### PR TITLE
`General`: Replace faqEnabled with number of FAQs check

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -82,6 +82,7 @@ attributes:
     - "@OptionGroup"
   always_on_same_line:
     - "@Environment"
+    - "@FeatureAvailability"
 identifier_name:
   max_length:
     warning: 55

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a7a8309c677a9d103b45fb5e6a92b6741c3d5cbbd9621d73f6ea1f0426f71da2",
+  "originHash" : "00c27685fea7710069efb5d91a4d898474c44174f319fc9d57c08a0ed24f14a8",
   "pins" : [
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "fdde93c",
-        "revision" : "fdde93c6f1931e1bc6c9ee088a6aa053655ce82e"
+        "branch" : "e8c7032",
+        "revision" : "e8c703225624e229a02b7c22304d2232c4228019"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
 //        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "fdde93c"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "e8c7032"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -44,7 +44,7 @@ public struct CourseView: View {
                 }
             }
 
-            if viewModel.course.faqEnabled ?? false {
+            if (viewModel.course.numberOfAcceptedFaqs ?? 0) > 0 {
                 Tab(R.string.localizable.faqTabLabel(),
                     systemImage: "questionmark.circle",
                     value: TabIdentifier.faq) {

--- a/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
+++ b/ArtemisKit/Sources/Messages/Views/SendMessageViews/SendMessageKeyboardToolbar.swift
@@ -106,7 +106,7 @@ struct SendMessageKeyboardToolbar<SendButton: View>: View {
             } label: {
                 Label(R.string.localizable.lectures(), systemImage: "character.book.closed")
             }
-            if viewModel.course.faqEnabled == true {
+            if (viewModel.course.numberOfAcceptedFaqs ?? 0) > 0 {
                 Button {
                     viewModel.wantsToAddMessageMentionContentType = .faq
                 } label: {


### PR DESCRIPTION
We no longer use `faqEnabled` to decide whether to show the FAQ tab or not. Instead, we now simply show it whenever there is at least one accepted/pubished FAQ.