### PR TITLE
`Iris`: Update chat session REST paths to new server convention

### DIFF
--- a/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisChatService/IrisChatHttpServiceImpl.swift
@@ -25,7 +25,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
 
         var resourceName: String {
             if mode == .tutorSuggestion {
-                return "api/iris/tutor-suggestion/\(entityId)/sessions/current"
+                return "api/iris/tutor-suggestion/posts/\(entityId)/sessions/current"
             }
             return "api/iris/chat/sessions/current"
         }
@@ -59,7 +59,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
 
         var resourceName: String {
             if mode == .tutorSuggestion {
-                return "api/iris/tutor-suggestion/\(entityId)/sessions"
+                return "api/iris/tutor-suggestion/posts/\(entityId)/sessions"
             }
             return "api/iris/chat/sessions"
         }
@@ -91,7 +91,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         var method: HTTPMethod { .get }
 
         var resourceName: String {
-            "api/iris/chat/\(courseId)/sessions/overview"
+            "api/iris/chat/courses/\(courseId)/sessions/overview"
         }
     }
 
@@ -114,7 +114,7 @@ struct IrisChatHttpServiceImpl: IrisChatHttpService {
         var method: HTTPMethod { .get }
 
         var resourceName: String {
-            "api/iris/chat/\(courseId)/session/\(sessionId)"
+            "api/iris/chat/courses/\(courseId)/sessions/\(sessionId)"
         }
     }
 


### PR DESCRIPTION
Updates the Iris chat session REST paths in `IrisChatHttpServiceImpl` to the new server convention introduced in [PR #12822](https://github.com/ls1intum/Artemis/pull/12822) on Artemis