### PR TITLE
`Search`: Fix search crashing when global search is disabled

### DIFF
--- a/ArtemisKit/Sources/Search/Views/SearchTabView.swift
+++ b/ArtemisKit/Sources/Search/Views/SearchTabView.swift
@@ -58,18 +58,27 @@ public struct SearchTabView: View {
 
 public struct GlobalSearchSection: View {
     @FeatureAvailability(.globalSearch) private var searchAvailable
-    @EnvironmentObject private var navController: NavigationController
-    @Environment(SearchTabViewModel.self) private var viewModel
 
     public init() {}
 
     public var body: some View {
         if searchAvailable {
-            scopeSuggestions
+            GlobalSearchSectionContent()
+        }
+    }
+}
 
-            Section {
-                SearchResultsView(viewModel: viewModel)
-            }
+// Split into two parts such that @Environment cannot be accessed
+// accidentally when global search is disabled
+private struct GlobalSearchSectionContent: View {
+    @EnvironmentObject private var navController: NavigationController
+    @Environment(SearchTabViewModel.self) private var viewModel
+
+    var body: some View {
+        scopeSuggestions
+
+        Section {
+            SearchResultsView(viewModel: viewModel)
         }
     }
 


### PR DESCRIPTION
When global search was disabled, accessing search from the dashboard could result in a crash. The reason was that one of the views was always created, but when search was disabled, it could not access the search view model from the environment because there was none.

Addressed by wrapping the view in an appropriate availability check.