### PR TITLE
`Iris`: Add "Ask Iris" button to lecture and exercise pages

### DIFF
--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -7,6 +7,7 @@
 
 import Common
 import DesignLibrary
+import Iris
 import Navigation
 import SharedModels
 import SwiftUI
@@ -25,6 +26,11 @@ public struct ExerciseDetailView: View {
                 VStack(alignment: .leading, spacing: .l) {
                     hint
                     ExerciseOverviewChipsRow(exercise: exercise, score: viewModel.score)
+                    if viewModel.irisEnabledInCourse,
+                       let askIris = AskIrisButton(courseId: viewModel.courseId, exercise: exercise) {
+                        askIris
+                            .padding(.horizontal, .m)
+                    }
                     problem
                     detail(exercise: exercise)
                 }
@@ -65,6 +71,7 @@ public extension ExerciseDetailView {
         self.init(viewModel: ExerciseDetailViewModel(
             courseId: course.id,
             exerciseId: exercise.id,
+            irisEnabledInCourse: course.irisEnabledInCourse == true,
             exercise: .done(response: exercise)))
     }
 

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailView.swift
@@ -27,10 +27,8 @@ public struct ExerciseDetailView: View {
                 VStack(alignment: .leading, spacing: .l) {
                     hint
                     ExerciseOverviewChipsRow(exercise: exercise, score: viewModel.score)
-                    if viewModel.irisEnabledInCourse,
-                       let askIris = AskIrisButton(courseId: viewModel.courseId, exercise: exercise) {
-                        askIris
-                            .padding(.horizontal, .m)
+                    if viewModel.irisEnabledInCourse {
+                        AskIrisButton(courseId: viewModel.courseId, exercise: exercise, horizontalPadding: .m)
                     }
                     if case .quiz(let quiz) = exercise,
                        quiz.canStartLiveQuiz || quiz.canStartPractice {

--- a/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailViewModel.swift
+++ b/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailViewModel.swift
@@ -15,6 +15,9 @@ import UserStore
 final class ExerciseDetailViewModel {
     let courseId: Int
     let exerciseId: Int
+    /// Whether Iris is enabled for this exercise's course. Drives the "Ask Iris"
+    /// button; `false` when the exercise is opened without a loaded course (deeplink).
+    let irisEnabledInCourse: Bool
 
     var exercise: DataState<Exercise>
     var problemStatementRendered: DataState<String> = .loading
@@ -35,12 +38,14 @@ final class ExerciseDetailViewModel {
     init(
         courseId: Int,
         exerciseId: Int,
+        irisEnabledInCourse: Bool = false,
         exercise: DataState<Exercise>,
         exerciseService: ExerciseService = ExerciseServiceFactory.shared,
         userSession: UserSession = UserSessionFactory.shared
     ) {
         self.courseId = courseId
         self.exerciseId = exerciseId
+        self.irisEnabledInCourse = irisEnabledInCourse
 
         self.exercise = exercise
         self.problemStatementRendered = .loading

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -10,6 +10,7 @@ import Common
 import SharedModels
 import ArtemisMarkdown
 import DesignLibrary
+import Iris
 import Navigation
 
 public struct LectureDetailView: View {
@@ -54,6 +55,10 @@ public struct LectureDetailView: View {
                             Text(R.string.localizable.communication())
                                 .font(.headline)
                             ChannelCell(courseId: viewModel.courseId, channel: channel)
+                        }
+
+                        if viewModel.course.value?.irisEnabledInCourse == true {
+                            AskIrisButton(courseId: viewModel.courseId, lecture: lecture)
                         }
                     }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -34,6 +34,10 @@ public struct LectureDetailView: View {
                         Text(R.string.localizable.overview())
                             .font(.title2).bold()
 
+                        if viewModel.course.value?.irisEnabledInCourse == true {
+                            AskIrisButton(courseId: viewModel.courseId, lecture: lecture)
+                        }
+
                         if let startDate = lecture.startDate {
                             Text(R.string.localizable.date())
                                 .font(.headline)
@@ -55,10 +59,6 @@ public struct LectureDetailView: View {
                             Text(R.string.localizable.communication())
                                 .font(.headline)
                             ChannelCell(courseId: viewModel.courseId, channel: channel)
-                        }
-
-                        if viewModel.course.value?.irisEnabledInCourse == true {
-                            AskIrisButton(courseId: viewModel.courseId, lecture: lecture)
                         }
                     }
 

--- a/ArtemisKit/Sources/Iris/Models/IrisChatMode.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisChatMode.swift
@@ -18,20 +18,19 @@ enum IrisChatMode: String, ConstantsEnum {
     case unknown
 }
 
-extension IrisChatMode {
-    /// The chat mode for an exercise, or `nil` for types Iris has no chat for.
+extension Exercise {
+    /// The Iris chat mode for this exercise, or `nil` for types Iris has no chat for.
     /// Mirrors the web app's `EXERCISE_TYPE_TO_CHAT_MODE`.
-    init?(exercise: Exercise) {
-        switch exercise {
-        case .programming:
-            self = .programmingExercise
-        case .text:
-            self = .textExercise
-        default:
-            return nil
+    var irisChatMode: IrisChatMode? {
+        switch self {
+        case .programming: .programmingExercise
+        case .text: .textExercise
+        default: nil
         }
     }
+}
 
+extension IrisChatMode {
     var icon: String {
         switch self {
         case .programmingExercise:

--- a/ArtemisKit/Sources/Iris/Models/IrisChatMode.swift
+++ b/ArtemisKit/Sources/Iris/Models/IrisChatMode.swift
@@ -19,6 +19,19 @@ enum IrisChatMode: String, ConstantsEnum {
 }
 
 extension IrisChatMode {
+    /// The chat mode for an exercise, or `nil` for types Iris has no chat for.
+    /// Mirrors the web app's `EXERCISE_TYPE_TO_CHAT_MODE`.
+    init?(exercise: Exercise) {
+        switch exercise {
+        case .programming:
+            self = .programmingExercise
+        case .text:
+            self = .textExercise
+        default:
+            return nil
+        }
+    }
+
     var icon: String {
         switch self {
         case .programmingExercise:

--- a/ArtemisKit/Sources/Iris/Models/SessionContext.swift
+++ b/ArtemisKit/Sources/Iris/Models/SessionContext.swift
@@ -36,14 +36,14 @@ extension SessionContext {
     }
 
     /// Rebuilds the context from a navigation ``IrisContextSource`` handed off by
-    /// an "Ask Iris" button. `nil` for an exercise type Iris has no chat mode for.
-    init?(source: IrisContextSource) {
-        switch source {
-        case .lecture(let lecture):
-            self.init(lecture: lecture)
-        case .exercise(let exercise):
-            guard let context = SessionContext(exercise: exercise) else { return nil }
-            self = context
-        }
+    /// an "Ask Iris" button. Not failable: the source already carries the resolved mode.
+    init(source: IrisContextSource) {
+        self.init(mode: IrisChatMode(rawValue: source.modeRawValue) ?? .unknown,
+                  entityId: source.entityId, entityName: source.entityName)
+    }
+
+    /// This context as a navigation payload for an "Ask Iris" button handoff.
+    var contextSource: IrisContextSource {
+        IrisContextSource(modeRawValue: mode.rawValue, entityId: entityId, entityName: entityName)
     }
 }

--- a/ArtemisKit/Sources/Iris/Models/SessionContext.swift
+++ b/ArtemisKit/Sources/Iris/Models/SessionContext.swift
@@ -29,12 +29,6 @@ extension SessionContext {
         self.init(mode: .lecture, entityId: lecture.id, entityName: lecture.title)
     }
 
-    /// The context for an exercise's Iris chat, or `nil` for unsupported types.
-    init?(exercise: Exercise) {
-        guard let mode = IrisChatMode(exercise: exercise) else { return nil }
-        self.init(mode: mode, entityId: exercise.id, entityName: exercise.baseExercise.title)
-    }
-
     /// Rebuilds the context from a navigation ``IrisContextSource`` handed off by
     /// an "Ask Iris" button. Not failable: the source already carries the resolved mode.
     init(source: IrisContextSource) {

--- a/ArtemisKit/Sources/Iris/Models/SessionContext.swift
+++ b/ArtemisKit/Sources/Iris/Models/SessionContext.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import Navigation
+import SharedModels
 
 /// A local model identifying the Iris context a session belongs to.
 /// Mirrors the TS `SessionContext` interface.
@@ -18,5 +20,30 @@ struct SessionContext: Hashable, Codable {
         self.mode = mode
         self.entityId = entityId
         self.entityName = entityName
+    }
+}
+
+extension SessionContext {
+    /// The context for a lecture's Iris chat.
+    init(lecture: Lecture) {
+        self.init(mode: .lecture, entityId: lecture.id, entityName: lecture.title)
+    }
+
+    /// The context for an exercise's Iris chat, or `nil` for unsupported types.
+    init?(exercise: Exercise) {
+        guard let mode = IrisChatMode(exercise: exercise) else { return nil }
+        self.init(mode: mode, entityId: exercise.id, entityName: exercise.baseExercise.title)
+    }
+
+    /// Rebuilds the context from a navigation ``IrisContextSource`` handed off by
+    /// an "Ask Iris" button. `nil` for an exercise type Iris has no chat mode for.
+    init?(source: IrisContextSource) {
+        switch source {
+        case .lecture(let lecture):
+            self.init(lecture: lecture)
+        case .exercise(let exercise):
+            guard let context = SessionContext(exercise: exercise) else { return nil }
+            self = context
+        }
     }
 }

--- a/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/Iris/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,9 @@
 "aboutIrisPrivacyDescription" = "Iris processes interactions within European data centers. Data handling follows applicable European data protection requirements.";
 "aboutIrisPrivacyDisclaimer" = "Review your institution's privacy policy for details.";
 
+// MARK: AskIrisButton
+"askIris" = "Ask Iris";
+
 // MARK: IrisContextSelectionView
 "selectTitle" = "Select Context";
 "lecturesSection" = "Lectures";

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
@@ -83,7 +83,7 @@ final class IrisChatViewModel {
         self.httpService = httpService
         self.sessionTitle = session?.title
         self.committedContext = session?.context
-        self.pendingContext = sessionPath.contextSource.flatMap(SessionContext.init(source:))
+        self.pendingContext = sessionPath.contextSource.map(SessionContext.init(source:))
     }
 
     func loadMessages() async {

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisChatViewModel.swift
@@ -83,6 +83,7 @@ final class IrisChatViewModel {
         self.httpService = httpService
         self.sessionTitle = session?.title
         self.committedContext = session?.context
+        self.pendingContext = sessionPath.contextSource.flatMap(SessionContext.init(source:))
     }
 
     func loadMessages() async {

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisContextSelectionViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisContextSelectionViewModel.swift
@@ -27,7 +27,7 @@ final class IrisContextSelectionViewModel {
     /// the web app's `EXERCISE_TYPE_TO_CHAT_MODE`), so other types are not listed.
     func exercises(in course: Course) -> [Exercise] {
         (course.exercises ?? [])
-            .filter { IrisChatMode(exercise: $0) != nil }
+            .filter { $0.irisChatMode != nil }
             .filter { matches($0.baseExercise.title) }
     }
 
@@ -38,7 +38,9 @@ final class IrisContextSelectionViewModel {
     /// `nil` for an exercise type Iris has no chat mode for; callers only pass
     /// exercises already filtered by ``exercises(in:)``, so in practice never nil.
     func context(for exercise: Exercise) -> SessionContext? {
-        SessionContext(exercise: exercise)
+        exercise.irisChatMode.map {
+            SessionContext(mode: $0, entityId: exercise.id, entityName: exercise.baseExercise.title)
+        }
     }
 
     func isSelected(lecture: Lecture, current: SessionContext?) -> Bool {
@@ -46,7 +48,7 @@ final class IrisContextSelectionViewModel {
     }
 
     func isSelected(exercise: Exercise, current: SessionContext?) -> Bool {
-        current?.mode == IrisChatMode(exercise: exercise) && current?.entityId == exercise.id
+        current?.mode == exercise.irisChatMode && current?.entityId == exercise.id
     }
 
     private func matches(_ title: String?) -> Bool {

--- a/ArtemisKit/Sources/Iris/ViewModels/IrisContextSelectionViewModel.swift
+++ b/ArtemisKit/Sources/Iris/ViewModels/IrisContextSelectionViewModel.swift
@@ -27,20 +27,18 @@ final class IrisContextSelectionViewModel {
     /// the web app's `EXERCISE_TYPE_TO_CHAT_MODE`), so other types are not listed.
     func exercises(in course: Course) -> [Exercise] {
         (course.exercises ?? [])
-            .filter(isSupported)
+            .filter { IrisChatMode(exercise: $0) != nil }
             .filter { matches($0.baseExercise.title) }
     }
 
     func context(for lecture: Lecture) -> SessionContext {
-        SessionContext(mode: .lecture,
-                       entityId: lecture.id,
-                       entityName: lecture.title)
+        SessionContext(lecture: lecture)
     }
 
-    func context(for exercise: Exercise) -> SessionContext {
-        SessionContext(mode: mode(for: exercise),
-                       entityId: exercise.id,
-                       entityName: exercise.baseExercise.title)
+    /// `nil` for an exercise type Iris has no chat mode for; callers only pass
+    /// exercises already filtered by ``exercises(in:)``, so in practice never nil.
+    func context(for exercise: Exercise) -> SessionContext? {
+        SessionContext(exercise: exercise)
     }
 
     func isSelected(lecture: Lecture, current: SessionContext?) -> Bool {
@@ -48,29 +46,11 @@ final class IrisContextSelectionViewModel {
     }
 
     func isSelected(exercise: Exercise, current: SessionContext?) -> Bool {
-        current?.mode == mode(for: exercise) && current?.entityId == exercise.id
+        current?.mode == IrisChatMode(exercise: exercise) && current?.entityId == exercise.id
     }
 
     private func matches(_ title: String?) -> Bool {
         guard !searchText.isEmpty else { return true }
         return title?.localizedCaseInsensitiveContains(searchText) ?? false
-    }
-
-    private func isSupported(_ exercise: Exercise) -> Bool {
-        switch exercise {
-        case .text, .programming:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func mode(for exercise: Exercise) -> IrisChatMode {
-        switch exercise {
-        case .programming:
-            return .programmingExercise
-        default:
-            return .textExercise
-        }
     }
 }

--- a/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
+++ b/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
@@ -15,48 +15,57 @@ import UserStore
 /// Opens — creating it if needed — the Iris chat session scoped to a specific
 /// lecture or exercise and navigates to it in the course's Iris tab.
 ///
-/// Callers gate on Iris being enabled in the course. The exercise initializer is
-/// failable — render it via `if let`, since it returns `nil` for an exercise type
-/// Iris has no chat mode for, leaving no gap when absent.
+/// Callers gate on Iris being enabled in the course; for an exercise type Iris has
+/// no chat mode for, the button renders nothing.
 /// If the user hasn't opted into AI yet, tapping routes to the Iris tab so they
 /// can choose there instead of creating a session.
 public struct AskIrisButton: View {
     @EnvironmentObject private var navigationController: NavigationController
 
     private let courseId: Int
-    private let context: SessionContext
+    /// `nil` for an exercise type Iris has no chat mode for.
+    private let context: SessionContext?
+    /// Applied inside the button, so an absent button leaves no padded gap behind.
+    private let horizontalPadding: CGFloat
 
     private let httpService: IrisChatHttpService = IrisChatHttpServiceFactory.shared
 
     @State private var isLoading = false
     @State private var error: UserFacingError?
 
-    private init(courseId: Int, context: SessionContext) {
+    private init(courseId: Int, context: SessionContext?, horizontalPadding: CGFloat) {
         self.courseId = courseId
         self.context = context
+        self.horizontalPadding = horizontalPadding
     }
 
     public var body: some View {
-        Button(action: openSession) {
-            HStack(spacing: .s) {
-                Group {
-                    if isLoading {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "eyes")
+        if let context {
+            Button {
+                openSession(context: context)
+            } label: {
+                HStack(spacing: .s) {
+                    Group {
+                        if isLoading {
+                            ProgressView()
+                        } else {
+                            Image(systemName: "eyes")
+                        }
                     }
+                    Text(R.string.localizable.askIris())
                 }
-                Text(R.string.localizable.askIris())
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
+            .buttonStyle(ArtemisButton(priority: .secondary))
+            .background(
+                // Matches the exercise overview chips.
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.Artemis.artemisBlue.opacity(0.1))
+            )
+            .disabled(isLoading)
+            .padding(.horizontal, horizontalPadding)
+            .alert(isPresented: showError, error: error) {}
         }
-        .buttonStyle(ArtemisButton(priority: .secondary))
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.Artemis.artemisBlue.opacity(0.1))
-        )
-        .disabled(isLoading)
-        .alert(isPresented: showError, error: error) {}
     }
 
     /// Whether the user has opted into cloud or local AI; same source as ``IrisSessionListView``.
@@ -64,7 +73,7 @@ public struct AskIrisButton: View {
         UserSessionFactory.shared.user?.selectedLLMUsage?.isAIEnabled ?? false
     }
 
-    private func openSession() {
+    private func openSession(context: SessionContext) {
         // Without consent, send the user to the Iris tab to choose their AI
         // experience rather than creating a session they can't use yet.
         guard isAIEnabled else {
@@ -81,7 +90,9 @@ public struct AskIrisButton: View {
             case .done(let session):
                 // Carry this lecture/exercise on the path so the chat pre-selects it
                 // (chip + next message), even if the server session has no context yet.
-                navigationController.goToIrisSession(courseId: courseId, sessionId: session.id, contextSource: context.contextSource)
+                navigationController.goToIrisSession(courseId: courseId,
+                                                     sessionId: session.id,
+                                                     contextSource: context.contextSource)
             case .failure(let error):
                 self.error = error
             case .loading:
@@ -101,15 +112,18 @@ public struct AskIrisButton: View {
 
 public extension AskIrisButton {
     /// A button for a lecture's Iris chat. Callers gate on Iris being enabled in the course.
-    init(courseId: Int, lecture: Lecture) {
-        self.init(courseId: courseId, context: SessionContext(lecture: lecture))
+    init(courseId: Int, lecture: Lecture, horizontalPadding: CGFloat = 0) {
+        self.init(courseId: courseId,
+                  context: SessionContext(lecture: lecture),
+                  horizontalPadding: horizontalPadding)
     }
 
-    /// A button for an exercise's Iris chat, or `nil` when the exercise type has no
+    /// A button for an exercise's Iris chat. Renders nothing when the exercise type has no
     /// Iris chat mode (only text & programming do). Callers gate on Iris being enabled.
-    init?(courseId: Int, exercise: Exercise) {
-        guard let mode = exercise.irisChatMode else { return nil }
-        let context = SessionContext(mode: mode, entityId: exercise.id, entityName: exercise.baseExercise.title)
-        self.init(courseId: courseId, context: context)
+    init(courseId: Int, exercise: Exercise, horizontalPadding: CGFloat = 0) {
+        let context = exercise.irisChatMode.map {
+            SessionContext(mode: $0, entityId: exercise.id, entityName: exercise.baseExercise.title)
+        }
+        self.init(courseId: courseId, context: context, horizontalPadding: horizontalPadding)
     }
 }

--- a/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
+++ b/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
@@ -1,0 +1,116 @@
+//
+//  AskIrisButton.swift
+//  ArtemisKit
+//
+//  Created by Senan Aslan on 20.06.26.
+//
+
+import Common
+import DesignLibrary
+import Navigation
+import SharedModels
+import SwiftUI
+import UserStore
+
+/// Opens — creating it if needed — the Iris chat session scoped to a specific
+/// lecture or exercise and navigates to it in the course's Iris tab.
+///
+/// Callers gate on Iris being enabled in the course. The exercise initializer is
+/// failable — render it via `if let`, since it returns `nil` for an exercise type
+/// Iris has no chat mode for, leaving no gap when absent.
+/// If the user hasn't opted into AI yet, tapping routes to the Iris tab so they
+/// can choose there instead of creating a session.
+public struct AskIrisButton: View {
+    @EnvironmentObject private var navigationController: NavigationController
+
+    private let courseId: Int
+    private let context: SessionContext
+    private let source: IrisContextSource
+
+    private let httpService: IrisChatHttpService = IrisChatHttpServiceFactory.shared
+
+    @State private var isLoading = false
+    @State private var error: UserFacingError?
+
+    private init(courseId: Int, context: SessionContext, source: IrisContextSource) {
+        self.courseId = courseId
+        self.context = context
+        self.source = source
+    }
+
+    public var body: some View {
+        Button(action: openSession) {
+            HStack(spacing: .s) {
+                Group {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "eyes")
+                    }
+                }
+                Text(R.string.localizable.askIris())
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(ArtemisButton(priority: .secondary))
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.Artemis.artemisBlue.opacity(0.1))
+        )
+        .disabled(isLoading)
+        .alert(isPresented: showError, error: error) {}
+    }
+
+    /// Whether the user has opted into cloud or local AI; same source as ``IrisSessionListView``.
+    private var isAIEnabled: Bool {
+        UserSessionFactory.shared.user?.selectedLLMUsage?.isAIEnabled ?? false
+    }
+
+    private func openSession() {
+        // Without consent, send the user to the Iris tab to choose their AI
+        // experience rather than creating a session they can't use yet.
+        guard isAIEnabled else {
+            navigationController.goToIris(courseId: courseId)
+            return
+        }
+
+        isLoading = true
+        Task { @MainActor in
+            let result = await httpService.getCurrentOrCreateSession(
+                mode: context.mode, entityId: context.entityId)
+            isLoading = false
+            switch result {
+            case .done(let session):
+                // Carry this lecture/exercise on the path so the chat pre-selects it
+                // (chip + next message), even if the server session has no context yet.
+                navigationController.goToIrisSession(courseId: courseId, sessionId: session.id, contextSource: source)
+            case .failure(let error):
+                self.error = error
+            case .loading:
+                break
+            }
+        }
+    }
+
+    private var showError: Binding<Bool> {
+        Binding(get: { error != nil }, set: { newValue in
+            if !newValue {
+                error = nil
+            }
+        })
+    }
+}
+
+public extension AskIrisButton {
+    /// A button for a lecture's Iris chat. Callers gate on Iris being enabled in the course.
+    init(courseId: Int, lecture: Lecture) {
+        self.init(courseId: courseId, context: SessionContext(lecture: lecture), source: .lecture(lecture))
+    }
+
+    /// A button for an exercise's Iris chat, or `nil` when the exercise type has no
+    /// Iris chat mode (only text & programming do). Callers gate on Iris being enabled.
+    init?(courseId: Int, exercise: Exercise) {
+        guard let context = SessionContext(exercise: exercise) else { return nil }
+        self.init(courseId: courseId, context: context, source: .exercise(exercise))
+    }
+}

--- a/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
+++ b/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
@@ -108,7 +108,8 @@ public extension AskIrisButton {
     /// A button for an exercise's Iris chat, or `nil` when the exercise type has no
     /// Iris chat mode (only text & programming do). Callers gate on Iris being enabled.
     init?(courseId: Int, exercise: Exercise) {
-        guard let context = SessionContext(exercise: exercise) else { return nil }
+        guard let mode = exercise.irisChatMode else { return nil }
+        let context = SessionContext(mode: mode, entityId: exercise.id, entityName: exercise.baseExercise.title)
         self.init(courseId: courseId, context: context)
     }
 }

--- a/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
+++ b/ArtemisKit/Sources/Iris/Views/AskIrisButton.swift
@@ -25,17 +25,15 @@ public struct AskIrisButton: View {
 
     private let courseId: Int
     private let context: SessionContext
-    private let source: IrisContextSource
 
     private let httpService: IrisChatHttpService = IrisChatHttpServiceFactory.shared
 
     @State private var isLoading = false
     @State private var error: UserFacingError?
 
-    private init(courseId: Int, context: SessionContext, source: IrisContextSource) {
+    private init(courseId: Int, context: SessionContext) {
         self.courseId = courseId
         self.context = context
-        self.source = source
     }
 
     public var body: some View {
@@ -83,7 +81,7 @@ public struct AskIrisButton: View {
             case .done(let session):
                 // Carry this lecture/exercise on the path so the chat pre-selects it
                 // (chip + next message), even if the server session has no context yet.
-                navigationController.goToIrisSession(courseId: courseId, sessionId: session.id, contextSource: source)
+                navigationController.goToIrisSession(courseId: courseId, sessionId: session.id, contextSource: context.contextSource)
             case .failure(let error):
                 self.error = error
             case .loading:
@@ -104,13 +102,13 @@ public struct AskIrisButton: View {
 public extension AskIrisButton {
     /// A button for a lecture's Iris chat. Callers gate on Iris being enabled in the course.
     init(courseId: Int, lecture: Lecture) {
-        self.init(courseId: courseId, context: SessionContext(lecture: lecture), source: .lecture(lecture))
+        self.init(courseId: courseId, context: SessionContext(lecture: lecture))
     }
 
     /// A button for an exercise's Iris chat, or `nil` when the exercise type has no
     /// Iris chat mode (only text & programming do). Callers gate on Iris being enabled.
     init?(courseId: Int, exercise: Exercise) {
         guard let context = SessionContext(exercise: exercise) else { return nil }
-        self.init(courseId: courseId, context: context, source: .exercise(exercise))
+        self.init(courseId: courseId, context: context)
     }
 }

--- a/ArtemisKit/Sources/Iris/Views/IrisContextSelectionView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisContextSelectionView.swift
@@ -59,12 +59,13 @@ struct IrisContextSelectionView: View {
                 if !exercises.isEmpty {
                     Section(R.string.localizable.exercisesSection()) {
                         ForEach(exercises) { exercise in
-                            let context = viewModel.context(for: exercise)
-                            ContextRow(title: exercise.baseExercise.title,
-                                       icon: context.mode.icon,
-                                       isSelected: viewModel.isSelected(exercise: exercise, current: currentSelection)) {
-                                onSet(context)
-                                dismiss()
+                            if let context = viewModel.context(for: exercise) {
+                                ContextRow(title: exercise.baseExercise.title,
+                                           icon: context.mode.icon,
+                                           isSelected: viewModel.isSelected(exercise: exercise, current: currentSelection)) {
+                                    onSet(context)
+                                    dismiss()
+                                }
                             }
                         }
                     }

--- a/ArtemisKit/Sources/Navigation/NavigationController.swift
+++ b/ArtemisKit/Sources/Navigation/NavigationController.swift
@@ -74,10 +74,12 @@ public extension NavigationController {
         log.debug("LecturePath was appended to queue")
     }
 
-    func goToIrisSession(courseId: Int, sessionId: Int) {
+    func goToIrisSession(courseId: Int, sessionId: Int, contextSource: IrisContextSource? = nil) {
         goToCourse(id: courseId)
         courseTab = .iris
-        selectedPath = IrisSessionPath(sessionId: sessionId, coursePath: selectedCourse ?? CoursePath(id: courseId))
+        selectedPath = IrisSessionPath(sessionId: sessionId,
+                                       contextSource: contextSource,
+                                       coursePath: selectedCourse ?? CoursePath(id: courseId))
         tabPath = NavigationPath()
     }
 
@@ -85,6 +87,15 @@ public extension NavigationController {
         goToCourse(id: courseId)
         courseTab = .iris
         selectedPath = IrisStartChatPath(inputText: inputText, coursePath: selectedCourse ?? CoursePath(id: courseId))
+        tabPath = NavigationPath()
+    }
+
+    /// Opens the Iris tab without selecting a session, e.g. to let the user pick
+    /// their AI experience before a session is created.
+    func goToIris(courseId: Int) {
+        goToCourse(id: courseId)
+        courseTab = .iris
+        selectedPath = nil
         tabPath = NavigationPath()
     }
 

--- a/ArtemisKit/Sources/Navigation/Paths.swift
+++ b/ArtemisKit/Sources/Navigation/Paths.swift
@@ -91,19 +91,30 @@ public struct ThreadPath: Hashable {
     }
 }
 
+/// The lecture or exercise an "Ask Iris" button opened a session for. Carries the
+/// source object across the module boundary — the Iris module rebuilds its
+/// `SessionContext` from it, since that type can't be named here.
+public enum IrisContextSource: Hashable {
+    case lecture(Lecture)
+    case exercise(Exercise)
+}
+
 public struct IrisSessionPath: Hashable {
     public let sessionId: Int
     public let defaultInput: String
     public let coursePath: CoursePath
+    /// A context to pre-select when the chat opens, e.g. from an "Ask Iris" button.
+    public let contextSource: IrisContextSource?
 
     /// Convenience for the enclosing course's id.
     public var courseId: Int {
         coursePath.id
     }
 
-    public init(sessionId: Int, defaultInput: String = "", coursePath: CoursePath) {
+    public init(sessionId: Int, defaultInput: String = "", contextSource: IrisContextSource? = nil, coursePath: CoursePath) {
         self.sessionId = sessionId
         self.defaultInput = defaultInput
+        self.contextSource = contextSource
         self.coursePath = coursePath
     }
 }

--- a/ArtemisKit/Sources/Navigation/Paths.swift
+++ b/ArtemisKit/Sources/Navigation/Paths.swift
@@ -91,12 +91,20 @@ public struct ThreadPath: Hashable {
     }
 }
 
-/// The lecture or exercise an "Ask Iris" button opened a session for. Carries the
-/// source object across the module boundary — the Iris module rebuilds its
-/// `SessionContext` from it, since that type can't be named here.
-public enum IrisContextSource: Hashable {
-    case lecture(Lecture)
-    case exercise(Exercise)
+/// The already-resolved Iris context an "Ask Iris" button opened a session for,
+/// carried across the module boundary as primitives — the Iris module rebuilds its
+/// `SessionContext` from it (that type can't be named here). Mirrors `SessionContext`
+/// one-to-one; `modeRawValue` stands in for its `IrisChatMode`, which also lives in Iris.
+public struct IrisContextSource: Hashable {
+    public let modeRawValue: String
+    public let entityId: Int
+    public let entityName: String?
+
+    public init(modeRawValue: String, entityId: Int, entityName: String?) {
+        self.modeRawValue = modeRawValue
+        self.entityId = entityId
+        self.entityName = entityName
+    }
 }
 
 public struct IrisSessionPath: Hashable {


### PR DESCRIPTION
Adds an "Ask Iris" button to the lecture and exercise detail pages that opens — creating it if needed — the Iris chat session scoped to that lecture/exercise and navigates to it, pre-selecting the context.

Behavior

- Shown only when Iris is enabled in the course. The exercise button also hides for exercise types Iris has no chat mode for (only text & programming).
- Without AI consent, tapping routes to the Iris tab so the user can pick their AI experience instead of creating an unusable session.

Notable changes

- New reusable AskIrisButton view.
- Context is handed to the chat via an `IrisContextSource` payload on `IrisSessionPath` (no shared singleton), keeping the Iris-domain `SessionContext` out of the lower Navigation module.
- Centralized exercise→chat-mode construction in shared `IrisChatMode(exercise:)` / `SessionContext(lecture:)/(exercise:)` inits, replacing duplicated logic.
- New `NavigationController.goToIris(courseId:)` route (Iris tab without a session).


https://github.com/user-attachments/assets/2367526a-90e7-436b-a8ad-8ae79798a831