### PR TITLE
`Search`: Fix search results inside course not showing

### DIFF
--- a/ArtemisKit/Sources/Search/SearchFilter.swift
+++ b/ArtemisKit/Sources/Search/SearchFilter.swift
@@ -28,7 +28,7 @@ enum SearchFilter: CaseIterable, Identifiable, Equatable {
         case .iris:
             Color.blue
         case .exercises:
-            Color.orange
+            Color.indigo
         case .lectures:
             Color.orange
         }

--- a/ArtemisKit/Sources/Search/Services/SearchServiceImpl.swift
+++ b/ArtemisKit/Sources/Search/Services/SearchServiceImpl.swift
@@ -20,7 +20,7 @@ struct SearchServiceImpl: SearchService {
         let searchTerm: String
 
         var resourceName: String {
-            "/api/search"
+            "api/search"
         }
 
         var method: HTTPMethod { .get }

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -54,7 +54,7 @@ class SearchTabViewModel {
         let service = SearchServiceFactory.shared
 
         searchResults = await service.search(for: selectedFilters.first?.apiFilterType,
-                                             in: scope == .course ? 0 : nil,
+                                             in: scope == .course ? courseId : nil,
                                              searchTerm: searchTerm)
         observeChanges()
         isLoading = false


### PR DESCRIPTION
Removes a leftover courseId = 0 from testing that prevented search from working inside a course. Updates the color for the exercise filter to match the one on the server (indigo).

Remaining issue: Decoding of dates (different format?), design updates.

<img width="300" src="https://github.com/user-attachments/assets/a56bc602-9380-45a8-a369-3fb7596ce57e" />
