### PR TITLE
`Iris`: Show iris tab when iris is enabled for the course

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "890c5cf33ce71fe3add567e372d050bc71c9714d1966e94362fbfc15abd390a8",
+  "originHash" : "e7ce8ae4b8cfabab370392383535a0e3b6f09c272cfabdb398a3b80ef52f17a2",
   "pins" : [
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "72696a4",
-        "revision" : "72696a4d4ee321177f095fe880f6dbe07c059994"
+        "branch" : "c309992",
+        "revision" : "c309992471b693556b4e6d3913bac7f93d61efb0"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
 //        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "72696a4"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "c309992"),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -15,10 +15,6 @@ public struct CourseView: View {
     @StateObject private var viewModel: CourseViewModel
     @FeatureAvailability(.globalSearch) private var searchEnabled
 
-    // TODO: Replace with @FeatureAvailability(.iris) once the Feature enum in
-    // artemis-ios-core-modules exposes the MODULE_FEATURE_IRIS case.
-    private var irisEnabled = false
-
     private let courseId: Int
 
     public var body: some View {
@@ -68,7 +64,7 @@ public struct CourseView: View {
                 }
             }
 
-            if irisEnabled {
+            if viewModel.course.irisEnabledInCourse == true {
                 Tab("Iris", systemImage: "eyes", value: TabIdentifier.iris) {
                     TabBarIpad {
                         IrisSessionListView(courseId: viewModel.course.id)

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -45,7 +45,7 @@ public struct CourseView: View {
                 }
             }
 
-            if (viewModel.course.numberOfAcceptedFaqs ?? 0) > 0 {
+            if ((viewModel.course.numberOfAcceptedFaqs ?? 0) > 0) && viewModel.course.irisEnabledInCourse == false {
                 Tab(R.string.localizable.faqTabLabel(),
                     systemImage: "questionmark.circle",
                     value: TabIdentifier.faq) {


### PR DESCRIPTION
- Only show the Iris tab if Iris is enabled in `viewModel.course.irisEnabledInCourse`
- Only show the FAQ tab if Iris is disabled to have the space for the search -> Temporary as FAQ's will be included in the exercise & lecture tabs in the future  