### PR TITLE
`Lectures`: Stop showing attachments attached directly to a lecture

### DIFF
--- a/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
+++ b/ArtemisKit/Sources/CourseView/LectureTab/LectureDetailView.swift
@@ -75,15 +75,6 @@ public struct LectureDetailView: View {
                             LectureUnitCell(viewModel: viewModel, lectureUnit: lectureUnit)
                         }
                     }
-
-                    if let attachments = lecture.attachments {
-                        Text(R.string.localizable.attachments())
-                            .font(.title2).bold()
-
-                        ForEach(attachments, id: \.id) { attachment in
-                            AttachmentCell(attachment: attachment)
-                        }
-                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.l)
@@ -170,44 +161,6 @@ private struct ChannelCell: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.l)
             .cardModifier(backgroundColor: .Artemis.exerciseCardBackgroundColor, cornerRadius: .m)
-        }
-    }
-}
-
-private struct AttachmentCell: View {
-    let attachment: Attachment
-
-    @State private var showAttachmentSheet = false
-
-    var body: some View {
-        Button {
-            showAttachmentSheet = true
-        } label: {
-            VStack(alignment: .leading) {
-                HStack {
-                    if let name = attachment.name {
-                        Text(name)
-                    }
-                    if let pathExtension = attachment.pathExtension {
-                        Chip(text: pathExtension, backgroundColor: .Artemis.artemisBlue)
-                    }
-                }
-                HStack(spacing: 0) {
-                    Text("(")
-                    if let version = attachment.version {
-                        Text("\(R.string.localizable.version()): \(version) -")
-                    }
-                    if let uploadDate = attachment.uploadDate {
-                        Text("\(R.string.localizable.date()): \(uploadDate.shortDateAndTime)")
-                    }
-                    Text(")")
-                }
-                .font(.caption)
-                .foregroundColor(.Artemis.secondaryLabel)
-            }
-        }
-        .sheet(isPresented: $showAttachmentSheet) {
-            LectureAttachmentSheet(attachment: attachment)
         }
     }
 }

--- a/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
+++ b/ArtemisKit/Sources/CourseView/Resources/en.lproj/Localizable.strings
@@ -123,7 +123,6 @@
 "dueSoon" = "Due soon";
 "past" = "Past";
 "lectureUnits" = "Lecture Units";
-"attachments" = "Attachments";
 "communication" = "Communication";
 "overview" = "Overview";
 "downloadCompletePdf" = "Download Complete PDF";


### PR DESCRIPTION
### Summary

Artemis is retiring attachments attached directly to a lecture in favour of attachment video units, so the server stops sending them. The lecture detail view no longer renders that section.

### Context

Attachment video units replaced lecture-level attachments a while ago and carry everything they did not: Pyris ingestion, competency links and slide support.

- Server: [ls1intum/Artemis#13686](https://github.com/ls1intum/Artemis/pull/13686)
- Shared model: [ls1intum/artemis-ios-core-modules#202](https://github.com/ls1intum/artemis-ios-core-modules/pull/202), which removes `Lecture.attachments`

### What changes

- `LectureDetailView` drops the "Attachments" section that listed the lecture's own attachments.
- The private `AttachmentCell` it used is removed with it.

`LectureAttachmentSheet` **stays**: it is still what opens the attachment of an attachment video unit, and the merged-PDF download for a lecture is unaffected.

### Testing

- Open a lecture: its units are listed as before, with no attachments section.
- Open an attachment video unit: its attachment still opens in the sheet.
- Use the complete PDF download button on a lecture: it still works.

Note that this depends on the shared-model pull request above, so it needs that one first.
