### PR TITLE
`Iris`: Recover reply missed while app was in the background

### DIFF
--- a/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
@@ -68,6 +68,18 @@ final class IrisChatViewModel {
         }
     }
 
+    /// Silent catch-up refresh for returning from the background, where a reply
+    /// published over the STOMP topic while we were disconnected is otherwise
+    /// lost (topics aren't replayed on reconnect). Unlike `loadMessages`, it
+    /// never overwrites loaded messages with a `.loading`/`.failure` state — a
+    /// flaky network on resume must not wipe the visible chat. The server list
+    /// is authoritative; the live stream dedupes via `upsert`.
+    func refreshMessages() async {
+        if case .done(let response) = await httpService.getMessages(sessionId: sessionPath.sessionId) {
+            messages = .done(response: response)
+        }
+    }
+
     func subscribeToWebsocket() async {
         let stream = await IrisWebsocketServiceFactory.shared.subscribe(sessionId: sessionPath.sessionId)
         websocketTask = Task { [weak self] in

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -16,6 +16,7 @@ struct IrisChatView: View {
     @State private var bottomSpacerShown = false
     @State private var showScrollToBottom = false
     @FocusState private var isInputFocused: Bool
+    @Environment(\.scenePhase) private var scenePhase
 
     private let onDeleted: () -> Void
     private let onTitleChange: (String) -> Void
@@ -131,6 +132,16 @@ struct IrisChatView: View {
         }
         .task { await viewModel.loadMessages() }
         .task { await viewModel.subscribeToWebsocket() }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Iris' reply arrives only once over the STOMP topic, which iOS tears
+            // down on backgrounding. STOMP doesn't replay messages published while
+            // we were disconnected, so a reply that lands in the background never
+            // reaches the live stream. Re-fetch the persisted messages on return to
+            // the foreground to catch up (upsert dedupes against the live stream).
+            if newPhase == .active {
+                Task { await viewModel.refreshMessages() }
+            }
+        }
         .onChange(of: viewModel.sessionTitle) { _, newTitle in
             if let newTitle { onTitleChange(newTitle) }
         }


### PR DESCRIPTION
**Problem**

When the app is backgrounded while waiting for an Iris reply, the incoming response never shows up after returning to the foreground. The loading indicator spins indefinitely.

**Root cause**
  
The Iris reply is delivered only once over the STOMP topic. iOS tears down the WebSocket on backgrounding, and STOMP topics aren't replayed on reconnect — so a reply published while we're disconnected is lost on the live stream, even though it's persisted on the server.

**Fix**

Re-fetch the persisted messages when the chat returns to the foreground (`scenePhase == .active`), mirroring the existing `RootView` pattern. The refresh is non-destructive: it only applies on success, so a flaky network on resume can't wipe the visible chat with an error state. The live stream continues to dedupe via `upsert`.