### PR TITLE
`Iris`: Add menu items to iris chat view

### DIFF
--- a/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
@@ -26,3 +26,27 @@
 "rateHelpful" = "Helpful";
 "rateUnhelpful" = "Not helpful";
 "scrollToBottom" = "Scroll to latest message";
+
+// MARK: IrisChatView – About Iris
+"aboutIris" = "About Iris";
+"close" = "Close";
+"aboutIrisMeetIris" = "Meet Iris";
+"aboutIrisSubtitle" = "Your AI tutor, built right into Artemis.";
+"aboutIrisDescription" = "As part of the EduTelligence suite of AI features in Artemis, Iris helps with course-related programming questions and lecture content using your current context.";
+"aboutIrisWhatIrisCanDo" = "What Iris can do";
+"aboutIrisWhatToExpect" = "What to expect from Iris";
+"aboutIrisContextAwareTitle" = "Context-aware";
+"aboutIrisContextAwareDescription" = "Iris can reference your problem statement, code, and build results, no copy-pasting needed.";
+"aboutIrisGuidedLearningTitle" = "Guided learning";
+"aboutIrisGuidedLearningDescription" = "Iris provides hints and explanations to help you solve problems independently.";
+"aboutIrisFeedbackHelpsTitle" = "Feedback helps";
+"aboutIrisFeedbackHelpsDescription" = "Rate answers and conversations to improve Iris' quality over time.";
+"aboutIrisGuideNotSolveTitle" = "Guide, not solve";
+"aboutIrisGuideNotSolveDescription" = "Iris does not provide complete solutions. It supports your problem-solving process.";
+"aboutIrisStayOnTopicTitle" = "Stay on topic";
+"aboutIrisStayOnTopicDescription" = "Iris answers questions about course content and programming topics only. It does not handle off-topic requests or organizational information.";
+"aboutIrisOwnYourWorkTitle" = "Own your work";
+"aboutIrisOwnYourWorkDescription" = "Use Iris as a learning aid, while maintaining academic integrity. Your submissions must reflect your own understanding and effort.";
+"aboutIrisPrivacyTitle" = "Privacy";
+"aboutIrisPrivacyDescription" = "Iris processes interactions within European data centers. Data handling follows applicable European data protection requirements.";
+"aboutIrisPrivacyDisclaimer" = "Review your institution's privacy policy for details.";

