### PR TITLE
`Calendar`: Fix widget not updating in some cases

### DIFF
--- a/Artemis.xcodeproj/project.pbxproj
+++ b/Artemis.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 				INFOPLIST_FILE = ArtemisWidgetExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ArtemisWidgetExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 TUM. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -647,7 +647,7 @@
 				INFOPLIST_FILE = ArtemisWidgetExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ArtemisWidgetExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 TUM. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0e97cbf423c739693c421ec39dce56f8756724fea57aee648c1c294a7711741b",
+  "originHash" : "51d64c2c2e59d53855d822b5a50b47ad276fea720121320da7b7c0118e307e0a",
   "pins" : [
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "8881634",
-        "revision" : "8881634fce24696962703dd1be74feb9b2c3f1ec"
+        "branch" : "e100abc",
+        "revision" : "e100abc6cd34ce788fcd30b0245e4196bc9fa7ad"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
 //        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "8881634"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "e100abc"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
+++ b/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
@@ -60,7 +60,7 @@ public struct CalendarTimelineProvider: AppIntentTimelineProvider {
 
         let startDates = allEvents.compactMap(\.startDate)
         let endDates = allEvents.compactMap(\.endDate)
-        for date in startDates + endDates {
+        for date in [.now] + startDates + endDates {
             // Always update within a minute of something starting or ending
             let entry = CalendarWidgetEntry(date: date.addingTimeInterval(60),
                                             needsConfiguration: false,


### PR DESCRIPTION
There were two issues causing the calendar widget to sometimes not update or be available:
- Double slash in the API path, caused by the configured server URL ending with a trailing slash
- Missing timeline entry for now, causing the widget to only update after the first event was over
- Deployment target was iOS 26.2 despite the widget being technically compatible with iOS 18