### PR TITLE
`Iris`: Add HTTP and WebSocket clients for chat sessions and messages  

### DIFF
--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -116,6 +116,8 @@ let package = Package(
         .target(
             name: "Iris",
             dependencies: [
+                .product(name: "APIClient", package: "artemis-ios-core-modules"),
+                .product(name: "Common", package: "artemis-ios-core-modules"),
                 .product(name: "SharedModels", package: "artemis-ios-core-modules")
             ]),
         .target(

--- a/ArtemisKit/Sources/Iris/Models/IrisCitationMetaDTO.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisCitationMetaDTO.swift
@@ -6,9 +6,9 @@
 //
 
 struct IrisCitationMetaDTO: Codable, Hashable {
-    let entityId: Int64
+    let entityId: Int
     let lectureTitle: String
     let lectureUnitTitle: String
-    let lectureId: Int64
-    let courseId: Int64
+    let lectureId: Int
+    let courseId: Int
 }

--- a/ArtemisKit/Sources/Iris/Models/IrisCourseSettings.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisCourseSettings.swift
@@ -35,7 +35,7 @@ struct IrisCourseSettingsDTO: Codable, Hashable {
 /// Full settings response from `GET /courses/{courseId}/iris-settings`.
 /// Combines the editable settings with the server-computed effective limits.
 struct IrisCourseSettingsWithRateLimitDTO: Codable, Hashable {
-    let courseId: Int64
+    let courseId: Int
     let settings: IrisCourseSettingsDTO
     let effectiveRateLimit: IrisRateLimitConfiguration
     let applicationRateLimitDefaults: IrisRateLimitConfiguration

--- a/ArtemisKit/Sources/Iris/Models/IrisMessage.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisMessage.swift
@@ -19,7 +19,7 @@ enum IrisSender: String, ConstantsEnum {
 /// Domain message produced by the LLM. Holds typed content, parsed `sentAt`
 /// and the optional Memiris references attached by the server.
 struct IrisAssistantMessage: Hashable, Identifiable {
-    let id: Int64
+    let id: Int
     let content: [IrisMessageContent]
     let sentAt: Date
     let helpful: Bool?
@@ -31,7 +31,7 @@ struct IrisAssistantMessage: Hashable, Identifiable {
 
 /// Domain message authored by the current user.
 struct IrisUserMessage: Hashable, Identifiable {
-    let id: Int64?
+    let id: Int?
     let content: [IrisTextMessageContent]
     let sentAt: Date?
     let messageDifferentiator: Int?
@@ -44,7 +44,7 @@ struct IrisUserMessage: Hashable, Identifiable {
 /// Domain message representing a server-generated artifact, e.g. a tutor
 /// suggestion result that is attached to a message thread.
 struct IrisArtifactMessage: Hashable, Identifiable {
-    let id: Int64?
+    let id: Int?
     let content: [IrisTextMessageContent]
     let sentAt: Date?
     let accessedMemories: [MemirisMemory]?
@@ -60,7 +60,7 @@ enum IrisMessage: Hashable, Identifiable {
     case user(IrisUserMessage)
     case artifact(IrisArtifactMessage)
 
-    var id: Int64? {
+    var id: Int? {
         switch self {
         case .assistant(let message): message.id
         case .user(let message): message.id

--- a/ArtemisKit/Sources/Iris/Models/IrisMessageContent.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisMessageContent.swift
@@ -15,8 +15,8 @@ enum IrisMessageContentType: String, ConstantsEnum {
 
 /// Plain-text message content used by user, assistant and artifact messages.
 struct IrisTextMessageContent: Hashable {
-    let id: Int64?
-    let messageId: Int64?
+    let id: Int?
+    let messageId: Int?
     let textContent: String
 }
 
@@ -25,8 +25,8 @@ struct IrisTextMessageContent: Hashable {
 /// (see `IrisMessageContentResponseDTO.attributes`); the chat service decodes
 /// that string into the typed `IrisJsonAttributes` payload below.
 struct IrisJsonMessageContent: Hashable {
-    let id: Int64?
-    let messageId: Int64?
+    let id: Int?
+    let messageId: Int?
     let attributes: IrisJsonAttributes
 }
 

--- a/ArtemisKit/Sources/Iris/Models/IrisMessageResponseDTO.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisMessageResponseDTO.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `attributes` is a JSON-encoded string when `type == "json"` and is parsed
 /// into `IrisJsonAttributes` only at the domain boundary.
 struct IrisMessageContentResponseDTO: Codable, Hashable {
-    let id: Int64?
+    let id: Int?
     let type: String
     let textContent: String?
     let attributes: String?
@@ -21,7 +21,7 @@ struct IrisMessageContentResponseDTO: Codable, Hashable {
 /// Mirrors the server `IrisMessageResponseDTO` record. Use this type at the
 /// HTTP/WebSocket boundary; map to `IrisMessage` domain types for app use.
 struct IrisMessageResponseDTO: Codable, Hashable, Identifiable {
-    let id: Int64?
+    let id: Int?
     let sentAt: Date?
     let helpful: Bool?
     let sender: IrisSender

--- a/ArtemisKit/Sources/Iris/Models/IrisSession.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisSession.swift
@@ -12,14 +12,14 @@ import Foundation
 /// `messages` carries the raw response DTOs; the chat service maps them to the
 /// `IrisMessage` domain type when populating UI state.
 struct IrisSession: Codable, Hashable, Identifiable {
-    let id: Int64
-    let userId: Int64
+    let id: Int
+    let userId: Int
     let messages: [IrisMessageResponseDTO]?
     /// Server-encoded JSON string of the most recent suggestion array, when present.
     let latestSuggestions: String?
     let title: String?
     let creationDate: Date
     let mode: ChatServiceMode?
-    let entityId: Int64
+    let entityId: Int
     let citationInfo: [IrisCitationMetaDTO]?
 }

--- a/ArtemisKit/Sources/Iris/Models/IrisSessionCountDTO.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisSessionCountDTO.swift
@@ -1,0 +1,14 @@
+//
+//  IrisSessionCountDTO.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 17.05.26.
+//
+
+import Foundation
+
+/// Pair of session/message counters returned by `GET /chat/sessions/count`.
+struct IrisSessionCountDTO: Codable, Hashable {
+    let sessions: Int
+    let messages: Int
+}

--- a/ArtemisKit/Sources/Iris/Models/IrisSessionDTO.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisSessionDTO.swift
@@ -10,10 +10,10 @@ import Foundation
 /// Slim session shape returned by `/chat/{courseId}/sessions/overview`,
 /// used to render the chat-history list. Does **not** contain messages.
 struct IrisSessionDTO: Codable, Hashable, Identifiable {
-    let id: Int64
+    let id: Int
     let title: String?
     let creationDate: Date
     let mode: ChatServiceMode
-    let entityId: Int64
+    let entityId: Int
     let entityName: String?
 }

--- a/ArtemisKit/Sources/Iris/Models/IrisStageDTO.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisStageDTO.swift
@@ -11,7 +11,7 @@ struct IrisStageDTO: Codable, Hashable {
     let name: String
     let weight: Int
     let state: IrisStageStateDTO
-    let message: String
+    let message: String?
     /// Internal stages are not shown in the UI and are hidden from the user.
     let `internal`: Bool
     let chatMessage: String?

--- a/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpService.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpService.swift
@@ -8,21 +8,22 @@
 import Common
 
 protocol IrisChatHttpService {
-    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession>
-    func createSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession>
+    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int) async -> DataState<IrisSession>
+    func createSession(mode: ChatServiceMode, entityId: Int) async -> DataState<IrisSession>
 
+    //TODO: courseId Long ?
     func getChatSessions(courseId: Int) async -> DataState<[IrisSessionDTO]>
-    func getChatSession(courseId: Int, sessionId: Int64) async -> DataState<IrisSession>
+    func getChatSession(courseId: Int, sessionId: Int) async -> DataState<IrisSession>
 
     func getSessionAndMessageCount() async -> DataState<IrisSessionCountDTO>
 
     func deleteAllSessions() async -> NetworkResponse
-    func deleteSession(sessionId: Int64) async -> NetworkResponse
+    func deleteSession(sessionId: Int) async -> NetworkResponse
 
-    func getMessages(sessionId: Int64) async -> DataState<[IrisMessageResponseDTO]>
-    func sendMessage(sessionId: Int64, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO>
-    func resendMessage(sessionId: Int64, messageId: Int64) async -> DataState<IrisMessageResponseDTO>
-    func rateMessage(sessionId: Int64, messageId: Int64, helpful: Bool) async -> DataState<IrisMessageResponseDTO>
+    func getMessages(sessionId: Int) async -> DataState<[IrisMessageResponseDTO]>
+    func sendMessage(sessionId: Int, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO>
+    func resendMessage(sessionId: Int, messageId: Int) async -> DataState<IrisMessageResponseDTO>
+    func rateMessage(sessionId: Int, messageId: Int, helpful: Bool) async -> DataState<IrisMessageResponseDTO>
 }
 
 enum IrisChatHttpServiceFactory: DependencyFactory {

--- a/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpService.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpService.swift
@@ -1,0 +1,30 @@
+//
+//  IrisChatHttpService.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 17.05.26.
+//
+
+import Common
+
+protocol IrisChatHttpService {
+    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession>
+    func createSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession>
+
+    func getChatSessions(courseId: Int) async -> DataState<[IrisSessionDTO]>
+    func getChatSession(courseId: Int, sessionId: Int64) async -> DataState<IrisSession>
+
+    func getSessionAndMessageCount() async -> DataState<IrisSessionCountDTO>
+
+    func deleteAllSessions() async -> NetworkResponse
+    func deleteSession(sessionId: Int64) async -> NetworkResponse
+
+    func getMessages(sessionId: Int64) async -> DataState<[IrisMessageResponseDTO]>
+    func sendMessage(sessionId: Int64, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO>
+    func resendMessage(sessionId: Int64, messageId: Int64) async -> DataState<IrisMessageResponseDTO>
+    func rateMessage(sessionId: Int64, messageId: Int64, helpful: Bool) async -> DataState<IrisMessageResponseDTO>
+}
+
+enum IrisChatHttpServiceFactory: DependencyFactory {
+    static let liveValue: IrisChatHttpService = IrisChatHttpServiceImpl()
+}

--- a/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
@@ -1,0 +1,296 @@
+//
+//  IrisChatHttpServiceImpl.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 17.05.26.
+//
+
+import APIClient
+import Common
+import Foundation
+
+struct IrisChatHttpServiceImpl: IrisChatHttpService {
+
+    let client = APIClient()
+
+    // MARK: - Sessions
+
+    struct GetCurrentSessionRequest: APIRequest {
+        typealias Response = IrisSession
+
+        let mode: ChatServiceMode
+        let entityId: Int64
+
+        var method: HTTPMethod { .post }
+
+        var resourceName: String {
+            if mode == .tutorSuggestion {
+                return "api/iris/tutor-suggestion/\(entityId)/sessions/current"
+            }
+            return "api/iris/chat/sessions/current"
+        }
+
+        var params: [URLQueryItem] {
+            guard mode != .tutorSuggestion else { return [] }
+            return [
+                .init(name: "mode", value: mode.rawValue),
+                .init(name: "entityId", value: "\(entityId)")
+            ]
+        }
+    }
+
+    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession> {
+        let result = await client.sendRequest(GetCurrentSessionRequest(mode: mode, entityId: entityId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct CreateSessionRequest: APIRequest {
+        typealias Response = IrisSession
+
+        let mode: ChatServiceMode
+        let entityId: Int64
+
+        var method: HTTPMethod { .post }
+
+        var resourceName: String {
+            if mode == .tutorSuggestion {
+                return "api/iris/tutor-suggestion/\(entityId)/sessions"
+            }
+            return "api/iris/chat/sessions"
+        }
+
+        var params: [URLQueryItem] {
+            guard mode != .tutorSuggestion else { return [] }
+            return [
+                .init(name: "mode", value: mode.rawValue),
+                .init(name: "entityId", value: "\(entityId)")
+            ]
+        }
+    }
+
+    func createSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession> {
+        let result = await client.sendRequest(CreateSessionRequest(mode: mode, entityId: entityId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct GetChatSessionsRequest: APIRequest {
+        typealias Response = [IrisSessionDTO]
+
+        let courseId: Int
+
+        var method: HTTPMethod { .get }
+
+        var resourceName: String {
+            "api/iris/chat/\(courseId)/sessions/overview"
+        }
+    }
+
+    func getChatSessions(courseId: Int) async -> DataState<[IrisSessionDTO]> {
+        let result = await client.sendRequest(GetChatSessionsRequest(courseId: courseId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct GetChatSessionRequest: APIRequest {
+        typealias Response = IrisSession
+
+        let courseId: Int
+        let sessionId: Int64
+
+        var method: HTTPMethod { .get }
+
+        var resourceName: String {
+            "api/iris/chat/\(courseId)/session/\(sessionId)"
+        }
+    }
+
+    func getChatSession(courseId: Int, sessionId: Int64) async -> DataState<IrisSession> {
+        let result = await client.sendRequest(GetChatSessionRequest(courseId: courseId, sessionId: sessionId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct GetSessionAndMessageCountRequest: APIRequest {
+        typealias Response = IrisSessionCountDTO
+
+        var method: HTTPMethod { .get }
+
+        var resourceName: String {
+            "api/iris/chat/sessions/count"
+        }
+    }
+
+    func getSessionAndMessageCount() async -> DataState<IrisSessionCountDTO> {
+        let result = await client.sendRequest(GetSessionAndMessageCountRequest())
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct DeleteAllSessionsRequest: APIRequest {
+        typealias Response = RawResponse
+
+        var method: HTTPMethod { .delete }
+
+        var resourceName: String {
+            "api/iris/chat/sessions"
+        }
+    }
+
+    func deleteAllSessions() async -> NetworkResponse {
+        let result = await client.sendRequest(DeleteAllSessionsRequest())
+        switch result {
+        case .success:
+            return .success
+        case .failure(let error):
+            return .failure(error: error)
+        }
+    }
+
+    struct DeleteSessionRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let sessionId: Int64
+
+        var method: HTTPMethod { .delete }
+
+        var resourceName: String {
+            "api/iris/chat/sessions/\(sessionId)"
+        }
+    }
+
+    func deleteSession(sessionId: Int64) async -> NetworkResponse {
+        let result = await client.sendRequest(DeleteSessionRequest(sessionId: sessionId))
+        switch result {
+        case .success:
+            return .success
+        case .failure(let error):
+            return .failure(error: error)
+        }
+    }
+
+    // MARK: - Messages
+
+    struct GetMessagesRequest: APIRequest {
+        typealias Response = [IrisMessageResponseDTO]
+
+        let sessionId: Int64
+
+        var method: HTTPMethod { .get }
+
+        var resourceName: String {
+            "api/iris/sessions/\(sessionId)/messages"
+        }
+    }
+
+    func getMessages(sessionId: Int64) async -> DataState<[IrisMessageResponseDTO]> {
+        let result = await client.sendRequest(GetMessagesRequest(sessionId: sessionId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct SendMessageRequest: APIRequest {
+        typealias Response = IrisMessageResponseDTO
+
+        let sessionId: Int64
+        let messageRequest: IrisMessageRequestDTO
+
+        var method: HTTPMethod { .post }
+
+        var resourceName: String {
+            "api/iris/sessions/\(sessionId)/messages"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try messageRequest.encode(to: encoder)
+        }
+    }
+
+    func sendMessage(sessionId: Int64, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO> {
+        let result = await client.sendRequest(SendMessageRequest(sessionId: sessionId, messageRequest: request))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct ResendMessageRequest: APIRequest {
+        typealias Response = IrisMessageResponseDTO
+
+        let sessionId: Int64
+        let messageId: Int64
+
+        var method: HTTPMethod { .post }
+
+        var resourceName: String {
+            "api/iris/sessions/\(sessionId)/messages/\(messageId)/resend"
+        }
+    }
+
+    func resendMessage(sessionId: Int64, messageId: Int64) async -> DataState<IrisMessageResponseDTO> {
+        let result = await client.sendRequest(ResendMessageRequest(sessionId: sessionId, messageId: messageId))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+
+    struct RateMessageRequest: APIRequest {
+        typealias Response = IrisMessageResponseDTO
+
+        let sessionId: Int64
+        let messageId: Int64
+        let helpful: Bool
+
+        var method: HTTPMethod { .put }
+
+        var resourceName: String {
+            "api/iris/sessions/\(sessionId)/messages/\(messageId)/helpful"
+        }
+
+        /// Server expects the raw boolean as the request body, not an object wrapper.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(helpful)
+        }
+    }
+
+    func rateMessage(sessionId: Int64, messageId: Int64, helpful: Bool) async -> DataState<IrisMessageResponseDTO> {
+        let result = await client.sendRequest(RateMessageRequest(sessionId: sessionId, messageId: messageId, helpful: helpful))
+        switch result {
+        case .success(let response):
+            return .done(response: response.0)
+        case .failure(let error):
+            return .failure(error: UserFacingError(error: error))
+        }
+    }
+}

--- a/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
@@ -19,7 +19,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         typealias Response = IrisSession
 
         let mode: ChatServiceMode
-        let entityId: Int64
+        let entityId: Int
 
         var method: HTTPMethod { .post }
 
@@ -39,7 +39,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession> {
+    func getCurrentOrCreateSession(mode: ChatServiceMode, entityId: Int) async -> DataState<IrisSession> {
         let result = await client.sendRequest(GetCurrentSessionRequest(mode: mode, entityId: entityId))
         switch result {
         case .success(let response):
@@ -53,7 +53,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         typealias Response = IrisSession
 
         let mode: ChatServiceMode
-        let entityId: Int64
+        let entityId: Int
 
         var method: HTTPMethod { .post }
 
@@ -73,7 +73,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func createSession(mode: ChatServiceMode, entityId: Int64) async -> DataState<IrisSession> {
+    func createSession(mode: ChatServiceMode, entityId: Int) async -> DataState<IrisSession> {
         let result = await client.sendRequest(CreateSessionRequest(mode: mode, entityId: entityId))
         switch result {
         case .success(let response):
@@ -109,7 +109,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         typealias Response = IrisSession
 
         let courseId: Int
-        let sessionId: Int64
+        let sessionId: Int
 
         var method: HTTPMethod { .get }
 
@@ -118,7 +118,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func getChatSession(courseId: Int, sessionId: Int64) async -> DataState<IrisSession> {
+    func getChatSession(courseId: Int, sessionId: Int) async -> DataState<IrisSession> {
         let result = await client.sendRequest(GetChatSessionRequest(courseId: courseId, sessionId: sessionId))
         switch result {
         case .success(let response):
@@ -171,7 +171,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
     struct DeleteSessionRequest: APIRequest {
         typealias Response = RawResponse
 
-        let sessionId: Int64
+        let sessionId: Int
 
         var method: HTTPMethod { .delete }
 
@@ -180,7 +180,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func deleteSession(sessionId: Int64) async -> NetworkResponse {
+    func deleteSession(sessionId: Int) async -> NetworkResponse {
         let result = await client.sendRequest(DeleteSessionRequest(sessionId: sessionId))
         switch result {
         case .success:
@@ -195,7 +195,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
     struct GetMessagesRequest: APIRequest {
         typealias Response = [IrisMessageResponseDTO]
 
-        let sessionId: Int64
+        let sessionId: Int
 
         var method: HTTPMethod { .get }
 
@@ -204,7 +204,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func getMessages(sessionId: Int64) async -> DataState<[IrisMessageResponseDTO]> {
+    func getMessages(sessionId: Int) async -> DataState<[IrisMessageResponseDTO]> {
         let result = await client.sendRequest(GetMessagesRequest(sessionId: sessionId))
         switch result {
         case .success(let response):
@@ -217,7 +217,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
     struct SendMessageRequest: APIRequest {
         typealias Response = IrisMessageResponseDTO
 
-        let sessionId: Int64
+        let sessionId: Int
         let messageRequest: IrisMessageRequestDTO
 
         var method: HTTPMethod { .post }
@@ -231,7 +231,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func sendMessage(sessionId: Int64, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO> {
+    func sendMessage(sessionId: Int, request: IrisMessageRequestDTO) async -> DataState<IrisMessageResponseDTO> {
         let result = await client.sendRequest(SendMessageRequest(sessionId: sessionId, messageRequest: request))
         switch result {
         case .success(let response):
@@ -244,8 +244,8 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
     struct ResendMessageRequest: APIRequest {
         typealias Response = IrisMessageResponseDTO
 
-        let sessionId: Int64
-        let messageId: Int64
+        let sessionId: Int
+        let messageId: Int
 
         var method: HTTPMethod { .post }
 
@@ -254,7 +254,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func resendMessage(sessionId: Int64, messageId: Int64) async -> DataState<IrisMessageResponseDTO> {
+    func resendMessage(sessionId: Int, messageId: Int) async -> DataState<IrisMessageResponseDTO> {
         let result = await client.sendRequest(ResendMessageRequest(sessionId: sessionId, messageId: messageId))
         switch result {
         case .success(let response):
@@ -267,8 +267,8 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
     struct RateMessageRequest: APIRequest {
         typealias Response = IrisMessageResponseDTO
 
-        let sessionId: Int64
-        let messageId: Int64
+        let sessionId: Int
+        let messageId: Int
         let helpful: Bool
 
         var method: HTTPMethod { .put }
@@ -284,7 +284,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         }
     }
 
-    func rateMessage(sessionId: Int64, messageId: Int64, helpful: Bool) async -> DataState<IrisMessageResponseDTO> {
+    func rateMessage(sessionId: Int, messageId: Int, helpful: Bool) async -> DataState<IrisMessageResponseDTO> {
         let result = await client.sendRequest(RateMessageRequest(sessionId: sessionId, messageId: messageId, helpful: helpful))
         switch result {
         case .success(let response):

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
@@ -13,10 +13,10 @@ import Common
 /// STOMP subscription on `/user/topic/iris/{sessionId}`. Single-consumer:
 /// re-subscribing to the same session replaces the previous stream.
 /// Cleanup is explicit via ``unsubscribe(sessionId:)`` (or
-/// ``unsubscribeAll()`` on logout / user change).
+/// ``unsubscribeAll()`` whenever the course is closed).
 protocol IrisWebsocketService: Sendable {
-    func subscribe(sessionId: Int64) async -> AsyncStream<IrisChatWebsocketDTO>
-    func unsubscribe(sessionId: Int64) async
+    func subscribe(sessionId: Int) async -> AsyncStream<IrisChatWebsocketDTO>
+    func unsubscribe(sessionId: Int) async
     func unsubscribeAll() async
 }
 

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
@@ -1,0 +1,25 @@
+//
+//  IrisWebsocketService.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 19.05.26.
+//
+
+import Common
+
+/// Streams Iris WebSocket payloads for a given chat session.
+///
+/// One ``AsyncStream`` per ``subscribe(sessionId:)`` call, backed by a single
+/// STOMP subscription on `/user/topic/iris/{sessionId}`. Single-consumer:
+/// re-subscribing to the same session replaces the previous stream.
+/// Cleanup is explicit via ``unsubscribe(sessionId:)`` (or
+/// ``unsubscribeAll()`` on logout / user change).
+protocol IrisWebsocketService: Sendable {
+    func subscribe(sessionId: Int64) async -> AsyncStream<IrisChatWebsocketDTO>
+    func unsubscribe(sessionId: Int64) async
+    func unsubscribeAll() async
+}
+
+enum IrisWebsocketServiceFactory: DependencyFactory {
+    static let liveValue: IrisWebsocketService = IrisWebsocketServiceImpl()
+}

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
@@ -1,0 +1,56 @@
+//
+//  IrisWebsocketServiceImpl.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 19.05.26.
+//
+
+import APIClient
+import Common
+import Foundation
+
+/// Decodes Iris WebSocket payloads for a chat session into a typed stream.
+///
+/// Single-consumer: each ``subscribe(sessionId:)`` call replaces any
+/// existing subscription for that session. The decode pump runs on a
+/// detached task; cancelling it (via ``unsubscribe(sessionId:)`` or
+/// ``unsubscribeAll()``) drops the STOMP subscription downstream.
+actor IrisWebsocketServiceImpl: IrisWebsocketService {
+
+    private var sessions: [Int64: Task<Void, Never>] = [:]
+
+    func subscribe(sessionId: Int64) -> AsyncStream<IrisChatWebsocketDTO> {
+        sessions.removeValue(forKey: sessionId)?.cancel()
+
+        let (stream, continuation) = AsyncStream<IrisChatWebsocketDTO>.makeStream()
+        let topic = IrisWebsocketTopic.makeIrisChat(sessionId: sessionId)
+
+        let task = Task.detached {
+            let raw = ArtemisStompClient.shared.subscribe(to: topic)
+            for await message in raw {
+                guard let dto = JSONDecoder.getTypeFromSocketMessage(
+                    type: IrisChatWebsocketDTO.self,
+                    message: message
+                ) else {
+                    continue
+                }
+                continuation.yield(dto)
+            }
+            continuation.finish()
+        }
+        sessions[sessionId] = task
+
+        continuation.onTermination = { _ in task.cancel() }
+
+        return stream
+    }
+
+    func unsubscribe(sessionId: Int64) {
+        sessions.removeValue(forKey: sessionId)?.cancel()
+    }
+
+    func unsubscribeAll() {
+        sessions.values.forEach { $0.cancel() }
+        sessions.removeAll()
+    }
+}

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
@@ -17,9 +17,9 @@ import Foundation
 /// ``unsubscribeAll()``) drops the STOMP subscription downstream.
 actor IrisWebsocketServiceImpl: IrisWebsocketService {
 
-    private var sessions: [Int64: Task<Void, Never>] = [:]
+    private var sessions: [Int: Task<Void, Never>] = [:]
 
-    func subscribe(sessionId: Int64) -> AsyncStream<IrisChatWebsocketDTO> {
+    func subscribe(sessionId: Int) -> AsyncStream<IrisChatWebsocketDTO> {
         sessions.removeValue(forKey: sessionId)?.cancel()
 
         let (stream, continuation) = AsyncStream<IrisChatWebsocketDTO>.makeStream()
@@ -28,6 +28,7 @@ actor IrisWebsocketServiceImpl: IrisWebsocketService {
         let task = Task.detached {
             let raw = ArtemisStompClient.shared.subscribe(to: topic)
             for await message in raw {
+                if Task.isCancelled { break }
                 guard let dto = JSONDecoder.getTypeFromSocketMessage(
                     type: IrisChatWebsocketDTO.self,
                     message: message
@@ -45,7 +46,7 @@ actor IrisWebsocketServiceImpl: IrisWebsocketService {
         return stream
     }
 
-    func unsubscribe(sessionId: Int64) {
+    func unsubscribe(sessionId: Int) {
         sessions.removeValue(forKey: sessionId)?.cancel()
     }
 

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketTopic.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketTopic.swift
@@ -6,7 +6,7 @@
 //
 
 enum IrisWebsocketTopic {
-    static func makeIrisChat(sessionId: Int64) -> String {
+    static func makeIrisChat(sessionId: Int) -> String {
         "/user/topic/iris/\(sessionId)"
     }
 }

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketTopic.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketTopic.swift
@@ -1,0 +1,12 @@
+//
+//  IrisWebsocketTopic.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 19.05.26.
+//
+
+enum IrisWebsocketTopic {
+    static func makeIrisChat(sessionId: Int64) -> String {
+        "/user/topic/iris/\(sessionId)"
+    }
+}


### PR DESCRIPTION
- Added new `IrisWebsocketService` streaming Iris payloads per session via STOMP (`/user/topic/iris/{sessionId}`), one `AsyncStream` per subscription with explicit cleanup
- Added new `IrisChatHttpService` mirroring the webclients `iris-chat-http.service.ts`
- 11 endpoints: session lifecycle (current/create/list/get/count/delete) + message CRUD (get/send/resend/rate)
- No callers yet - will be wired up in follow-ups
- Tutor-Suggestion & MCQ endpoints intentionally deferred -> Will be added when corresponding features get added