### PR TITLE
`Iris`: Add message action bar

### DIFF
--- a/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,7 @@
 "thinking" = "Thinking…";
 "emptyChatTitle" = "How can I help you today?";
 "askIrisPlaceholder" = "Ask Iris...";
+"irisDisclaimer" = "Iris can make mistakes. Consider checking important information.";
 
 // MARK: IrisChatView – Message actions
 "copyText" = "Copy";

--- a/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
@@ -18,3 +18,9 @@
 "thinking" = "Thinking…";
 "emptyChatTitle" = "How can I help you today?";
 "askIrisPlaceholder" = "Ask Iris...";
+
+// MARK: IrisChatView – Message actions
+"copyText" = "Copy";
+"shareMessage" = "Share";
+"rateHelpful" = "Helpful";
+"rateUnhelpful" = "Not helpful";

--- a/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
@@ -24,3 +24,4 @@
 "shareMessage" = "Share";
 "rateHelpful" = "Helpful";
 "rateUnhelpful" = "Not helpful";
+"scrollToBottom" = "Scroll to latest message";

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
@@ -100,6 +100,22 @@ final class IrisChatViewModel {
         }
     }
 
+    func rateMessage(messageId: Int, helpful: Bool) {
+        Task { [weak self] in
+            guard let self else { return }
+            let result = await httpService.rateMessage(
+                sessionId: sessionPath.sessionId, messageId: messageId, helpful: helpful)
+            switch result {
+            case .done(let response):
+                upsert(message: response)
+            case .failure(let error):
+                self.error = error
+            case .loading:
+                break
+            }
+        }
+    }
+
     func deleteSession() async -> Bool {
         let result = await httpService.deleteSession(sessionId: sessionPath.sessionId)
         switch result {

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -242,10 +242,10 @@ private struct ScrollToBottomButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: "chevron.down")
-                .font(.callout.weight(.semibold))
+            Image(systemName: "arrow.down")
+                .font(.title3.weight(.semibold))
                 .foregroundStyle(.primary)
-                .padding(.m)
+                .padding(.m + .s)
                 .background(.regularMaterial, in: .circle)
                 .overlay(Circle().stroke(Color.primary.opacity(0.1)))
                 .shadow(color: .black.opacity(0.15), radius: 4, y: 2)

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -49,6 +49,7 @@ struct IrisChatView: View {
                                         .id("loadingStageRow")
                                 } else if messages.last?.sender == .llm {
                                     DisclaimerView()
+                                        .id("disclaimer")
                                 }
                             }
                             .padding(.l)
