### PR TITLE
`Iris`: Fix chat stuck awaiting reply during navigation transitions

### DIFF
--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketService.swift
@@ -9,14 +9,14 @@ import Common
 
 /// Streams Iris WebSocket payloads for a given chat session.
 ///
-/// One ``AsyncStream`` per ``subscribe(sessionId:)`` call, backed by a single
-/// STOMP subscription on `/user/topic/iris/{sessionId}`. Single-consumer:
-/// re-subscribing to the same session replaces the previous stream.
-/// Cleanup is explicit via ``unsubscribe(sessionId:)`` (or
-/// ``unsubscribeAll()`` whenever the course is closed).
+/// One ``AsyncStream`` per ``subscribe(sessionId:)`` call, all backed by a single
+/// STOMP subscription on `/user/topic/iris/{sessionId}`. Multi-consumer:
+/// overlapping subscriptions to the same session coexist (each gets its own
+/// stream). A consumer is cleaned up automatically when its stream is cancelled,
+/// so callers just drive it from a SwiftUI `.task`. ``unsubscribeAll()`` drops
+/// every subscription, e.g. when the course is closed.
 protocol IrisWebsocketService: Sendable {
     func subscribe(sessionId: Int) async -> AsyncStream<IrisChatWebsocketDTO>
-    func unsubscribe(sessionId: Int) async
     func unsubscribeAll() async
 }
 

--- a/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
+++ b/ArtemisKit/Sources/Iris/Services/IrisWebsocketService/IrisWebsocketServiceImpl.swift
@@ -9,30 +9,62 @@ import APIClient
 import Common
 import Foundation
 
-/// Decodes Iris WebSocket payloads for a chat session into a typed stream.
+/// Decodes Iris WebSocket payloads for a chat session into typed streams.
 ///
