### PR TITLE
`CourseView`: Dynamically adjust which tabs are visible

### DIFF
--- a/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Artemis.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a1f992a76fdcb7a81031a61c1d85ff0c8fee4c89667ba134569192e020d0108f",
+  "originHash" : "ef7eb67f3e5017bb30c34c5743d933c4d9773d9e21e1c11ca1b4b82c745d92c3",
   "pins" : [
     {
       "identity" : "artemis-ios-core-modules",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ls1intum/artemis-ios-core-modules",
       "state" : {
-        "branch" : "0606124",
-        "revision" : "060612416034b1d9527347c9e56475111336efe3"
+        "revision" : "ff81668d612f9666ea2181373418edea0ed2b459",
+        "version" : "20.1.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "576a65b4ffb8c12ddad4950dc21eea2ef071bec2",
-        "version" : "1.3.0"
+        "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
+        "version" : "1.3.1"
       }
     },
     {

--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onmyway133/Smile", revision: "6bacbf7"),
 //        .package(url: "https://github.com/ls1intum/apollon-ios-module", .upToNextMajor(from: "1.0.9")), // Disabled because not working
-        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", revision: "0606124"),
+        .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "20.1.0")),
         .package(url: "https://github.com/mac-cain13/R.swift.git", from: "7.8.0")
     ],
     targets: [

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -35,7 +35,8 @@ public struct CourseView: View {
                     systemImage: "character.book.closed.fill",
                     value: TabIdentifier.lecture) {
                     TabBarIpad {
-                        LectureListView(viewModel: viewModel)
+                        LectureListView(viewModel: viewModel,
+                                        showFaqButton: !potentiallyVisibleTabs.contains(.faq))
                     }
                 }
             }
@@ -81,6 +82,11 @@ public struct CourseView: View {
         // Add a file and image picker here, inside the navigation it doesn't work sometimes
         .supportsFilePicker()
         .supportsImagePicker()
+        .onChange(of: potentiallyVisibleTabs) {
+            if !potentiallyVisibleTabs.contains(navigationController.courseTab) {
+                navigationController.courseTab = potentiallyVisibleTabs.first ?? .exercise
+            }
+        }
     }
 }
 

