### PR TITLE
`Search`: Improve search tab default styling

### DIFF
--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -66,23 +66,11 @@ public struct CourseView: View {
         // Add a file and image picker here, inside the navigation it doesn't work sometimes
         .supportsFilePicker()
         .supportsImagePicker()
-        .autoFocusSearchOnSearchTab()
     }
 }
 
 extension CourseView {
     init(course: Course) {
         self.init(viewModel: CourseViewModel(course: course), courseId: course.id)
-    }
-}
-
-private extension View {
-    @ViewBuilder
-    func autoFocusSearchOnSearchTab() -> some View {
-        if #available(iOS 26, *) {
-            tabViewSearchActivation(.searchTabSelection)
-        } else {
-            self
-        }
     }
 }

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -56,9 +56,11 @@ public struct CourseView: View {
 
             if searchEnabled {
                 Tab(value: .search, role: .search) {
-                    TabBarIpad {
-                        SearchTabView(courseId: viewModel.course.id)
-                    }
+                    SearchTabView(courseId: viewModel.course.id)
+                    // Search tab does not use split view, so always use compact toolbar
+                        .environment(\.horizontalSizeClass, nil)
+                        .courseToolbar(title: viewModel.course.title ?? R.string.localizable.loading())
+                        .environment(\.horizontalSizeClass, .compact)
                 }
             }
         }

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -58,7 +58,6 @@ public struct CourseView: View {
                 Tab(value: .search, role: .search) {
                     SearchTabView(courseId: viewModel.course.id)
                     // Search tab does not use split view, so always use compact toolbar
-                        .environment(\.horizontalSizeClass, nil)
                         .courseToolbar(title: viewModel.course.title ?? R.string.localizable.loading())
                         .environment(\.horizontalSizeClass, .compact)
                 }


### PR DESCRIPTION
Improves two things in the search tab:
- On iPhone, keyboard no longer opens by default, allowing users to see suggestions
- On iPad, overlaps with the tab bar are fixed (caused by not using Split View in this tab as it makes no sense)

<img width="500" src="https://github.com/user-attachments/assets/58dd4cdf-aeba-45a1-9ebd-13719e0539e5" />