--- a/ArtemisKit/Sources/Iris/Views/AboutIrisView.swift
+++ b/ArtemisKit/Sources/Iris/Views/AboutIrisView.swift
@@ -1,0 +1,167 @@
+//
+//  AboutIrisView.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 13.06.26.
+//
+
+import DesignLibrary
+import SwiftUI
+
+/// Native counterpart to the web client's "About Iris" modal.
+struct AboutIrisView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: .l) {
+                    header
+                    Divider()
+                    section(title: R.string.localizable.aboutIrisWhatIrisCanDo(),
+                            cards: FeatureCard.whatIrisCanDo)
+                    Divider()
+                    section(title: R.string.localizable.aboutIrisWhatToExpect(),
+                            cards: FeatureCard.whatToExpect)
+                    Divider()
+                    section(cards: FeatureCard.privacy)
+                }
+                .padding(.l)
+            }
+            .navigationTitle(R.string.localizable.aboutIris())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(R.string.localizable.close()) { dismiss() }
+                }
+            }
+        }
+        .presentationDragIndicator(.visible)
+    }
+
+    private var header: some View {
+        VStack(spacing: .m) {
+            Image("iris-colored", bundle: .module)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 72, height: 72)
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+            VStack(spacing: .s) {
+                Text(R.string.localizable.aboutIrisMeetIris())
+                    .font(.title2.bold())
+                Text(R.string.localizable.aboutIrisSubtitle())
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(R.string.localizable.aboutIrisDescription())
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func section(title: String? = nil, cards: [FeatureCard]) -> some View {
+        VStack(alignment: .leading, spacing: .l) {
+            if let title {
+                Text(title)
+                    .font(.headline)
+            }
+            ForEach(cards) { card in
+                FeatureCardRow(card: card)
+            }
+        }
+    }
+}
+
+private struct FeatureCard: Identifiable {
+    let title: String
+    let description: String
+    let footNote: String?
+    let systemName: String
+    let tint: Color
+
+    var id: String { title }
+    
+    init(title: String, description: String, footNote: String? = nil, systemName: String, tint: Color) {
+        self.title = title
+        self.description = description
+        self.footNote = footNote
+        self.systemName = systemName
+        self.tint = tint
+    }
+}
+
+private extension FeatureCard {
+    static var whatIrisCanDo: [FeatureCard] {
+        [
+            FeatureCard(title: R.string.localizable.aboutIrisContextAwareTitle(),
+                        description: R.string.localizable.aboutIrisContextAwareDescription(),
+                        systemName: "brain", tint: Color.Artemis.artemisBlue),
+            FeatureCard(title: R.string.localizable.aboutIrisGuidedLearningTitle(),
+                        description: R.string.localizable.aboutIrisGuidedLearningDescription(),
+                        systemName: "lightbulb", tint: Color.Artemis.artemisBlue),
+            FeatureCard(title: R.string.localizable.aboutIrisFeedbackHelpsTitle(),
+                        description: R.string.localizable.aboutIrisFeedbackHelpsDescription(),
+                        systemName: "hand.thumbsup", tint: Color.Artemis.artemisBlue)
+        ]
+    }
+
+    static var whatToExpect: [FeatureCard] {
+        [
+            FeatureCard(title: R.string.localizable.aboutIrisGuideNotSolveTitle(),
+                        description: R.string.localizable.aboutIrisGuideNotSolveDescription(),
+                        systemName: "safari", tint: .indigo),
+            FeatureCard(title: R.string.localizable.aboutIrisStayOnTopicTitle(),
+                        description: R.string.localizable.aboutIrisStayOnTopicDescription(),
+                        systemName: "book", tint: .indigo),
+            FeatureCard(title: R.string.localizable.aboutIrisOwnYourWorkTitle(),
+                        description: R.string.localizable.aboutIrisOwnYourWorkDescription(),
+                        systemName: "person", tint: .indigo)
+        ]
+    }
+
+    static var privacy: [FeatureCard] {
+        [
+            FeatureCard(title: R.string.localizable.aboutIrisPrivacyTitle(),
+                        description: R.string.localizable.aboutIrisPrivacyDescription(),
+                        footNote: R.string.localizable.aboutIrisPrivacyDisclaimer(),
+                        systemName: "lock.shield", tint: .green)
+        ]
+    }
+}
+
+private struct FeatureCardRow: View {
+    let card: FeatureCard
+
+    var body: some View {
+        HStack(alignment: .top, spacing: .m) {
+            IconBadge(systemName: card.systemName, tint: card.tint)
+            VStack(alignment: .leading, spacing: .xs) {
+                Text(card.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(card.description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                if let footNote = card.footNote {
+                    Text(footNote)
+                        .font(.footnote)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+}
+
+private struct IconBadge: View {
+    let systemName: String
+    let tint: Color
+
+    var body: some View {
+        Image(systemName: systemName)
+            .font(.headline)
+            .foregroundStyle(tint)
+            .frame(width: 36, height: 36)
+            .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 9))
+    }
+}

--- a/ArtemisKit/Sources/Iris/Views/AboutIrisView.swift
+++ b/ArtemisKit/Sources/Iris/Views/AboutIrisView.swift
@@ -36,7 +36,6 @@ struct AboutIrisView: View {
                 }
             }
         }
-        .presentationDragIndicator(.visible)
     }
 
     private var header: some View {

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -19,15 +19,18 @@ struct IrisChatView: View {
     @FocusState private var isInputFocused: Bool
     @Environment(\.scenePhase) private var scenePhase
 
+    private let isCreatingSession: Bool
     private let onNewChat: () -> Void
     private let onDeleted: () -> Void
     private let onTitleChange: (String) -> Void
 
     init(sessionPath: IrisSessionPath,
+         isCreatingSession: Bool = false,
          onNewChat: @escaping () -> Void = {},
          onDeleted: @escaping () -> Void = {},
          onTitleChange: @escaping (String) -> Void = { _ in }) {
         _viewModel = State(wrappedValue: IrisChatViewModel(sessionPath: sessionPath))
+        self.isCreatingSession = isCreatingSession
         self.onNewChat = onNewChat
         self.onDeleted = onDeleted
         self.onTitleChange = onTitleChange
@@ -115,6 +118,7 @@ struct IrisChatView: View {
                     } label: {
                         Label(R.string.localizable.newChat(), systemImage: "square.and.pencil")
                     }
+                    .disabled(isCreatingSession)
 
                     Button {
                         showAboutIris = true
@@ -130,7 +134,11 @@ struct IrisChatView: View {
                         Label(R.string.localizable.deleteChat(), systemImage: "trash")
                     }
                 } label: {
-                    Image(systemName: "ellipsis.circle")
+                    if isCreatingSession {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "ellipsis.circle")
+                    }
                 }
                 .confirmationDialog(
                     R.string.localizable.deleteChatConfirmationMessage(),

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -156,7 +156,6 @@ struct IrisChatView: View {
                 }
                 .sheet(isPresented: $showAboutIris) {
                     AboutIrisView()
-                        .presentationDragIndicator(.hidden)
                 }
             }
         }

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -13,18 +13,22 @@ import UIKit
 struct IrisChatView: View {
     @State private var viewModel: IrisChatViewModel
     @State private var showDeleteConfirmation = false
+    @State private var showAboutIris = false
     @State private var bottomSpacerShown = false
     @State private var showScrollToBottom = false
     @FocusState private var isInputFocused: Bool
     @Environment(\.scenePhase) private var scenePhase
 
+    private let onNewChat: () -> Void
     private let onDeleted: () -> Void
     private let onTitleChange: (String) -> Void
 
     init(sessionPath: IrisSessionPath,
+         onNewChat: @escaping () -> Void = {},
          onDeleted: @escaping () -> Void = {},
          onTitleChange: @escaping (String) -> Void = { _ in }) {
         _viewModel = State(wrappedValue: IrisChatViewModel(sessionPath: sessionPath))
+        self.onNewChat = onNewChat
         self.onDeleted = onDeleted
         self.onTitleChange = onTitleChange
     }
@@ -106,6 +110,20 @@ struct IrisChatView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
+                    Button {
+                        onNewChat()
+                    } label: {
+                        Label(R.string.localizable.newChat(), systemImage: "square.and.pencil")
+                    }
+
+                    Button {
+                        showAboutIris = true
+                    } label: {
+                        Label(R.string.localizable.aboutIris(), systemImage: "info.circle")
+                    }
+
+                    Divider()
+
                     Button(role: .destructive) {
                         showDeleteConfirmation = true
                     } label: {
@@ -127,6 +145,10 @@ struct IrisChatView: View {
                         }
                     }
                     Button(R.string.localizable.cancel(), role: .cancel) {}
+                }
+                .sheet(isPresented: $showAboutIris) {
+                    AboutIrisView()
+                        .presentationDragIndicator(.hidden)
                 }
             }
         }

--- a/ArtemisKit/Sources/Iris/Views/IrisSessionListView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisSessionListView.swift
@@ -88,7 +88,7 @@ public struct IrisSessionListView: View {
                 .refreshable { await viewModel.loadSessions() }
                 .contentMargins(.bottom, 80, for: .scrollContent)
                 .overlay(alignment: .bottomTrailing) {
-                    NewIrisSessionButton(viewModel: viewModel, courseId: courseId)
+                    NewIrisSessionButton(isCreating: viewModel.isCreatingSession, action: createAndOpenSession)
                         .padding()
                 }
             }
@@ -97,6 +97,7 @@ public struct IrisSessionListView: View {
             if let path = navigationController.selectedPath as? IrisSessionPath {
                 IrisChatView(
                     sessionPath: path,
+                    onNewChat: createAndOpenSession,
                     onDeleted: {
                         viewModel.removeSession(sessionId: path.sessionId)
                         navigationController.selectedPath = nil
@@ -112,6 +113,17 @@ public struct IrisSessionListView: View {
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(isPresented: viewModel.showError, error: viewModel.error, actions: {})
         .task { await viewModel.loadSessions() }
+    }
+
+    /// Creates a session and navigates to it. Shared by the + button and the
+    /// chat view's "New Chat" menu item.
+    private func createAndOpenSession() {
+        Task {
+            if let newSession = await viewModel.createNewSession() {
+                navigationController.selectedPath = IrisSessionPath(
+                    session: newSession, coursePath: CoursePath(id: courseId))
+            }
+        }
     }
 }
 
@@ -163,20 +175,13 @@ private struct IrisSessionRowView: View {
 }
 
 private struct NewIrisSessionButton: View {
-    @EnvironmentObject private var navigationController: NavigationController
-    @Bindable var viewModel: IrisSessionListViewModel
-    let courseId: Int
+    let isCreating: Bool
+    let action: () -> Void
 
     var body: some View {
-        Button {
-            Task {
-                if let newSession = await viewModel.createNewSession() {
-                    navigationController.selectedPath = IrisSessionPath(session: newSession, coursePath: CoursePath(id: courseId))
-                }
-            }
-        } label: {
+        Button(action: action) {
             Group {
-                if viewModel.isCreatingSession {
+                if isCreating {
                     ProgressView()
                         .tint(.white)
                 } else {
@@ -189,6 +194,6 @@ private struct NewIrisSessionButton: View {
             .background(Color.Artemis.artemisBlue, in: .circle)
             .shadow(color: Color.gray.opacity(0.2), radius: .m)
         }
-        .disabled(viewModel.isCreatingSession)
+        .disabled(isCreating)
     }
 }

--- a/ArtemisKit/Sources/Iris/Views/IrisSessionListView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisSessionListView.swift
@@ -97,6 +97,7 @@ public struct IrisSessionListView: View {
             if let path = navigationController.selectedPath as? IrisSessionPath {
                 IrisChatView(
                     sessionPath: path,
+                    isCreatingSession: viewModel.isCreatingSession,
                     onNewChat: createAndOpenSession,
                     onDeleted: {
                         viewModel.removeSession(sessionId: path.sessionId)


### PR DESCRIPTION
## Motivation

  The Iris chat view only allowed deleting the current chat. Users had to navigate
  back to the session list to start a new conversation, and there was no in-app
  explanation of what Iris is or how to use it responsibly (unlike the web client,
  which has an "About Iris" modal).

  ## Description
  
  - Added **"New Chat"** and **"About Iris"** menu items to the chat view's toolbar menu.
  - Added a native **About Iris** screen, mirroring the web client's modal. It explains
    what Iris can do, what to expect from it, and how data is handled (privacy).
  - Refactored session creation into a shared `createAndOpenSession` helper, now used by
    both the "+" button in the session list and the new "New Chat" menu item.
  - The toolbar menu shows a loading indicator and disables "New Chat" while a session
    is being created.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e3b5662f-0c44-40ee-bdff-152255c55993" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5d1909a1-07d0-4a78-83de-c11269218dfe" />