@@ -78,8 +79,14 @@ struct IrisChatView: View {
                     .overlay(alignment: .bottom) {
                         if showScrollToBottom {
                             ScrollToBottomButton {
-                                if let id = messages.last?.id {
-                                    withAnimation { proxy.scrollTo(id, anchor: .bottom) }
+                                withAnimation {
+                                    if viewModel.isAwaitingResponse {
+                                        proxy.scrollTo("loadingStageRow", anchor: .bottom)
+                                    } else if messages.last?.sender == .llm {
+                                        proxy.scrollTo("disclaimer", anchor: .bottom)
+                                    } else if let id = messages.last?.id {
+                                        proxy.scrollTo(id, anchor: .bottom)
+                                    }
                                 }
                             }
                             .padding(.bottom, .m)

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -47,6 +47,8 @@ struct IrisChatView: View {
                                 if viewModel.isAwaitingResponse {
                                     LoadingStageRow(stage: viewModel.currentStage)
                                         .id("loadingStageRow")
+                                } else if messages.last?.sender == .llm {
+                                    DisclaimerView()
                                 }
                             }
                             .padding(.l)
@@ -222,6 +224,16 @@ private struct IrisMessageActionBar: View {
         .foregroundStyle(.secondary)
         .buttonStyle(.plain)
         .padding(.top, .s)
+    }
+}
+
+private struct DisclaimerView: View {
+    var body: some View {
+        Text(R.string.localizable.irisDisclaimer())
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.top, .s)
     }
 }
 

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -14,6 +14,7 @@ struct IrisChatView: View {
     @State private var viewModel: IrisChatViewModel
     @State private var showDeleteConfirmation = false
     @State private var bottomSpacerShown = false
+    @State private var showScrollToBottom = false
     @FocusState private var isInputFocused: Bool
 
     private let onDeleted: () -> Void
@@ -55,6 +56,14 @@ struct IrisChatView: View {
                         }
                     }
                     .defaultScrollAnchor(.bottom)
+                    .onScrollGeometryChange(for: Bool.self) { geometry in
+                        let distanceFromBottom = geometry.contentSize.height
+                            - geometry.contentOffset.y
+                            - geometry.containerSize.height
+                        return distanceFromBottom > 120
+                    } action: { _, isAway in
+                        withAnimation(.easeInOut(duration: 0.2)) { showScrollToBottom = isAway }
+                    }
                     .onChange(of: messages.count) {
                         guard let last = messages.last, last.sender == .user else { return }
                         bottomSpacerShown = true
@@ -62,6 +71,17 @@ struct IrisChatView: View {
                             withAnimation {
                                 proxy.scrollTo(last.id, anchor: .top)
                             }
+                        }
+                    }
+                    .overlay(alignment: .bottom) {
+                        if showScrollToBottom {
+                            ScrollToBottomButton {
+                                if let id = messages.last?.id {
+                                    withAnimation { proxy.scrollTo(id, anchor: .bottom) }
+                                }
+                            }
+                            .padding(.bottom, .m)
+                            .transition(.opacity.combined(with: .scale))
                         }
                     }
                 }
@@ -202,6 +222,23 @@ private struct IrisMessageActionBar: View {
         .foregroundStyle(.secondary)
         .buttonStyle(.plain)
         .padding(.top, .s)
+    }
+}
+
+private struct ScrollToBottomButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "chevron.down")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.primary)
+                .padding(.m)
+                .background(.regularMaterial, in: .circle)
+                .overlay(Circle().stroke(Color.primary.opacity(0.1)))
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+        }
+        .accessibilityLabel(R.string.localizable.scrollToBottom())
     }
 }
 

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -8,6 +8,7 @@
 import ArtemisMarkdown
 import DesignLibrary
 import SwiftUI
