### PR TITLE
`Iris`: Use secondary color for context menu plus button

### DIFF
--- a/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
+++ b/ArtemisKit/Sources/Iris/Views/IrisChatView.swift
@@ -436,6 +436,7 @@ private struct InputBar: View {
                 Button(action: onPlusTapped) {
                     Image(systemName: "plus")
                         .imageScale(.large)
+                        .foregroundStyle(.secondary)
                 }
                 .popover(isPresented: $isContextPresented,
                          attachmentAnchor: .point(.top),


### PR DESCRIPTION
Change color of context menu (+ button) from primary to secondary according to thesis presentation feedback.