--- a/ArtemisKit/Sources/CourseView/CourseView.swift
+++ b/ArtemisKit/Sources/CourseView/CourseView.swift
@@ -11,6 +11,7 @@ import DesignLibrary
 
 public struct CourseView: View {
     @EnvironmentObject private var navigationController: NavigationController
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     @StateObject private var viewModel: CourseViewModel
     @FeatureAvailability(.globalSearch) private var searchEnabled
@@ -19,23 +20,27 @@ public struct CourseView: View {
 
     public var body: some View {
         TabView(selection: $navigationController.courseTab) {
-            Tab(R.string.localizable.exercisesTabLabel(),
-                systemImage: "list.bullet.clipboard.fill",
-                value: TabIdentifier.exercise) {
-                TabBarIpad {
-                    ExerciseListView(viewModel: viewModel)
+            if potentiallyVisibleTabs.contains(.exercise) {
+                Tab(R.string.localizable.exercisesTabLabel(),
+                    systemImage: "list.bullet.clipboard.fill",
+                    value: TabIdentifier.exercise) {
+                    TabBarIpad {
+                        ExerciseListView(viewModel: viewModel)
+                    }
                 }
             }
 
-            Tab(R.string.localizable.lectureTabLabel(),
-                systemImage: "character.book.closed.fill",
-                value: TabIdentifier.lecture) {
-                TabBarIpad {
-                    LectureListView(viewModel: viewModel)
+            if potentiallyVisibleTabs.contains(.lecture) {
+                Tab(R.string.localizable.lectureTabLabel(),
+                    systemImage: "character.book.closed.fill",
+                    value: TabIdentifier.lecture) {
+                    TabBarIpad {
+                        LectureListView(viewModel: viewModel)
+                    }
                 }
             }
 
-            if viewModel.isMessagesVisible {
+            if viewModel.isMessagesVisible && potentiallyVisibleTabs.contains(.communication) {
                 Tab(R.string.localizable.messagesTabLabel(),
                     systemImage: "bubble.right.fill",
                     value: TabIdentifier.communication) {
@@ -45,7 +50,7 @@ public struct CourseView: View {
                 }
             }
 
-            if ((viewModel.course.numberOfAcceptedFaqs ?? 0) > 0) && viewModel.course.irisEnabledInCourse == false {
+            if ((viewModel.course.numberOfAcceptedFaqs ?? 0) > 0) && potentiallyVisibleTabs.contains(.faq) {
                 Tab(R.string.localizable.faqTabLabel(),
                     systemImage: "questionmark.circle",
                     value: TabIdentifier.faq) {
@@ -55,7 +60,7 @@ public struct CourseView: View {
                 }
             }
 
-            if searchEnabled {
+            if searchEnabled && potentiallyVisibleTabs.contains(.search) {
                 Tab(value: .search, role: .search) {
                     SearchTabView(courseId: viewModel.course.id)
                     // Search tab does not use split view, so always use compact toolbar
@@ -64,7 +69,7 @@ public struct CourseView: View {
                 }
             }
 
-            if viewModel.course.irisEnabledInCourse == true {
+            if viewModel.course.irisEnabledInCourse == true && potentiallyVisibleTabs.contains(.iris) {
                 Tab("Iris", systemImage: "eyes", value: TabIdentifier.iris) {
                     TabBarIpad {
                         IrisSessionListView(course: viewModel.course)
@@ -82,5 +87,53 @@ public struct CourseView: View {
 extension CourseView {
     init(course: Course) {
         self.init(viewModel: CourseViewModel(course: course), courseId: course.id)
+    }
+}
+
+private extension CourseView {
+    var potentiallyVisibleTabs: [TabIdentifier] {
+        var tabs = [TabIdentifier]()
+
+        // Add tabs in "importance" order after the first 5
+        if viewModel.course.irisEnabledInCourse == true {
+            tabs.append(.iris)
+        }
+
+        if searchEnabled {
+            tabs.append(.search)
+        }
+
+        if viewModel.course.exercises?.isEmpty != true {
+            tabs.append(.exercise)
+        }
+
+        if viewModel.course.lectures?.isEmpty != true {
+            tabs.append(.lecture)
+        }
+
+        if viewModel.isMessagesVisible {
+            tabs.append(.communication)
+        }
+
+        // Importance order -> shown if possible
+        if viewModel.course.numberOfAcceptedFaqs ?? 0 > 0 {
+            tabs.append(.faq)
+        }
+
+        // All necessary tabs visible, but still space -> Show at least exercises/lectures (default)
+        if tabs.count < 5 {
+            tabs.append(.exercise)
+        }
+        if tabs.count < 5 {
+            tabs.append(.lecture)
+        }
+
+        let tabLimit = isIpadWithTopBar ? 7 : 5
+
+        return Array(tabs.prefix(tabLimit))
+    }
+
+    var isIpadWithTopBar: Bool {
+        sizeClass == .regular && UIDevice.current.userInterfaceIdiom != .phone
     }
 }

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureListView.swift
@@ -6,6 +6,7 @@
 //
 
 import DesignLibrary
+import Faq
 import Navigation
 import Notifications
 import SharedModels
@@ -18,6 +19,9 @@ struct LectureListView: View {
     @State private var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
 
     @State private var searchText = ""
+
+    @State private var showFaq = false
+    let showFaqButton: Bool
 
     private var selectedLecture: Binding<LecturePath?> {
         navController.selectedPathBinding($navController.selectedPath)
@@ -65,6 +69,25 @@ struct LectureListView: View {
                             value.scrollTo(id, anchor: .top)
                         }
                     }
+                }
+                .safeAreaInset(edge: .bottom) {
+                    if showFaqButton && viewModel.course.numberOfAcceptedFaqs ?? 0 > 0 {
+                        Button {
+                            showFaq = true
+                        } label: {
+                            Image(systemName: "questionmark")
+                                .foregroundStyle(.white)
+                                .font(.title2)
+                                .frame(width: 60, height: 60, alignment: .center)
+                                .background(Color.Artemis.artemisBlue, in: .circle)
+                                .shadow(color: Color.gray.opacity(0.2), radius: .m)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+                .sheet(isPresented: $showFaq) {
+                    FaqListView(course: viewModel.course, showToolbar: false)
                 }
             }
             .courseToolbar()

--- a/ArtemisKit/Sources/Faq/Views/FaqListView.swift
+++ b/ArtemisKit/Sources/Faq/Views/FaqListView.swift
@@ -18,13 +18,15 @@ public struct FaqListView: View {
     @EnvironmentObject var navController: NavigationController
     @State private var columnVisibilty: NavigationSplitViewVisibility = .doubleColumn
     @State var viewModel: FaqViewModel
+    private let showToolbar: Bool
 
     private var selectedFaq: Binding<FaqPath?> {
         navController.selectedPathBinding($navController.selectedPath)
     }
 
-    public init(course: Course) {
+    public init(course: Course, showToolbar: Bool = false) {
         self._viewModel = State(initialValue: FaqViewModel(course: course))
+        self.showToolbar = showToolbar
     }
 
     public var body: some View {
@@ -66,7 +68,7 @@ public struct FaqListView: View {
                         .padding()
                 }
             }
-            .courseToolbar()
+            .courseToolbar(overrideWithDismiss: !showToolbar)
         } detail: {
             NavigationStack(path: $navController.tabPath) {
                 Group {

--- a/ArtemisKit/Sources/Faq/Views/FaqListView.swift
+++ b/ArtemisKit/Sources/Faq/Views/FaqListView.swift
@@ -24,7 +24,7 @@ public struct FaqListView: View {
         navController.selectedPathBinding($navController.selectedPath)
     }
 
-    public init(course: Course, showToolbar: Bool = false) {
+    public init(course: Course, showToolbar: Bool = true) {
         self._viewModel = State(initialValue: FaqViewModel(course: course))
         self.showToolbar = showToolbar
     }

--- a/ArtemisKit/Sources/Notifications/Navigation/CourseToolbar.swift
+++ b/ArtemisKit/Sources/Notifications/Navigation/CourseToolbar.swift
@@ -11,8 +11,13 @@ import SwiftUI
 public extension View {
     /// Use this modifier at a high level (e.g. CourseView) with title to provide a toolbar.
     /// Use at lower level (e.g. ExerciseList) to attach toolbar where needed.
-    func courseToolbar(title: String? = nil) -> some View {
-        modifier(CourseToolbarViewEnvironmentModifier(title: title))
+    @ViewBuilder
+    func courseToolbar(title: String? = nil, overrideWithDismiss: Bool = false) -> some View {
+        if !overrideWithDismiss {
+            modifier(CourseToolbarViewEnvironmentModifier(title: title))
+        } else {
+            modifier(DismissModifier())
+        }
     }
 }
 
@@ -45,6 +50,22 @@ private struct CourseToolbarViewModifier: ViewModifier {
                 .disableGlass26()
                 ToolbarItem(placement: .topBarTrailing) {
                     NotificationToolbarButton(placement: .navBar, sizeClass: sizeClass)
+                }
+            }
+    }
+}
+
+private struct DismissModifier: ViewModifier {
+    @Environment(\.dismiss) private var dismiss
+
+    func body(content: Content) -> some View {
+        content
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(R.string.localizable.close()) {
+                        dismiss()
+                    }
                 }
             }
     }

--- a/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Training/DNDQuestionView.swift
@@ -53,7 +53,7 @@ struct DNDQuestionView: View {
     }
 
     var answer: DTO.SubmittedAnswerFromLiveClient {
-        .dragAndDrop(.init(quizQuestion: .init(id: question.id), mappings: mappings))
+        .dragAndDrop(.init(quizQuestion: .init(id: question.id), mappings: mappings, _type: .dragAndDrop))
     }
 }
 

--- a/ArtemisKit/Sources/Quiz/Views/Training/MCQuestionView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Training/MCQuestionView.swift
@@ -70,6 +70,6 @@ struct MCQuestionView: View {
 
     var answer: DTO.SubmittedAnswerFromLiveClient {
         let answers = selectedAnswers.map { DTO.EntityIdRef(id: $0) }
-        return .multipleChoice(.init(quizQuestion: .init(id: question.id), selectedOptions: answers))
+        return .multipleChoice(.init(quizQuestion: .init(id: question.id), selectedOptions: answers, _type: .multipleChoice))
     }
 }

--- a/ArtemisKit/Sources/Quiz/Views/Training/ShortAnswerQuestionView.swift
+++ b/ArtemisKit/Sources/Quiz/Views/Training/ShortAnswerQuestionView.swift
@@ -84,7 +84,7 @@ struct ShortAnswerQuestionView: View {
     }
 
     private var answer: DTO.SubmittedAnswerFromLiveClient {
-        .shortAnswer(.init(quizQuestion: .init(id: question.id), submittedTexts: textInputs))
+        .shortAnswer(.init(quizQuestion: .init(id: question.id), submittedTexts: textInputs, _type: .shortAnswer))
     }
 
     private func solutions(for spot: Int64) -> [String]? {


### PR DESCRIPTION
We will need to implement some way to deal with more than five tabs, now that we have added Iris to the app.

As an intermediate solution, we limit the number of shown tabs to 5 (max supported without overflow) on iPhone and compact mode on iPad. As a result, the FAQ tab is not shown if all other tabs should be visible too, and instead placed inside the lectures tab.

Screen recording shows FAQ tab moving from its own tab to a button in the lectures tab:

https://github.com/user-attachments/assets/d785451c-9c59-40a0-a262-8423c8d4a789

