### PR TITLE
`Search`: Add global search to dashboard

### DIFF
--- a/ArtemisKit/Package.swift
+++ b/ArtemisKit/Package.swift
@@ -104,6 +104,7 @@ let package = Package(
                 .product(name: "Account", package: "artemis-ios-core-modules"),
                 .product(name: "APIClient", package: "artemis-ios-core-modules"),
                 .product(name: "DesignLibrary", package: "artemis-ios-core-modules"),
+                .product(name: "ProfileInfo", package: "artemis-ios-core-modules"),
                 .product(name: "SharedModels", package: "artemis-ios-core-modules"),
                 .product(name: "SharedServices", package: "artemis-ios-core-modules"),
                 .product(name: "RswiftLibrary", package: "R.swift")
@@ -216,6 +217,7 @@ let package = Package(
                 "Notifications",
                 .product(name: "APIClient", package: "artemis-ios-core-modules"),
                 .product(name: "Common", package: "artemis-ios-core-modules"),
+                .product(name: "ProfileInfo", package: "artemis-ios-core-modules"),
                 .product(name: "SharedModels", package: "artemis-ios-core-modules"),
                 .product(name: "SharedServices", package: "artemis-ios-core-modules"),
                 .product(name: "UserStore", package: "artemis-ios-core-modules")

--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -7,6 +7,7 @@
 
 import CourseRegistration
 import DesignLibrary
+import Search
 import SharedModels
 import SwiftUI
 
@@ -16,12 +17,20 @@ struct CourseGrid: View {
 
     @Bindable var viewModel: DashboardViewModel
     @State private var isCourseRegistrationPresented = false
+    @FocusState private var searchFocused
 
     var body: some View {
         DataStateView(data: $viewModel.coursesForDashboard) {
             await viewModel.loadCourses()
         } content: { _ in
             ScrollView {
+                if !viewModel.searchText.isEmpty {
+                    GlobalSearchSection()
+                        .padding(.horizontal)
+                        .padding(.vertical, .s)
+                        .background(.quinary, in: .rect(cornerRadius: .l))
+                }
+
                 if !viewModel.recentCourses.isEmpty && viewModel.searchText.isEmpty {
                     Text(R.string.localizable.recentlyAccessed())
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -56,7 +65,8 @@ struct CourseGrid: View {
                 .padding(.vertical)
             }
             .contentMargins(.horizontal, .l, for: .scrollContent)
-            .searchable(text: $viewModel.searchText)
+            .searchFocused($searchFocused)
+            .globalSearchable(searchText: $viewModel.searchText)
             .refreshable {
                 await viewModel.loadCourses()
             }

--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -7,6 +7,7 @@
 
 import CourseRegistration
 import DesignLibrary
+import ProfileInfo
 import Search
 import SharedModels
 import SwiftUI
@@ -14,6 +15,8 @@ import SwiftUI
 struct CourseGrid: View {
     private static let layout = [GridItem(.adaptive(minimum: 380, maximum: .infinity), spacing: .l, alignment: .center)]
     let namespace: Namespace.ID
+
+    @FeatureAvailability(.globalSearch) private var globalSearchAvailable
 
     @Bindable var viewModel: DashboardViewModel
     @State private var isCourseRegistrationPresented = false
@@ -26,8 +29,7 @@ struct CourseGrid: View {
             ScrollView {
                 if !viewModel.searchText.isEmpty || searchFocused {
                     GlobalSearchSection()
-                        .padding(.horizontal)
-                        .padding(.vertical, .s)
+                        .padding(.m)
                         .background(.quinary, in: .rect(cornerRadius: .l))
                 }
 
@@ -35,6 +37,7 @@ struct CourseGrid: View {
                     Text(R.string.localizable.recentlyAccessed())
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.title.bold())
+                        .padding(.top, searchFocused ? .m : 0)
 
                     LazyVGrid(columns: Self.layout, spacing: .l) {
                         ForEach(viewModel.recentCourses) { course in
@@ -53,7 +56,7 @@ struct CourseGrid: View {
                         CourseGridCell(courseForDashboard: course, viewModel: viewModel)
                     }
                 }
-                if viewModel.filteredCourses.isEmpty && !viewModel.searchText.isEmpty {
+                if viewModel.filteredCourses.isEmpty && !viewModel.searchText.isEmpty && !globalSearchAvailable {
                     ContentUnavailableView.search
                 }
 
@@ -64,9 +67,10 @@ struct CourseGrid: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical)
             }
+            .animation(.default, value: searchFocused)
             .contentMargins(.horizontal, .l, for: .scrollContent)
-            .searchFocused($searchFocused)
             .globalSearchable(searchText: $viewModel.searchText)
+            .searchFocused($searchFocused)
             .refreshable {
                 await viewModel.loadCourses()
             }

--- a/ArtemisKit/Sources/Dashboard/CourseGrid.swift
+++ b/ArtemisKit/Sources/Dashboard/CourseGrid.swift
@@ -24,7 +24,7 @@ struct CourseGrid: View {
             await viewModel.loadCourses()
         } content: { _ in
             ScrollView {
-                if !viewModel.searchText.isEmpty {
+                if !viewModel.searchText.isEmpty || searchFocused {
                     GlobalSearchSection()
                         .padding(.horizontal)
                         .padding(.vertical, .s)

--- a/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDTO.swift
@@ -42,6 +42,21 @@ extension SearchResultDTO {
     }
 }
 
+extension SearchResultDTO: Hashable {
+    static func == (lhs: SearchResultDTO, rhs: SearchResultDTO) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(type)
+        hasher.combine(title)
+        hasher.combine(description)
+        hasher.combine(badge)
+        hasher.combine(metadata?.hashValue)
+    }
+}
+
 extension SearchResultDTO {
     func navigate(with controller: NavigationController) async {
         await metadata?.navigateToDetail(with: controller, result: self)

--- a/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
+++ b/ArtemisKit/Sources/Search/Models/SearchResultDetails.swift
@@ -9,7 +9,7 @@ import Foundation
 import Navigation
 import SwiftUI
 
-protocol SearchResultDetails: Decodable {
+protocol SearchResultDetails: Decodable, Hashable {
     var courseId: Int? { get }
     var courseName: String? { get }
 

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -14,7 +14,7 @@ class SearchTabViewModel {
     let irisEnabled: Bool
 
     var searchTerm = ""
-    var scope: SearchScope = .course
+    var scope: SearchScope
     var selectedFilters = [SearchFilter]()
 
     var searchRequest: SearchRequest {
@@ -26,9 +26,10 @@ class SearchTabViewModel {
     var searchResults: DataState<[SearchResultDTO]> = .loading
     var isLoading = false
 
-    init(courseId: Int, irisEnabled: Bool) {
+    init(courseId: Int, irisEnabled: Bool, defaultScope: SearchScope = .course) {
         self.courseId = courseId
         self.irisEnabled = irisEnabled
+        self.scope = defaultScope
     }
 
     private var updateSearchTask: Task<(), Never>?

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -54,7 +54,7 @@ class SearchTabViewModel {
     }
 
     func performSearch() async {
-        if searchTerm.count >= 3 || searchTerm.isEmpty {
+        guard searchTerm.count >= 3 || searchTerm.isEmpty else {
             // Only search if there are 3+ characters (or 0 for suggestion)
             observeChanges()
             return
@@ -65,8 +65,8 @@ class SearchTabViewModel {
         let service = SearchServiceFactory.shared
 
         let results = await service.search(for: selectedFilters.first?.apiFilterTypes,
-                                             in: scope == .course ? courseId : nil,
-                                             searchTerm: searchTerm)
+                                           in: scope == .course ? courseId : nil,
+                                           searchTerm: searchTerm)
 
         searchResults = results.map {
             if let limitResults {

--- a/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
+++ b/ArtemisKit/Sources/Search/ViewModels/SearchTabViewModel.swift
@@ -12,6 +12,7 @@ import Foundation
 class SearchTabViewModel {
     let courseId: Int
     let irisEnabled: Bool
+    let limitResults: Int?
 
     var searchTerm = ""
     var scope: SearchScope
@@ -26,10 +27,11 @@ class SearchTabViewModel {
     var searchResults: DataState<[SearchResultDTO]> = .loading
     var isLoading = false
 
-    init(courseId: Int, irisEnabled: Bool, defaultScope: SearchScope = .course) {
+    init(courseId: Int, irisEnabled: Bool, defaultScope: SearchScope = .course, limitResults: Int? = nil) {
         self.courseId = courseId
         self.irisEnabled = irisEnabled
         self.scope = defaultScope
+        self.limitResults = limitResults
     }
 
     private var updateSearchTask: Task<(), Never>?
@@ -52,13 +54,27 @@ class SearchTabViewModel {
     }
 
     func performSearch() async {
+        if searchTerm.count >= 3 || searchTerm.isEmpty {
+            // Only search if there are 3+ characters (or 0 for suggestion)
+            observeChanges()
+            return
+        }
+
         isLoading = true
 
         let service = SearchServiceFactory.shared
 
-        searchResults = await service.search(for: selectedFilters.first?.apiFilterTypes,
+        let results = await service.search(for: selectedFilters.first?.apiFilterTypes,
                                              in: scope == .course ? courseId : nil,
                                              searchTerm: searchTerm)
+
+        searchResults = results.map {
+            if let limitResults {
+                return Array($0.prefix(limitResults))
+            }
+            return $0
+        }
+
         observeChanges()
         isLoading = false
     }

--- a/ArtemisKit/Sources/Search/Views/SearchResultsView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchResultsView.swift
@@ -20,7 +20,7 @@ struct SearchResultsView: View {
                 ContentUnavailableView.search
                     .loadingIndicator(isLoading: $viewModel.isLoading)
             } else {
-                ForEach(results.filter(\.isDisplayable), id: \.id) { result in
+                ForEach(results.filter(\.isDisplayable), id: \.hashValue) { result in
                     SearchResultView(result: result)
                         .loadingIndicator(isLoading: $viewModel.isLoading)
                 }

--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -66,7 +66,7 @@ public struct GlobalSearchSection: View {
     public var body: some View {
         if searchAvailable {
             scopeSuggestions
-            
+
             Section {
                 SearchResultsView(viewModel: viewModel)
             }

--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -7,6 +7,7 @@
 
 import Navigation
 import Notifications
+import ProfileInfo
 import SwiftUI
 import UserStore
 
@@ -56,16 +57,19 @@ public struct SearchTabView: View {
 }
 
 public struct GlobalSearchSection: View {
+    @FeatureAvailability(.globalSearch) private var searchAvailable
     @EnvironmentObject private var navController: NavigationController
     @Environment(SearchTabViewModel.self) private var viewModel
 
     public init() {}
 
     public var body: some View {
-        scopeSuggestions
-
-        Section {
-            SearchResultsView(viewModel: viewModel)
+        if searchAvailable {
+            scopeSuggestions
+            
+            Section {
+                SearchResultsView(viewModel: viewModel)
+            }
         }
     }
 
@@ -100,7 +104,9 @@ private struct ScopeSuggestion: View {
             if let action {
                 action()
             } else {
-                viewModel.selectedFilters.append(filter)
+                withAnimation {
+                    viewModel.selectedFilters.append(filter)
+                }
             }
         } label: {
             label

--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 import UserStore
 
 public struct SearchTabView: View {
-    @EnvironmentObject private var navController: NavigationController
     @State private var viewModel: SearchTabViewModel
 
     public init(courseId: Int, irisEnabled: Bool) {
@@ -23,11 +22,7 @@ public struct SearchTabView: View {
             List {
                 scopePicker
 
-                scopeSuggestions
-
-                Section {
-                    SearchResultsView(viewModel: viewModel)
-                }
+                GlobalSearchSection()
 
                 // Search text field does not count to Safe Area while open, so create some space
                 Spacer().listRowBackground(Color.clear)
@@ -35,9 +30,7 @@ public struct SearchTabView: View {
             .animation(.default, value: viewModel.selectedFilters)
             .animation(.default, value: viewModel.searchTerm.isEmpty)
             .submitLabel(.search)
-            .searchable(text: $viewModel.searchTerm, tokens: $viewModel.selectedFilters) { token in
-                Label(token.displayTitle, systemImage: token.systemImage)
-            }
+            .globalSearchable(viewModel: viewModel)
             .listRowSpacing(.m)
             .listSectionSpacing(.compact)
             .courseToolbar()
@@ -58,6 +51,21 @@ public struct SearchTabView: View {
             .pickerStyle(.segmented)
             .listRowBackground(Color.clear)
             .listRowInsets(EdgeInsets())
+        }
+    }
+}
+
+public struct GlobalSearchSection: View {
+    @EnvironmentObject private var navController: NavigationController
+    @Environment(SearchTabViewModel.self) private var viewModel
+
+    public init() {}
+
+    public var body: some View {
+        scopeSuggestions
+
+        Section {
+            SearchResultsView(viewModel: viewModel)
         }
     }
 

--- a/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
@@ -1,10 +1,11 @@
 //
-//  File.swift
+//  SearchViewModifiers.swift
 //  ArtemisKit
 //
 //  Created by Anian Schleyer on 28.08.26.
 //
 
+import ProfileInfo
 import SwiftUI
 
 extension View {
@@ -20,6 +21,7 @@ extension View {
 struct ExternalGlobalSearchViewModifier: ViewModifier {
     @State private var viewModel: SearchTabViewModel
     @Binding var searchText: String
+    @FeatureAvailability(.globalSearch) private var searchAvailable
 
     init(searchText: Binding<String>) {
         self._viewModel = State(initialValue: .init(courseId: 0, irisEnabled: false, defaultScope: .global, limitResults: 3))
@@ -27,11 +29,17 @@ struct ExternalGlobalSearchViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        content
-            .globalSearchable(viewModel: viewModel)
-            .onChange(of: viewModel.searchTerm) { _, newValue in
-                searchText = newValue
-            }
+        if searchAvailable {
+            content
+                .animation(.default, value: viewModel.searchResults.value)
+                .globalSearchable(viewModel: viewModel)
+                .onChange(of: viewModel.searchTerm) { _, newValue in
+                    searchText = newValue
+                }
+        } else {
+            content
+                .searchable(text: $searchText)
+        }
     }
 }
 

--- a/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  ArtemisKit
+//
+//  Created by Anian Schleyer on 28.08.26.
+//
+
+import SwiftUI
+
+extension View {
+    public func globalSearchable(searchText: Binding<String>) -> some View {
+        modifier(ExternalGlobalSearchViewModifier(searchText: searchText))
+    }
+
+    func globalSearchable(viewModel: SearchTabViewModel) -> some View {
+        modifier(GlobalSearchViewModifier(viewModel: viewModel))
+    }
+}
+
+struct ExternalGlobalSearchViewModifier: ViewModifier {
+    @State private var viewModel: SearchTabViewModel
+    @Binding var searchText: String
+
+    init(searchText: Binding<String>) {
+        self._viewModel = State(initialValue: .init(courseId: 0, irisEnabled: false, defaultScope: .global))
+        self._searchText = searchText
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .globalSearchable(viewModel: viewModel)
+            .onChange(of: viewModel.searchTerm) { _, newValue in
+                searchText = newValue
+            }
+    }
+}
+
+struct GlobalSearchViewModifier: ViewModifier {
+    @Bindable var viewModel: SearchTabViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .environment(viewModel)
+            .searchable(text: $viewModel.searchTerm, tokens: $viewModel.selectedFilters) { token in
+                Label(token.displayTitle, systemImage: token.systemImage)
+            }
+    }
+}

--- a/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchViewModifiers.swift
@@ -22,7 +22,7 @@ struct ExternalGlobalSearchViewModifier: ViewModifier {
     @Binding var searchText: String
 
     init(searchText: Binding<String>) {
-        self._viewModel = State(initialValue: .init(courseId: 0, irisEnabled: false, defaultScope: .global))
+        self._viewModel = State(initialValue: .init(courseId: 0, irisEnabled: false, defaultScope: .global, limitResults: 3))
         self._searchText = searchText
     }
 


### PR DESCRIPTION
Allow users to access global search from the dashboard: When search field is focused, suggestions and filters appear above courses. Search results are also displayed there.

<img width="300" src="https://github.com/user-attachments/assets/e505b536-9198-4b67-9021-2344668b4ebf" />
<img width="300" src="https://github.com/user-attachments/assets/25fde000-9c53-4672-acb7-265a4fe1148f" />

https://github.com/user-attachments/assets/602cd2f9-4882-4036-80ca-be36e0f1935b