-/// Single-consumer: each ``subscribe(sessionId:)`` call replaces any
-/// existing subscription for that session. The decode pump runs on a
-/// detached task; cancelling it (via ``unsubscribe(sessionId:)`` or
-/// ``unsubscribeAll()``) drops the STOMP subscription downstream.
+/// Multi-consumer: each ``subscribe(sessionId:)`` returns its own stream, all fed
+/// by a single STOMP subscription per session (a "hub"). This tolerates the
+/// overlapping view instances SwiftUI briefly creates for the same session during
+/// a navigation/tab transition — they no longer cancel each other's subscription.
+/// A consumer is dropped automatically when its stream is cancelled (the view's
+/// `.task` ends); the hub's STOMP subscription is torn down, after a short debounce,
+/// once its last consumer is gone.
 actor IrisWebsocketServiceImpl: IrisWebsocketService {
 
-    // Debounce window for tearing down a STOMP subscription. ArtemisStompClient
+    // Debounce window for tearing down a hub's STOMP subscription. ArtemisStompClient
     // disconnects the socket as soon as its topic list is empty, so a fast
-    // chat-to-chat navigation (unsubscribe A, subscribe B) would otherwise
-    // race the reconnect and surface a network error. Holding the old topic
-    // for a short grace period keeps the socket alive across the swap.
+    // chat-to-chat navigation (last consumer leaves, new one joins) would otherwise
+    // race the reconnect and surface a network error. Holding the topic for a short
+    // grace period keeps the socket alive across the swap.
     private static let unsubscribeDebounce: Duration = .milliseconds(300)
 
-    private var sessions: [Int: Task<Void, Never>] = [:]
+    private struct SessionHub {
+        /// The single STOMP reader fanning out to all consumers of this session.
+        let task: Task<Void, Never>
+        /// Live consumers keyed by an opaque token, each with its own stream.
+        var consumers: [Int: AsyncStream<IrisChatWebsocketDTO>.Continuation] = [:]
+    }
+
+    private var hubs: [Int: SessionHub] = [:]
+    private var nextToken = 0
 
     func subscribe(sessionId: Int) -> AsyncStream<IrisChatWebsocketDTO> {
-        sessions.removeValue(forKey: sessionId)?.cancel()
+        nextToken += 1
+        let token = nextToken
 
         let (stream, continuation) = AsyncStream<IrisChatWebsocketDTO>.makeStream()
-        let topic = IrisWebsocketTopic.makeIrisChat(sessionId: sessionId)
 
-        let task = Task.detached {
+        if hubs[sessionId] == nil {
+            hubs[sessionId] = SessionHub(task: makeReaderTask(sessionId: sessionId))
+        }
+        hubs[sessionId]?.consumers[token] = continuation
+
+        continuation.onTermination = { [weak self] _ in
+            Task { await self?.removeConsumer(sessionId: sessionId, token: token) }
+        }
+
+        return stream
+    }
+
+    func unsubscribeAll() {
+        hubs.values.forEach { $0.task.cancel() }
+        hubs.removeAll()
+    }
+
+    /// The single STOMP reader for a session: decodes frames and fans them out to
+    /// every current consumer. Runs until the hub is torn down (task cancelled).
+    private func makeReaderTask(sessionId: Int) -> Task<Void, Never> {
+        let topic = IrisWebsocketTopic.makeIrisChat(sessionId: sessionId)
+        return Task.detached { [weak self] in
             let raw = ArtemisStompClient.shared.subscribe(to: topic)
             for await message in raw {
                 if Task.isCancelled { break }
@@ -42,33 +74,30 @@ actor IrisWebsocketServiceImpl: IrisWebsocketService {
                 ) else {
                     continue
                 }
-                continuation.yield(dto)
+                await self?.broadcast(sessionId: sessionId, dto: dto)
             }
-            continuation.finish()
         }
-        sessions[sessionId] = task
-
-        continuation.onTermination = { _ in task.cancel() }
-
-        return stream
     }
 
-    func unsubscribe(sessionId: Int) {
-        let task = sessions[sessionId]
+    private func broadcast(sessionId: Int, dto: IrisChatWebsocketDTO) {
+        hubs[sessionId]?.consumers.values.forEach { $0.yield(dto) }
+    }
+
+    private func removeConsumer(sessionId: Int, token: Int) {
+        hubs[sessionId]?.consumers.removeValue(forKey: token)
+        let remaining = hubs[sessionId]?.consumers.count ?? 0
+        guard remaining == 0 else { return }
+        // Debounce: a quick resubscribe (e.g. the surviving instance of a churny
+        // transition) keeps the hub alive instead of bouncing the socket.
         Task { [weak self] in
             try? await Task.sleep(for: Self.unsubscribeDebounce)
-            await self?.cancelIfUnchanged(sessionId: sessionId, task: task)
+            await self?.teardownIfEmpty(sessionId: sessionId)
         }
     }
 
-    func unsubscribeAll() {
-        sessions.values.forEach { $0.cancel() }
-        sessions.removeAll()
-    }
-
-    private func cancelIfUnchanged(sessionId: Int, task: Task<Void, Never>?) {
-        guard sessions[sessionId] == task else { return }
-        sessions.removeValue(forKey: sessionId)
-        task?.cancel()
+    private func teardownIfEmpty(sessionId: Int) {
+        guard let hub = hubs[sessionId], hub.consumers.isEmpty else { return }
+        hub.task.cancel()
+        hubs.removeValue(forKey: sessionId)
     }
 }

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
@@ -15,7 +15,6 @@ import SwiftUI
 final class IrisChatViewModel {
     let sessionPath: IrisSessionPath
     private let httpService: IrisChatHttpService
-    private var websocketTask: Task<Void, Never>?
 
     var messages: DataState<[IrisMessageResponseDTO]> = .loading
     var stages: [IrisStageDTO] = []
@@ -110,13 +109,16 @@ final class IrisChatViewModel {
         }
     }
 
-    func subscribeToWebsocket() async {
-        let stream = await IrisWebsocketServiceFactory.shared.subscribe(sessionId: sessionPath.sessionId)
-        websocketTask = Task { [weak self] in
-            for await dto in stream {
-                guard let self else { return }
-                handleWebsocketDTO(dto)
-            }
+    /// Subscribes to the session's websocket and forwards frames until the
+    /// enclosing `.task` is cancelled (the view is actually removed). Driven from
+    /// `.task` rather than `onAppear`/`onDisappear`, whose spurious callbacks
+    /// during a `NavigationSplitView`/`TabView` transition previously tore down the
+    /// live subscription and left the chat stuck awaiting a reply.
+    func observeWebsocket() async {
+        let sessionId = sessionPath.sessionId
+        let stream = await IrisWebsocketServiceFactory.shared.subscribe(sessionId: sessionId)
+        for await dto in stream {
+            handleWebsocketDTO(dto)
         }
     }
 
@@ -195,12 +197,6 @@ final class IrisChatViewModel {
         case .loading, .notStarted:
             return false
         }
-    }
-
-    func disconnect() async {
-        await IrisWebsocketServiceFactory.shared.unsubscribe(sessionId: sessionPath.sessionId)
-        websocketTask?.cancel()
-        websocketTask = nil
     }
 
     private func handleWebsocketDTO(_ dto: IrisChatWebsocketDTO) {

--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -187,7 +187,7 @@ struct IrisChatView: View {
             }
         }
         .task { await viewModel.loadMessages() }
-        .task { await viewModel.subscribeToWebsocket() }
+        .task { await viewModel.observeWebsocket() }
         .onChange(of: scenePhase) { _, newPhase in
             // Iris' reply arrives only once over the STOMP topic, which iOS tears
             // down on backgrounding. STOMP doesn't replay messages published while
@@ -203,10 +203,6 @@ struct IrisChatView: View {
         }
         .onChange(of: viewModel.committedContext) { _, newContext in
             if let newContext { onContextChange(newContext) }
-        }
-        .onDisappear { Task {
-            await viewModel.disconnect()
-        }
         }
         .alert(isPresented: viewModel.showError, error: viewModel.error, actions: {})
     }


### PR DESCRIPTION
### Problem

Navigating between Iris chats (or switching tabs) could leave a chat stuck showing the loading indicator forever: the reply never appeared. SwiftUI briefly creates overlapping instances of the same session's view during a `NavigationSplitView`/`TabView` transition, and the old single-consumer WebSocket service let the departing instance cancel the surviving instance's STOMP subscription.

### Change

Rework `IrisWebsocketService` from single-consumer to a multi-consumer **hub**: one STOMP subscription per session fans out to any number of streams. Overlapping subscriptions now coexist instead of cancelling each other.

- Consumers are driven from a SwiftUI `.task` and cleaned up automatically when their stream is cancelled (the view is actually removed).
- The hub's STOMP subscription is torn down after a short debounce once its last consumer leaves — keeping the socket alive across a fast chat-to-chat swap.
- Removes the explicit `unsubscribe`/`disconnect` plumbing and the `onDisappear` teardown that caused the premature cancellation.

### Testing

- Rapidly switch between two Iris chats and between the Iris tab and other tabs; send a message and confirm the reply always arrives.
- Background/foreground the app mid-conversation; confirm no dangling sockets or missed replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)