### PR TITLE
`Calendar`: Improve spacing for small widget on iPad Lock Screen

### DIFF
--- a/ArtemisKit/Sources/Calendar/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Calendar/Resources/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "failedLoading" = "Artemis failed to load events";
 "failedLoadingShort" = "Failed to load";
 "noUpcomingEvents" = "No upcoming events in the next month.\nEnjoy your free time!";
+"noUpcomingEventsShort" = "No upcoming events.\nEnjoy your time!";
 
 "dueSoon" = "Due Soon";
 "nextLecture" = "Next Lecture";

--- a/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/HomeScreenWidgetView.swift
@@ -27,7 +27,7 @@ public struct HomeScreenWidgetView: View {
             ContentUnavailableView(isSmall ? i18n.failedLoadingShort() : i18n.failedLoading(),
                                    systemImage: "antenna.radiowaves.left.and.right.slash")
         } else if upcomingEvents.isEmpty {
-            Text(R.string.localizable.noUpcomingEvents())
+            Text(isSmall ? i18n.noUpcomingEventsShort() : i18n.noUpcomingEvents())
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         } else {

--- a/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
+++ b/ArtemisKit/Sources/Calendar/Views/SmallWidgetView.swift
@@ -7,8 +7,11 @@
 
 import SharedModels
 import SwiftUI
+import WidgetKit
 
 struct SmallWidgetView: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
     let events: [DTO.CalendarEvent]
 
     var nextEvent: DTO.CalendarEvent? {
@@ -26,7 +29,8 @@ struct SmallWidgetView: View {
                 }
             }
         }
-        .padding()
+        // No padding needed on the iPad Lock Screen
+        .padding(renderingMode == .vibrant ? .s : .m)
         .containerRelativeFrame([.vertical, .horizontal], alignment: .topLeading)
     }
 }

--- a/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
+++ b/ArtemisKit/Sources/Calendar/Widget/CalendarTimelineProvider.swift
@@ -40,6 +40,10 @@ public struct CalendarTimelineProvider: AppIntentTimelineProvider {
 
     public func timeline(for configuration: CalendarCourseConfigurationIntent,
                          in context: Context) async -> Timeline<CalendarWidgetEntry> {
+        if context.isPreview {
+            return await Timeline(entries: [snapshot(for: configuration, in: context)],
+                                  policy: .never)
+        }
 
         guard let courseId = configuration.course?.id else {
             return Timeline(entries: [


### PR DESCRIPTION
On the iPad Lock Screen, widgets use less padding around the outside. Thus the widget looked a bit out of place.

We also shorten the text when no events are scheduled to look cleaner.