+import UIKit
 
 struct IrisChatView: View {
     @State private var viewModel: IrisChatViewModel
@@ -39,7 +40,7 @@ struct IrisChatView: View {
                         } else {
                             LazyVStack(alignment: .leading, spacing: .m) {
                                 ForEach(messages) { message in
-                                    MessageRow(message: message)
+                                    MessageRow(message: message, viewModel: viewModel)
                                         .id(message.id)
                                 }
                                 if viewModel.isAwaitingResponse {
@@ -114,6 +115,7 @@ struct IrisChatView: View {
 
 private struct MessageRow: View {
     let message: IrisMessageResponseDTO
+    let viewModel: IrisChatViewModel
 
     private var isUser: Bool {
         message.sender == .user
@@ -144,9 +146,62 @@ private struct MessageRow: View {
                             .foregroundStyle(.primary)
                     }
                 }
+                if message.id != nil {
+                    IrisMessageActionBar(message: message, viewModel: viewModel)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+}
+
+private struct IrisMessageActionBar: View {
+    let message: IrisMessageResponseDTO
+    let viewModel: IrisChatViewModel
+    @State private var didCopy = false
+
+    private var plainText: String {
+        message.content.compactMap(\.textContent).joined(separator: "\n\n")
+    }
+
+    var body: some View {
+        HStack(spacing: .l) {
+            Button {
+                UIPasteboard.general.string = plainText
+                didCopy = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { didCopy = false }
+            } label: {
+                Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+            }
+            .accessibilityLabel(R.string.localizable.copyText())
+
+            ShareLink(item: plainText) {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .accessibilityLabel(R.string.localizable.shareMessage())
+
+            Button {
+                if message.helpful != true, let id = message.id {
+                    viewModel.rateMessage(messageId: id, helpful: true)
+                }
+            } label: {
+                Image(systemName: message.helpful == true ? "hand.thumbsup.fill" : "hand.thumbsup")
+            }
+            .accessibilityLabel(R.string.localizable.rateHelpful())
+
+            Button {
+                if message.helpful != false, let id = message.id {
+                    viewModel.rateMessage(messageId: id, helpful: false)
+                }
+            } label: {
+                Image(systemName: message.helpful == false ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+            }
+            .accessibilityLabel(R.string.localizable.rateUnhelpful())
+        }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .buttonStyle(.plain)
+        .padding(.top, .s)
     }
 }
 

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -195,37 +195,34 @@ private struct IrisMessageActionBar: View {
 
     var body: some View {
         HStack(spacing: .l) {
-            Button {
+            Button(R.string.localizable.copyText(),
+                   systemImage: didCopy ? "checkmark" : "doc.on.doc") {
                 UIPasteboard.general.string = plainText
                 didCopy = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) { didCopy = false }
-            } label: {
-                Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
             }
-            .accessibilityLabel(R.string.localizable.copyText())
+            .labelStyle(.iconOnly)
 
             ShareLink(item: plainText) {
-                Image(systemName: "square.and.arrow.up")
+                Label(R.string.localizable.shareMessage(), systemImage: "square.and.arrow.up")
             }
-            .accessibilityLabel(R.string.localizable.shareMessage())
+            .labelStyle(.iconOnly)
 
-            Button {
+            Button(R.string.localizable.rateHelpful(),
+                   systemImage: message.helpful == true ? "hand.thumbsup.fill" : "hand.thumbsup") {
                 if message.helpful != true, let id = message.id {
                     viewModel.rateMessage(messageId: id, helpful: true)
                 }
-            } label: {
-                Image(systemName: message.helpful == true ? "hand.thumbsup.fill" : "hand.thumbsup")
             }
-            .accessibilityLabel(R.string.localizable.rateHelpful())
+            .labelStyle(.iconOnly)
 
-            Button {
+            Button(R.string.localizable.rateUnhelpful(),
+                   systemImage: message.helpful == false ? "hand.thumbsdown.fill" : "hand.thumbsdown") {
                 if message.helpful != false, let id = message.id {
                     viewModel.rateMessage(messageId: id, helpful: false)
                 }
-            } label: {
-                Image(systemName: message.helpful == false ? "hand.thumbsdown.fill" : "hand.thumbsdown")
             }
-            .accessibilityLabel(R.string.localizable.rateUnhelpful())
+            .labelStyle(.iconOnly)
         }
         .font(.callout)
         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

- Add `IrisMessageActionBar` to each LLM message in `IrisChatView`, showing action buttons below every Iris response
  - **Copy**: Copies the plain text of the message to the clipboard, with a brief checkmark confirmation
  - **Share**: Opens the system share sheet for the message content
  - **Thumbs up / Thumbs down**: Rates the message as helpful or not helpful; icons switch to filled variants to reflect the current rating
- Add `rateMessage(messageId:helpful:)` method to `IrisChatViewModel` that calls the existing HTTP service and upserts the updated message into the local state
- Add `DisclaimerView` shown below the last Iris message ("Iris can make mistakes. Consider checking important information.")
- Add `ScrollToBottomButton` that appears with a fade+scale animation when the user scrolls more than 120 pt away from the bottom; tapping it scrolls to the latest message, loading indicator, or disclaimer depending on the current chat state
- Add localized strings for all new UI elements (`copyText`, `shareMessage`, `rateHelpful`, `rateUnhelpful`, `scrollToBottom`, `irisDisclaimer`)

<img width="300" alt="IMG_9584" src="https://github.com/user-attachments/assets/89034a79-561f-45c7-9870-26e7f0c63805" />

<img width="300" alt="Screenshot 2026-06-08 at 04 48 42" src="https://github.com/user-attachments/assets/5b804bfe-200e-4c81-b630-2ecd09267b74" />
