### PR TITLE
`Development`: Use the canonical Artemis API paths

### DIFF
--- a/ArtemisKit/Sources/CourseRegistration/Services/CourseRegistrationService/CourseRegistrationServiceImpl.swift
+++ b/ArtemisKit/Sources/CourseRegistration/Services/CourseRegistrationService/CourseRegistrationServiceImpl.swift
@@ -15,7 +15,7 @@ class CourseRegistrationServiceImpl: CourseRegistrationService {
         }
 
         var resourceName: String {
-            return "api/core/courses/for-enrollment"
+            return "api/course/courses/for-enrollment"
         }
     }
 
@@ -40,7 +40,7 @@ class CourseRegistrationServiceImpl: CourseRegistrationService {
         }
 
         var resourceName: String {
-            return "api/core/courses/\(courseId)/enroll"
+            return "api/course/courses/\(courseId)/enroll"
         }
     }
 

--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureAttachmentSheet.swift
@@ -51,7 +51,7 @@ struct LectureAttachmentSheet: View {
     }
 
     private func loadAttachment(lectureId: Int, lectureName: String) async {
-        let normalizedLink = "/api/core/files/attachments/lecture/\(lectureId)/merge-pdf"
+        let normalizedLink = "/api/core/files/attachments/lectures/\(lectureId)/merge-pdf"
         previewURL = await LectureServiceFactory.shared.getAttachmentFile(link: normalizedLink, name: lectureName)
     }
 }

--- a/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
+++ b/ArtemisKit/Sources/Messages/Services/MessagesService/MessagesServiceImpl.swift
@@ -737,7 +737,7 @@ struct MessagesServiceImpl: MessagesService {
         }
 
         var resourceName: String {
-            return "api/core/courses/\(courseId)/users/search?loginOrName=\(searchText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&roles=students,tutors,instructors"
+            return "api/course/courses/\(courseId)/users/search?loginOrName=\(searchText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&roles=students,tutors,instructors"
         }
     }
 


### PR DESCRIPTION
### Summary

Four endpoints the app calls are reached through a legacy alias. The Artemis server tags those responses with `Deprecation` and `Sunset` headers and the aliases stop responding on **30 September 2026**. This switches them to the canonical paths.

### What changes

| Before | After |
|---|---|
| `api/core/courses/for-enrollment` | `api/course/courses/for-enrollment` |
| `api/core/courses/{courseId}/enroll` | `api/course/courses/{courseId}/enroll` |
| `api/core/courses/{courseId}/users/search` | `api/course/courses/{courseId}/users/search` |
| `api/core/files/attachments/lecture/{lectureId}/merge-pdf` | `api/core/files/attachments/lectures/{lectureId}/merge-pdf` |

The three course paths only change prefix. All three are served by the same `CourseAccessResource`, mapped as `@RequestMapping({ "api/course/", CourseLegacyRestPaths.CORE_PREFIX })`: the first entry is the canonical one and every later entry is a legacy alias kept for the migration window.

The merged-PDF path is a method-level alias on `FileResource`, mapped as `@GetMapping({ "files/attachments/lectures/{lectureId}/merge-pdf", "files/attachments/lecture/{lectureId}/merge-pdf" })`. `LectureAttachmentSheet` is the one place in the app that builds a file URL itself instead of appending what the server put in `attachment.link`, so it is the one file path a client release can fix.

Request and response shapes are identical in all four cases.

### Depends on

The push notification registration paths live in `artemis-ios-core-modules` and move in ls1intum/artemis-ios-core-modules#203 (`api/communication/push_notification/register` and `/unregister` to `api/notification/push_notification/...`). They reach this app once the revision pinned in `ArtemisKit/Package.swift` is bumped past that merge; this pull request does not bump it.

### Not touched

The remaining `api/core/files/...` paths this app requests are **not** hardcoded here. The server writes the legacy spelling into `course.courseIcon`, `user.imageUrl`, `attachment.link` and `dragAndDropQuestion.backgroundFilePath` (`FilePathConverter.externalUriForFileSystemPath`), and the app appends whatever it was given. Those spellings can only be retired server-side, by changing what is emitted and migrating the values already persisted, so no client release fixes them:

- `api/core/files/course/icons/{courseId}/*`
- `api/core/files/user/profile-pictures/{userId}/*`
- `api/core/files/drag-and-drop/backgrounds/{questionId}/*`
- `api/core/files/attachments/lecture/{lectureId}/{attachmentName}`
- `api/core/files/attachments/attachment-unit/{attachmentVideoUnitId}/*` and its `/student/*` variant

The `/student/` retry in `LectureServiceImpl.getAttachmentFile` inherits its base URL from that same server-provided link, so it is in the same group.

`api/core/files/...` itself is **not** legacy: `api/core/` is the canonical prefix of `FileResource`.

### Testing

- Course enrollment: open the course registration screen, confirm the list of enrollable courses loads, and enroll in one.
- Conversations: open a channel, add a member, and confirm the user search returns results.
- Lecture attachments: open a lecture whose units carry PDF attachments and open the merged PDF view.

### Context

Found while auditing the Artemis server's deprecated API paths. The other clients have their own pull requests: ls1intum/artemis-android#694 and ls1intum/artemis-extension#463.

### Server requirement

The canonical paths landed in Artemis 9.3 (released 25 May 2026), so a release carrying this change needs the instances it talks to to run 9.3 or newer. That is the same bar the legacy aliases set from the other side: they stop responding on 30 September 2026.
