### PR TITLE
`Calendar`: Add small Home Screen widget

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "51d64c2c2e59d53855d822b5a50b47ad276fea720121320da7b7c0118e307e0a",
+  "originHash" : "dc216eaa81eabd40f1f87db71f6c3d50a159537157dccb1fd71edd6295b3f822",
   "pins" : [
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "e100abc",
-        "revision" : "e100abc6cd34ce788fcd30b0245e4196bc9fa7ad"
+        "branch" : "747015a",
+        "revision" : "747015a4cc38b7b22ae0102a6a67211def891526"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
 //        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "e100abc"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "747015a"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/Calendar/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Calendar/Resources/en.lproj/Localizable.strings
@@ -1,7 +1,10 @@
 "notConfigured" = "Widget not configured";
+"notConfiguredShort" = "Configure";
 "configureDetail" = "Long-press, then tap edit to configure.";
+"configureDetailShort" = "Hold, then edit.";
 
 "failedLoading" = "Artemis failed to load events";
+"failedLoadingShort" = "Failed to load";
 "noUpcomingEvents" = "No upcoming events in the next month.\nEnjoy your free time!";
 
 "dueSoon" = "Due Soon";

--- a/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
@@ -5,6 +5,7 @@
 //  Created by Anian Schleyer on 29.04.26.
 //
 
+import SharedModels
 import SwiftUI
 
 public struct HomeScreenWidgetView: View {
@@ -25,23 +26,22 @@ public struct HomeScreenWidgetView: View {
         } else if entry.error {
             ContentUnavailableView(isSmall ? i18n.failedLoadingShort() : i18n.failedLoading(),
                                    systemImage: "antenna.radiowaves.left.and.right.slash")
-        } else if hasNoUpcomingEvents {
+        } else if upcomingEvents.isEmpty {
             Text(R.string.localizable.noUpcomingEvents())
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         } else {
             if isSmall {
-                
+                SmallWidgetView(events: upcomingEvents)
             } else {
-                MediumWidgetView(events: entry.calendarEvents)
+                MediumWidgetView(events: upcomingEvents)
             }
         }
     }
 
-    private var hasNoUpcomingEvents: Bool {
-        entry.calendarEvents.isEmpty || entry.calendarEvents.allSatisfy { event in
-            // All events in the past (exams not shown)
-            (event.endDate ?? event.startDate) < entry.date || event._type == .exam
+    private var upcomingEvents: [DTO.CalendarEvent] {
+        entry.calendarEvents.filter { event in
+            (event.endDate ?? event.startDate) > entry.date && event._type != .exam
         }
     }
 

--- a/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
@@ -1,0 +1,51 @@
+//
+//  HomeScreenWidgetView.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 29.04.26.
+//
+
+import SwiftUI
+
+public struct HomeScreenWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+
+    let entry: CalendarWidgetEntry
+
+    public init(entry: CalendarWidgetEntry) {
+        self.entry = entry
+    }
+
+    public var body: some View {
+        let i18n = R.string.localizable
+        if entry.needsConfiguration {
+            ContentUnavailableView(isSmall ? i18n.notConfiguredShort() : i18n.notConfigured(),
+                                   systemImage: "wrench.adjustable",
+                                   description: Text(isSmall ? i18n.configureDetailShort() : i18n.configureDetail()))
+        } else if entry.error {
+            ContentUnavailableView(isSmall ? i18n.failedLoadingShort() : i18n.failedLoading(),
+                                   systemImage: "antenna.radiowaves.left.and.right.slash")
+        } else if hasNoUpcomingEvents {
+            Text(R.string.localizable.noUpcomingEvents())
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        } else {
+            if isSmall {
+                
+            } else {
+                MediumWidgetView(events: entry.calendarEvents)
+            }
+        }
+    }
+
+    private var hasNoUpcomingEvents: Bool {
+        entry.calendarEvents.isEmpty || entry.calendarEvents.allSatisfy { event in
+            // All events in the past (exams not shown)
+            (event.endDate ?? event.startDate) < entry.date || event._type == .exam
+        }
+    }
+
+    private var isSmall: Bool {
+        family == .systemSmall
+    }
+}

--- a/ArtemisKit/Sources/Calendar/Views/MediumWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/MediumWidgetView.swift
@@ -24,18 +24,14 @@ struct MediumWidgetView: View {
             WidgetDueSoonView(events: events)
 
             if let nextLecture {
-                WidgetEventGroup(title: R.string.localizable.nextLecture(),
-                                 showSubtitle: false,
+                WidgetEventGroup(showSubtitle: false,
                                  events: [nextLecture],
-                                 color: .teal,
                                  canTakeMoreSpace: nextTutorial == nil)
             }
 
             if let nextTutorial {
-                WidgetEventGroup(title: R.string.localizable.nextTutorial(),
-                                 showSubtitle: false,
+                WidgetEventGroup(showSubtitle: false,
                                  events: [nextTutorial],
-                                 color: .blue,
                                  canTakeMoreSpace: nextLecture == nil)
             }
         }

--- a/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
@@ -1,5 +1,5 @@
 //
-//  MediumWidgetView.swift
+//  SmallWidgetView.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 09.05.26.
@@ -8,7 +8,7 @@
 import SharedModels
 import SwiftUI
 
-struct MediumWidgetView: View {
+struct SmallWidgetView: View {
     let events: [DTO.CalendarEvent]
 
     var nextLecture: DTO.CalendarEvent? {

--- a/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
@@ -11,36 +11,22 @@ import SwiftUI
 struct SmallWidgetView: View {
     let events: [DTO.CalendarEvent]
 
-    var nextLecture: DTO.CalendarEvent? {
-        events.first { $0._type == .lecture }
-    }
-
-    var nextTutorial: DTO.CalendarEvent? {
-        events.first { $0._type == .tutorial }
+    var nextEvent: DTO.CalendarEvent? {
+        events.first
     }
 
     var body: some View {
-        TwoColumnLayout {
-            WidgetDueSoonView(events: events)
-
-            if let nextLecture {
-                WidgetEventGroup(title: R.string.localizable.nextLecture(),
-                                 showSubtitle: false,
-                                 events: [nextLecture],
-                                 color: .teal,
-                                 canTakeMoreSpace: nextTutorial == nil)
-            }
-
-            if let nextTutorial {
-                WidgetEventGroup(title: R.string.localizable.nextTutorial(),
-                                 showSubtitle: false,
-                                 events: [nextTutorial],
-                                 color: .blue,
-                                 canTakeMoreSpace: nextLecture == nil)
+        Group {
+            if let nextEvent {
+                switch nextEvent._type {
+                case .fileUploadExercise, .modelingExercise, .programmingExercise, .quizExercise, .textExercise:
+                    WidgetDueSoonView(events: events)
+                default:
+                    WidgetEventGroup(showSubtitle: false, events: [nextEvent], canTakeMoreSpace: true)
+                }
             }
         }
-        .padding(.horizontal)
-        .padding(.vertical, .m)
+        .padding(.m)
         .containerRelativeFrame([.vertical, .horizontal], alignment: .topLeading)
     }
 }

--- a/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
@@ -26,7 +26,7 @@ struct SmallWidgetView: View {
                 }
             }
         }
-        .padding(.m)
+        .padding()
         .containerRelativeFrame([.vertical, .horizontal], alignment: .topLeading)
     }
 }

--- a/ArtemisKit/Sources/Calendar/Views/TwoColumnLayout.swift
+++ b/ArtemisKit/Sources/Calendar/Views/TwoColumnLayout.swift
@@ -13,7 +13,11 @@ struct TwoColumnLayout: Layout {
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         let width = proposal.width ?? 0
-        let columnWidth = (width - spacing) / 2
+        let columnWidth = if subviews.count == 1 {
+            width // Use full width if only one view needs to be placed
+        } else {
+            (width - spacing) / 2
+        }
 
         var leftHeight: CGFloat = 0
         var rightHeight: CGFloat = 0
@@ -32,7 +36,11 @@ struct TwoColumnLayout: Layout {
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let columnWidth = (bounds.width - spacing) / 2
+        let columnWidth = if subviews.count == 1 {
+            bounds.width // Use full width if only one view needs to be placed
+        } else {
+            (bounds.width - spacing) / 2
+        }
 
         var leftY: CGFloat = bounds.minY
         var rightY: CGFloat = bounds.minY

--- a/ArtemisKit/Sources/Calendar/Views/WidgetDueSoonView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/WidgetDueSoonView.swift
@@ -45,10 +45,7 @@ struct WidgetDueSoonView: View {
 
     var body: some View {
         if !events.isEmpty {
-            WidgetEventGroup(title: R.string.localizable.dueSoon(),
-                             showSubtitle: true,
-                             events: events,
-                             color: .indigo)
+            WidgetEventGroup(showSubtitle: true, events: events)
         }
     }
 }

--- a/ArtemisKit/Sources/Calendar/Views/WidgetEventGroup.swift
+++ b/ArtemisKit/Sources/Calendar/Views/WidgetEventGroup.swift
@@ -36,15 +36,30 @@ struct WidgetEventGroup: View {
                         Text(event.title)
                             .lineLimit(canTakeMoreSpace ? 2 : 1)
 
-                        if events.count == 1 && !showSubtitle {
-                            Text(event.startDate, style: .date)
-                        }
+                        timeView(for: event)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .font(.subheadline)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func timeView(for event: DTO.CalendarEvent) -> some View {
+        if events.count == 1 && !showSubtitle {
+            Text(event.startDate, style: .date)
+            if canTakeMoreSpace {
+                HStack(alignment: .firstTextBaseline, spacing: .s) {
+                    Text(event.startDate, style: .time)
+                    if let endDate = event.endDate {
+                        Text("-")
+                        Text(endDate, style: .time)
+                    }
+                }
+            }
+        }
     }
 
     private var title: String {

--- a/ArtemisKit/Sources/Calendar/Views/WidgetEventGroup.swift
+++ b/ArtemisKit/Sources/Calendar/Views/WidgetEventGroup.swift
@@ -9,10 +9,8 @@ import SharedModels
 import SwiftUI
 
 struct WidgetEventGroup: View {
-    let title: String
     let showSubtitle: Bool
     let events: [DTO.CalendarEvent]
-    let color: Color
     var canTakeMoreSpace = false
 
     var body: some View {
@@ -47,5 +45,31 @@ struct WidgetEventGroup: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var title: String {
+        switch events.first?._type {
+        case .fileUploadExercise, .modelingExercise, .programmingExercise, .quizExercise, .textExercise:
+            R.string.localizable.dueSoon()
+        case .lecture:
+            R.string.localizable.nextLecture()
+        case .tutorial:
+            R.string.localizable.nextTutorial()
+        default:
+            ""
+        }
+    }
+
+    private var color: Color {
+        switch events.first?._type {
+        case .fileUploadExercise, .modelingExercise, .programmingExercise, .quizExercise, .textExercise:
+                .indigo
+        case .lecture:
+                .teal
+        case .tutorial:
+                .blue
+        default:
+                .gray
+        }
     }
 }

--- a/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
+++ b/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
@@ -23,7 +23,8 @@ public struct CalendarTimelineProvider: AppIntentTimelineProvider {
                             calendarEvents: [
                                 .init(_type: .lecture,
                                       title: "Software Engineering",
-                                      startDate: .tomorrow),
+                                      startDate: .tomorrow,
+                                      endDate: .tomorrow.addingTimeInterval(3600)),
                                 .init(_type: .programmingExercise,
                                       title: "W04E01 Broker",
                                       startDate: .tomorrow),

--- a/ArtemisWidgetExtension/ArtemisCalendarWidget.swift
+++ b/ArtemisWidgetExtension/ArtemisCalendarWidget.swift
@@ -17,10 +17,10 @@ struct ArtemisCalendarWidget: Widget {
         AppIntentConfiguration(kind: kind,
                                intent: CalendarCourseConfigurationIntent.self,
                                provider: CalendarTimelineProvider()) { entry in
-            MediumCalendarWidgetView(entry: entry)
+            HomeScreenWidgetView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
         }
-        .supportedFamilies([.systemMedium])
+        .supportedFamilies([.systemMedium, .systemSmall])
         .configurationDisplayName("Calendar")
         .description("Keep an overview of upcoming events.")
     }


### PR DESCRIPTION
This PR adds a new size option for the Home Screen calendar widget: Small. Users can now choose between medium and small when adding the widget, as well as resize the existing widget.
This widget always shows the first upcoming event.

<img width="300" src="https://github.com/user-attachments/assets/3586d1bf-c0b1-42df-bb53-618736483bcb" />
<img width="300" src="https://github.com/user-attachments/assets/f9230a58-4b46-4b26-9a6d-556adaf429da" />


https://github.com/user-attachments/assets/502bf281-dcef-4ba6-8113-c256ee098723