### PR TITLE
`Quiz`: Fix scaling of drop locations for D&D questions

### DIFF
--- a/ArtemisKit/Sources/CourseView/Services/ExerciseService/ProblemStatementService.swift
+++ b/ArtemisKit/Sources/CourseView/Services/ExerciseService/ProblemStatementService.swift
@@ -5,10 +5,8 @@
 //  Created by Anian Schleyer on 07.04.26.
 //
 
-import Foundation
-
-import Foundation
 import Common
+import Foundation
 import SharedModels
 
 protocol ProblemStatementService {

--- a/ArtemisKit/Sources/Quiz/Views/Leaderboard/LeaderboardView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Leaderboard/LeaderboardView.swift
@@ -11,7 +11,7 @@ import SharedModels
 import SwiftUI
 
 struct LeaderboardView: View {
-    
+
     @Bindable var viewModel: LeaderboardViewModel
 
     var body: some View {

--- a/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
@@ -152,9 +152,3 @@ struct DropLocation: View {
         selected = false
     }
 }
-
-/// 1536 x 1024
-///
-/// Scaled to 804 x 335
-///
-/// Pos1: 104, 30 -> 55, 10

--- a/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
@@ -15,8 +15,6 @@ extension DTO.QuizQuestionWithSolution: WithImage {}
 struct DNDQuestionView: View {
     let question: DTO.QuizQuestionTraining
 
-    @State private var imageSize: CGSize?
-
     @State private var mappings: [DTO.DragAndDropMappingFromLiveClient]
 
     var backgroundImage: URL? {
@@ -36,16 +34,13 @@ struct DNDQuestionView: View {
                 .padding(.horizontal)
         }
 
-        ArtemisAsyncImage(imageURL: backgroundImage) { _ in
-        } onSuccess: { img in
-            imageSize = img.image.size
-        } errorPlaceholder: {
+        ArtemisAsyncImage(imageURL: backgroundImage) {
             Text("Failed to load image :/")
         }
         .scaledToFit()
         .containerRelativeFrame(.horizontal)
         .overlay {
-            DNDDropLocations(mappings: $mappings, question: question.quizQuestionWithSolutionDTO, imageSize: imageSize)
+            DNDDropLocations(mappings: $mappings, question: question.quizQuestionWithSolutionDTO)
         }
 
         Text(R.string.localizable.dndInfo())
@@ -67,24 +62,16 @@ struct DNDDropLocations: View {
     @Binding var mappings: [DTO.DragAndDropMappingFromLiveClient]
 
     let question: DTO.QuizQuestionWithSolution
-    let imageSize: CGSize?
 
     var body: some View {
-        if let imageSize,
-           let dropLocations = question.dropLocations,
+        if let dropLocations = question.dropLocations,
            let dragItems = question.dragItems {
             GeometryReader { geo in
-                let width = geo.size.width * 2 // Web app also has the factor of two
-                let height = geo.size.height * 1.25 // Don't ask.
-
-                let scaleX = imageSize.width / width
-                let scaleY = imageSize.height / height
-
                 ForEach(dropLocations, id: \.id) { location in
                     DropLocation(dragItems: dragItems,
                                  location: location,
-                                 scaleX: scaleX,
-                                 scaleY: scaleY,
+                                 scaleX: geo.size.width,
+                                 scaleY: geo.size.height,
                                  mappings: $mappings)
                 }
             }
@@ -102,10 +89,11 @@ struct DropLocation: View {
     @Binding var mappings: [DTO.DragAndDropMappingFromLiveClient]
 
     var body: some View {
-        let startX = (location.posX ?? 0) / scaleX
-        let startY = (location.posY ?? 0) / scaleY
-        let width = (location.width ?? 0) / scaleX
-        let height = (location.height ?? 0) / scaleY
+        // Positions are scaled from 0...200
+        let startX = (location.posX ?? 0) / 200 * scaleX
+        let startY = (location.posY ?? 0) / 200 * scaleY
+        let width = (location.width ?? 0) / 200 * scaleX
+        let height = (location.height ?? 0) / 200 * scaleY
 
         Button {
             if mappings.first(where: { $0.dropLocation?.id == location.id })?.dragItem?.id == nil {
@@ -164,3 +152,9 @@ struct DropLocation: View {
         selected = false
     }
 }
+
+/// 1536 x 1024
+///
+/// Scaled to 804 x 335
+///
+/// Pos1: 104, 30 -> 55, 10


### PR DESCRIPTION
Drag and drop questions work differently than I thought, and my example worked by coincidence. Positions are scaled between 0…200, and not the image resolution. This PR fixes this so that drop locations are now positioned correctly for all images.